### PR TITLE
Cleanup

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"log"
 	"strconv"
-	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -15,7 +14,6 @@ import (
 	"github.com/buildkite/agent-stack-k8s/api"
 	"github.com/buildkite/agent-stack-k8s/scheduler"
 	"github.com/buildkite/go-buildkite/v3/buildkite"
-	"github.com/sanity-io/litter"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -44,20 +42,16 @@ func TestWalkingSkeleton(t *testing.T) {
 		assert build success
 	*/
 	ctx := context.Background()
-	token := MustEnv("BUILDKITE_TOKEN")
-	org := MustEnv("BUILDKITE_ORG")
-	agentToken := MustEnv("BUILDKITE_AGENT_TOKEN")
+	token := MustEnv(t, "BUILDKITE_TOKEN")
+	org := MustEnv(t, "BUILDKITE_ORG")
+	agentToken := MustEnv(t, "BUILDKITE_AGENT_TOKEN")
 	graphqlClient := api.NewClient(token)
 
 	getOrg, err := api.GetOrganization(ctx, graphqlClient, org)
-	if err != nil {
-		t.Fatalf("failed to fetch org: %v", err)
-	}
+	assert.NoError(t, err)
 
 	steps, err := fixtures.ReadFile("fixtures/helloworld.yaml")
-	if err != nil {
-		t.Fatalf("failed to read fixture: %v", err)
-	}
+	assert.NoError(t, err)
 
 	createPipeline, err := api.PipelineCreate(ctx, graphqlClient, api.PipelineCreateInput{
 		OrganizationId: getOrg.Organization.Id,
@@ -69,27 +63,22 @@ func TestWalkingSkeleton(t *testing.T) {
 			Yaml: string(steps),
 		},
 	})
-	if err != nil {
-		t.Fatalf("failed to create pipeline: %v", err)
-	}
+	assert.NoError(t, err)
+
 	pipeline := createPipeline.PipelineCreate.Pipeline
 	if !*preservePipelines {
 		t.Cleanup(func() {
 			_, err = api.PipelineDelete(ctx, graphqlClient, api.PipelineDeleteInput{
 				Id: pipeline.Id,
 			})
-			if err != nil {
-				t.Fatalf("failed to delete pipeline: %v", err)
-			}
+			assert.NoError(t, err)
 			t.Logf("deleted pipeline! %v", pipeline.Name)
 		})
 	}
 
 	runCtx, cancel := context.WithCancel(context.Background())
 	go func() {
-		if err := scheduler.Run(runCtx, token, org, pipeline.Name, agentToken, !*preservePods); err != nil {
-			t.Logf("failed to run scheduler: %v", err)
-		}
+		assert.NoError(t, scheduler.Run(runCtx, token, org, pipeline.Name, agentToken, !*preservePods))
 	}()
 	t.Cleanup(func() {
 		cancel()
@@ -100,24 +89,16 @@ func TestWalkingSkeleton(t *testing.T) {
 		Commit:     "HEAD",
 		Branch:     branch,
 	})
-	if err != nil {
-		t.Fatalf("failed to create build: %v", err)
-	}
+	assert.NoError(t, err)
 	build := createBuild.BuildCreate.Build
-	if len(build.Jobs.Edges) != 1 {
-		t.Fatalf("expected one job, got %s", litter.Sdump(build.Jobs.Edges))
-	}
+	assert.Len(t, build.Jobs.Edges, 1)
 	node := build.Jobs.Edges[0].Node
 	job, ok := node.(*api.BuildCreateBuildCreateBuildCreatePayloadBuildJobsJobConnectionEdgesJobEdgeNodeJobTypeCommand)
-	if !ok {
-		t.Fatalf("expected job to be command type, got: %s", node.GetTypename())
-	}
+	assert.True(t, ok)
 Out:
 	for {
 		getBuild, err := api.GetBuild(ctx, graphqlClient, build.Uuid)
-		if err != nil {
-			t.Fatalf("failed to get build: %v", err)
-		}
+		assert.NoError(t, err)
 		switch getBuild.Build.State {
 		case api.BuildStatesPassed:
 			t.Log("build passed!")
@@ -131,40 +112,27 @@ Out:
 	}
 
 	config, err := buildkite.NewTokenConfig(token, false)
-
-	if err != nil {
-		t.Fatalf("client config failed: %s", err)
-	}
+	assert.NoError(t, err)
 
 	client := buildkite.NewClient(config.Client())
 	logs, _, err := client.Jobs.GetJobLog(org, pipeline.Name, strconv.Itoa(build.Number), job.Uuid)
-	if err != nil {
-		t.Fatalf("failed to fetch logs for job: %v", err)
-	}
-	if logs.Content == nil {
-		t.Fatal("expected logs to not be nil")
-	}
-	if !strings.Contains(*logs.Content, "Buildkite Agent Stack for Kubernetes") {
-		t.Fatalf(`failed to find README content in job logs: %v`, *logs.Content)
-	}
+	assert.NoError(t, err)
+	assert.NotNil(t, logs.Content)
+	assert.Contains(t, *logs.Content, "Buildkite Agent Stack for Kubernetes")
 
 	artifacts, _, err := client.Artifacts.ListByBuild(org, pipeline.Name, strconv.Itoa(build.Number), nil)
-	if err != nil {
-		t.Fatalf("failed to fetch artifacts for job: %v", err)
-	}
-	if len(artifacts) != 2 {
-		t.Fatalf("expected 2 artifacts, got %d", len(artifacts))
-	}
+	assert.NoError(t, err)
+	assert.Len(t, artifacts, 2)
 	filenames := []string{*artifacts[0].Filename, *artifacts[1].Filename}
 	assert.Contains(t, filenames, "README.md")
 	assert.Contains(t, filenames, "CODE_OF_CONDUCT.md")
 }
 
-func MustEnv(key string) string {
+func MustEnv(t *testing.T, key string) string {
 	if v, ok := syscall.Getenv(key); ok {
 		return v
 	}
 
-	log.Fatalf("variable '%s' cannot be found in the environment", key)
+	t.Fatalf("variable '%s' cannot be found in the environment", key)
 	return ""
 }

--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ func main() {
 	agentToken := MustEnv("BUILDKITE_AGENT_TOKEN")
 	org := MustEnv("BUILDKITE_ORG")
 
-	if err := scheduler.Run(ctx, token, org, *pipeline, agentToken); err != nil {
+	if err := scheduler.Run(ctx, token, org, *pipeline, agentToken, true); err != nil {
 		log.Fatalf("failed to run scheduler: %v", err)
 	}
 }

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -62,7 +62,7 @@ const (
 	agentImage = "benmoss/buildkite-agent:latest"
 )
 
-func Run(ctx context.Context, token, org, pipeline, agentToken string) error {
+func Run(ctx context.Context, token, org, pipeline, agentToken string, deletePods bool) error {
 	graphqlClient := api.NewClient(token)
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, nil)
@@ -139,8 +139,10 @@ func Run(ctx context.Context, token, org, pipeline, agentToken string) error {
 							return fmt.Errorf("failed to watch pod: %w", err)
 						}
 					}
-					if err := clientset.CoreV1().Pods(ns).Delete(context.Background(), pod.Name, metav1.DeleteOptions{}); err != nil {
-						return fmt.Errorf("failed to delete pod: %w", err)
+					if deletePods {
+						if err := clientset.CoreV1().Pods(ns).Delete(context.Background(), pod.Name, metav1.DeleteOptions{}); err != nil {
+							return fmt.Errorf("failed to delete pod: %w", err)
+						}
 					}
 				default:
 					return fmt.Errorf("received unknown job type: %v", litter.Sdump(job))


### PR DESCRIPTION
Built on top of #13 

Just some small refactoring and two new test flags, `--preserve-pipelines` and `--preserve-pods` which will keep test pipelines and pods around after the tests have finished. I've found myself doing that manually (commenting out code) and figured it'd be useful enough to make them debugging flags.