### PR TITLE
Upload artifacts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/qri-io/jsonpointer v0.0.0-20180309164927-168dd9e45cf2 // indirect
 	github.com/qri-io/jsonschema v0.0.0-20180607150648-d0d3b10ec792 // indirect
 	golang.org/x/net v0.0.0-20220722155237-a158d28d115b // indirect
@@ -57,6 +58,7 @@ require (
 	github.com/buildkite/agent/v3 v3.40.0
 	github.com/sanity-io/litter v1.5.5
 	github.com/spf13/pflag v1.0.5
+	github.com/stretchr/testify v1.8.1
 	github.com/vektah/gqlparser/v2 v2.4.5 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
 	golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -229,6 +229,8 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v0.0.0-20161117074351-18a02ba4a312/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
@@ -236,7 +238,10 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
 github.com/vektah/gqlparser/v2 v2.4.0/go.mod h1:flJWIR04IMQPGz+BXLrORkrARBxv/rtyIAFvd/MceW0=
 github.com/vektah/gqlparser/v2 v2.4.5 h1:C02NsyEsL4TXJB7ndonqTfuQOL4XPIu0aAWugdmTgmc=

--- a/integration/fixtures/helloworld.yaml
+++ b/integration/fixtures/helloworld.yaml
@@ -1,5 +1,6 @@
 steps:
   - label: ":wave:"
+    artifact_paths: "CODE_OF_CONDUCT.md"
     env:
       BUILDKITE_SHELL: /bin/sh -e -c
     plugins:

--- a/integration/fixtures/helloworld.yaml
+++ b/integration/fixtures/helloworld.yaml
@@ -8,3 +8,6 @@ steps:
             - image: alpine:latest
               command: [cat]
               args: [README.md]
+            - image: buildkite/agent:latest
+              command: [buildkite-agent]
+              args: [artifact upload "README.md"]

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/buildkite/agent-stack-k8s/scheduler"
 	"github.com/buildkite/go-buildkite/v3/buildkite"
 	"github.com/sanity-io/litter"
+	"github.com/stretchr/testify/assert"
 )
 
 func init() {
@@ -143,12 +144,12 @@ Out:
 	if err != nil {
 		t.Fatalf("failed to fetch artifacts for job: %v", err)
 	}
-	if len(artifacts) != 1 {
-		t.Fatalf("expected 1 artifacts, got %d", len(artifacts))
+	if len(artifacts) != 2 {
+		t.Fatalf("expected 2 artifacts, got %d", len(artifacts))
 	}
-	if *artifacts[0].Filename != "README.md" {
-		t.Fatalf("unexpected artifact filename: %s", *artifacts[0].Filename)
-	}
+	filenames := []string{*artifacts[0].Filename, *artifacts[1].Filename}
+	assert.Contains(t, filenames, "README.md")
+	assert.Contains(t, filenames, "CODE_OF_CONDUCT.md")
 }
 
 func MustEnv(key string) string {

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -138,6 +138,17 @@ Out:
 	if !strings.Contains(*logs.Content, "Buildkite Agent Stack for Kubernetes") {
 		t.Fatalf(`failed to find README content in job logs: %v`, *logs.Content)
 	}
+
+	artifacts, _, err := client.Artifacts.ListByBuild(org, pipeline.Name, strconv.Itoa(build.Number), nil)
+	if err != nil {
+		t.Fatalf("failed to fetch artifacts for job: %v", err)
+	}
+	if len(artifacts) != 1 {
+		t.Fatalf("expected 1 artifacts, got %d", len(artifacts))
+	}
+	if *artifacts[0].Filename != "README.md" {
+		t.Fatalf("unexpected artifact filename: %s", *artifacts[0].Filename)
+	}
 }
 
 func MustEnv(key string) string {


### PR DESCRIPTION
This feature was pretty simple. I needed to 
- [wire up the access token](https://github.com/benmoss/agent/commit/0305c18ad1cdb5fd1ee0c5663f1b907d68699047) to the bootstrap containers so that they have permission to upload artifacts
- add another optional sidecar to allow [artifact_paths](https://buildkite.com/docs/pipelines/artifacts#upload-artifacts-with-a-command-step) to work