### PR TITLE
Support for user-specified containers

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "agent"]
+path = agent
+url = https://github.com/benmoss/agent.git
+branch = "kubernetes-job-runner"

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 require (
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	github.com/buildkite/yaml v0.0.0-20210326113714-4a3f40911396 // indirect
 	github.com/cenkalti/backoff v1.1.1-0.20171020064038-309aa717adbf // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.8.0 // indirect
@@ -30,6 +31,8 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/qri-io/jsonpointer v0.0.0-20180309164927-168dd9e45cf2 // indirect
+	github.com/qri-io/jsonschema v0.0.0-20180607150648-d0d3b10ec792 // indirect
 	github.com/stretchr/testify v1.8.1 // indirect
 	golang.org/x/net v0.0.0-20220722155237-a158d28d115b // indirect
 	golang.org/x/oauth2 v0.0.0-20220622183110-fd043fe589d2 // indirect
@@ -52,6 +55,7 @@ require (
 	github.com/agnivade/levenshtein v1.1.1 // indirect
 	github.com/alexflint/go-arg v1.4.2 // indirect
 	github.com/alexflint/go-scalar v1.0.0 // indirect
+	github.com/buildkite/agent/v3 v3.40.0
 	github.com/sanity-io/litter v1.5.5
 	github.com/spf13/pflag v1.0.5
 	github.com/vektah/gqlparser/v2 v2.4.5 // indirect

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/qri-io/jsonpointer v0.0.0-20180309164927-168dd9e45cf2 // indirect
 	github.com/qri-io/jsonschema v0.0.0-20180607150648-d0d3b10ec792 // indirect
-	github.com/stretchr/testify v1.8.1 // indirect
 	golang.org/x/net v0.0.0-20220722155237-a158d28d115b // indirect
 	golang.org/x/oauth2 v0.0.0-20220622183110-fd043fe589d2 // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect

--- a/go.sum
+++ b/go.sum
@@ -56,8 +56,12 @@ github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
 github.com/bradleyjkemp/cupaloy/v2 v2.6.0 h1:knToPYa2xtfg42U3I6punFEjaGFKWQRXJwj0JTv4mTs=
 github.com/bradleyjkemp/cupaloy/v2 v2.6.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
+github.com/buildkite/agent/v3 v3.40.0 h1:WACmXFk7MI98W3Sg9VWxWWB9r6lIKwr271SQl6cDj9I=
+github.com/buildkite/agent/v3 v3.40.0/go.mod h1:OoQEX2ZfXEuZqXqfwBwU6HGrDgDyHh/G5AEtKDErJlo=
 github.com/buildkite/go-buildkite/v3 v3.0.1 h1:5kX1fFDj3Co7cP6cqZKuW1VoCJz3u4cOx6wfdCeM4ZA=
 github.com/buildkite/go-buildkite/v3 v3.0.1/go.mod h1:6pweknacVv7He5Lvbf54urp2P0W6/b4Nrcxn718PQrE=
+github.com/buildkite/yaml v0.0.0-20210326113714-4a3f40911396 h1:qLN32md48xyTEqw6XEZMyNMre7njm0XXvDrea6NVwOM=
+github.com/buildkite/yaml v0.0.0-20210326113714-4a3f40911396/go.mod h1:AV5wtJnn1/CRaRGlJ8xspkMWfKXV0/pkJVgGleTIrfk=
 github.com/cenkalti/backoff v1.1.1-0.20171020064038-309aa717adbf h1:yxlp0s+Sge9UsKEK0Bsvjiopb9XRk+vxylmZ9eGBfm8=
 github.com/cenkalti/backoff v1.1.1-0.20171020064038-309aa717adbf/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -207,6 +211,10 @@ github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/qri-io/jsonpointer v0.0.0-20180309164927-168dd9e45cf2 h1:C8RRfIlExwwrXw28G8LkrpWiHUVT4uLowfvjUYJ2Iec=
+github.com/qri-io/jsonpointer v0.0.0-20180309164927-168dd9e45cf2/go.mod h1:DnJPaYgiKu56EuDp8TU5wFLdZIcAnb/uH9v37ZaMV64=
+github.com/qri-io/jsonschema v0.0.0-20180607150648-d0d3b10ec792 h1:vwTGeGWCew89DI4ZwKCaobGAN7ExvZiBzgn4LZHMVOc=
+github.com/qri-io/jsonschema v0.0.0-20180607150648-d0d3b10ec792/go.mod h1:v+TzC990ezhKzsEvlyorBWqCKtXtv7ihKY0LBSg/45c=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/go.sum
+++ b/go.sum
@@ -160,7 +160,7 @@ github.com/google/pprof v0.0.0-20200229191704-1ebb73c60ed3/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200430221834-fc25d7d30c6d/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
-github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
@@ -229,8 +229,6 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
-github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v0.0.0-20161117074351-18a02ba4a312/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
@@ -238,10 +236,7 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
-github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
 github.com/vektah/gqlparser/v2 v2.4.0/go.mod h1:flJWIR04IMQPGz+BXLrORkrARBxv/rtyIAFvd/MceW0=
 github.com/vektah/gqlparser/v2 v2.4.5 h1:C02NsyEsL4TXJB7ndonqTfuQOL4XPIu0aAWugdmTgmc=

--- a/integration/fixtures/helloworld.yaml
+++ b/integration/fixtures/helloworld.yaml
@@ -1,3 +1,10 @@
 steps:
   - label: ":wave:"
-    command: "echo hello world"
+    env:
+      BUILDKITE_SHELL: /bin/sh -e -c
+    plugins:
+      - kubernetes:
+          containers:
+            - image: alpine:latest
+              command: [echo]
+              args: [hello, world]

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -110,6 +110,7 @@ Out:
 		}
 		switch getBuild.Build.State {
 		case api.BuildStatesPassed:
+			t.Log("build passed!")
 			break Out
 		case api.BuildStatesFailed:
 			t.Fatalf("build failed")

--- a/justfile
+++ b/justfile
@@ -16,3 +16,11 @@ gomod:
   set -euo pipefail
   go mod tidy
   git diff --no-ext-diff --quiet --exit-code --name-only go.mod go.sum
+
+agent:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  export GOOS=linux GOARCH=amd64
+  cd agent/packaging/docker/alpine-linux
+  go build -o buildkite-agent github.com/buildkite/agent/v3
+  docker buildx build --tag benmoss/buildkite-agent:latest --push .

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ func main() {
 		log.Fatalf("pipeline is required")
 	}
 	token := MustEnv("BUILDKITE_TOKEN")
+	// TODO(bmo): generate agent tokens with the API
 	agentToken := MustEnv("BUILDKITE_AGENT_TOKEN")
 	org := MustEnv("BUILDKITE_ORG")
 

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -190,7 +190,6 @@ func podFromJob(
 	for k, v := range envMap {
 		switch k {
 		case "BUILDKITE_PLUGINS": //noop
-			env = append(env, corev1.EnvVar{Name: k, Value: "[]"})
 		case "BUILDKITE_COMMAND": //noop
 		default:
 			env = append(env, corev1.EnvVar{Name: k, Value: v})

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -9,11 +10,13 @@ import (
 	"time"
 
 	"github.com/buildkite/agent-stack-k8s/api"
+	"github.com/buildkite/agent/v3/agent/plugin"
 	"github.com/sanity-io/litter"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
@@ -27,16 +30,36 @@ var defaultBootstrapPod = &corev1.Pod{
 	},
 	Spec: corev1.PodSpec{
 		RestartPolicy: corev1.RestartPolicyNever,
-		Containers: []corev1.Container{
+		InitContainers: []corev1.Container{
 			{
-				Name:  "agent",
-				Image: "buildkite/agent:latest",
+				Name:            "copy-agent",
+				Image:           agentImage,
+				ImagePullPolicy: corev1.PullAlways,
+				Command:         []string{"cp"},
+				Args:            []string{"/usr/local/bin/buildkite-agent", "/workspace"},
+				VolumeMounts: []corev1.VolumeMount{
+					{
+						Name:      "workspace",
+						MountPath: "/workspace",
+					},
+				},
+			},
+		},
+		Volumes: []corev1.Volume{
+			{
+				Name: "workspace",
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
 			},
 		},
 	},
 }
 
-const ns = "default"
+const (
+	ns         = "default"
+	agentImage = "benmoss/buildkite-agent:latest"
+)
 
 func Run(ctx context.Context, token, org, pipeline, agentToken string) error {
 	graphqlClient := api.NewClient(token)
@@ -91,6 +114,7 @@ func Run(ctx context.Context, token, org, pipeline, agentToken string) error {
 					}
 					_, err = toolswatch.UntilWithSync(ctx, lw, &corev1.Pod{}, nil, func(ev watch.Event) (bool, error) {
 						if pod, ok := ev.Object.(*corev1.Pod); ok {
+							// todo: handle image pull errors
 							switch pod.Status.Phase {
 							case corev1.PodPending, corev1.PodRunning, corev1.PodUnknown:
 								log.Println(pod.Status.Phase)
@@ -99,8 +123,8 @@ func Run(ctx context.Context, token, org, pipeline, agentToken string) error {
 								log.Println("pod success!")
 								return true, nil
 							case corev1.PodFailed:
-								log.Println(pod.Status.Phase)
-								return false, fmt.Errorf("pod failed")
+								log.Println("pod failed!")
+								return true, nil
 							default:
 								return false, fmt.Errorf("unexpected pod status: %s", pod.Status.Phase)
 							}
@@ -108,7 +132,11 @@ func Run(ctx context.Context, token, org, pipeline, agentToken string) error {
 						return false, errors.New("event object not of type v1.Node")
 					})
 					if err != nil {
-						return fmt.Errorf("failed to watch pod: %w", err)
+						if errors.Is(err, wait.ErrWaitTimeout) {
+							log.Println("context canceled")
+						} else {
+							return fmt.Errorf("failed to watch pod: %w", err)
+						}
 					}
 					if err := clientset.CoreV1().Pods(ns).Delete(ctx, pod.Name, metav1.DeleteOptions{}); err != nil {
 						return fmt.Errorf("failed to delete pod: %w", err)
@@ -125,20 +153,29 @@ func podFromJob(
 	job api.CommandJob,
 	token string,
 ) (*corev1.Pod, error) {
-	var pod *corev1.Pod
 	envMap := map[string]string{}
 	for _, val := range job.Env {
 		parts := strings.Split(val, "=")
 		envMap[parts[0]] = parts[1]
 	}
-	pod = defaultBootstrapPod.DeepCopy()
-	pod.Spec.RestartPolicy = corev1.RestartPolicyNever
-	pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
-		Name: "workspace",
-		VolumeSource: corev1.VolumeSource{
-			EmptyDir: &corev1.EmptyDirVolumeSource{},
-		},
-	})
+
+	pod := defaultBootstrapPod.DeepCopy()
+	if envMap["BUILDKITE_PLUGINS"] == "" {
+		return nil, fmt.Errorf("no plugins found")
+	}
+	plugins, err := plugin.CreateFromJSON(envMap["BUILDKITE_PLUGINS"])
+	if err != nil {
+		return nil, fmt.Errorf("err parsing plugins: %w", err)
+	}
+	for _, plugin := range plugins {
+		asJson, err := json.Marshal(plugin.Configuration)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal config: %w", err)
+		}
+		if err := json.Unmarshal(asJson, &pod.Spec); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal config: %w", err)
+		}
+	}
 	var env []corev1.EnvVar
 	env = append(env, corev1.EnvVar{
 		Name:  "BUILDKITE_BUILD_PATH",
@@ -151,25 +188,57 @@ func podFromJob(
 		Value: job.Uuid,
 	})
 	for k, v := range envMap {
-		env = append(env, corev1.EnvVar{Name: k, Value: v})
+		switch k {
+		case "BUILDKITE_PLUGINS": //noop
+			env = append(env, corev1.EnvVar{Name: k, Value: "[]"})
+		case "BUILDKITE_COMMAND": //noop
+		default:
+			env = append(env, corev1.EnvVar{Name: k, Value: v})
+		}
 	}
 	volumeMounts := []corev1.VolumeMount{{Name: "workspace", MountPath: "/workspace"}}
-	massageContainers := func(name string, containers []corev1.Container, c corev1.Container, i int) {
+	if len(pod.Spec.Containers) != 1 {
+		return nil, fmt.Errorf("only one container is supported right now")
+	}
+	for i, c := range pod.Spec.Containers {
+		command := strings.Join(append(c.Command, c.Args...), " ")
+		c.Command = []string{"/workspace/buildkite-agent"}
+		c.Args = []string{"bootstrap"}
+		c.ImagePullPolicy = corev1.PullAlways
 		c.Env = append(c.Env, env...)
+		c.Env = append(c.Env, corev1.EnvVar{
+			Name:  "BUILDKITE_COMMAND",
+			Value: command,
+		}, corev1.EnvVar{
+			Name:  "BUILDKITE_AGENT_EXPERIMENT",
+			Value: "kubernetes-exec",
+		}, corev1.EnvVar{
+			Name:  "BUILDKITE_BOOTSTRAP_PHASES",
+			Value: "command",
+		}, corev1.EnvVar{
+			Name:  "BUILDKITE_AGENT_NAME",
+			Value: "whocares",
+		})
 		if c.Name == "" {
-			c.Name = fmt.Sprintf("%s-%d", name, i)
+			c.Name = fmt.Sprintf("%s-%d", "container", i)
 		}
 		if c.WorkingDir == "" {
 			c.WorkingDir = "/workspace"
 		}
 		c.VolumeMounts = append(c.VolumeMounts, volumeMounts...)
-		containers[i] = c
+		pod.Spec.Containers[i] = c
 	}
-	for i, c := range pod.Spec.Containers {
-		massageContainers("container", pod.Spec.Containers, c, i)
-	}
-	for i, c := range pod.Spec.InitContainers {
-		massageContainers("init", pod.Spec.InitContainers, c, i)
-	}
+	pod.Spec.Containers = append(pod.Spec.Containers, corev1.Container{
+		Name:            "agent",
+		Image:           agentImage,
+		WorkingDir:      "/workspace",
+		VolumeMounts:    volumeMounts,
+		ImagePullPolicy: corev1.PullAlways,
+		Env: append(env, corev1.EnvVar{
+			Name:  "BUILDKITE_AGENT_EXPERIMENT",
+			Value: "kubernetes-exec",
+		}),
+	})
+	log.Printf("pod: %v", litter.Sdump(pod))
 	return pod, nil
 }


### PR DESCRIPTION
This PR addresses splitting up the agent bootstrap so that it can happen in a separate container from the container that does the actual job execution, as specified in the kubernetes plugin section.

As of this PR we're not cloning the source repo into the workspace, so the test example still just runs "echo hello world" from inside an alpine container, with no references to the repo source.

Tracking changes to the agent codebase in a submodule, the code is currently in a fork in my personal account: https://github.com/benmoss/agent/tree/kubernetes-job-runner

Longer term we can get these changes merged upstream and released into the normal images