### PR TITLE
Run sidecars in parallel instead of serially

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ When a job is available, the controller will create a pod to acquire and run the
 
 The entrypoint rewriting and ordering logic is heavily inspired by [the approach used in Tekton](https://github.com/tektoncd/pipeline/blob/933e4f667c19eaf0a18a19557f434dbabe20d063/docs/developers/README.md#entrypoint-rewriting-and-step-ordering).
 
+The first container specified in the `containers:` array will be the command run
+in the foreground of your job, while any other containers will be run in the
+background and can be used for running sidecar services.
+
 ## Requirements
 
 - A Kubernetes cluster and kubeconfig file
@@ -84,11 +88,15 @@ sequenceDiagram
     bc->>kubernetes: cleanup finished pods
 ```
 
-## Sample buildkite pipeline
+## Sample pipelines
+
+Run [jib](https://github.com/GoogleContainerTools/jib) to produce a container image:
 
 ```yaml!
 steps:
 - label: build image
+  agents:
+    queue: kubernetes
   plugins:
   - kubernetes:
       podSpec:
@@ -98,6 +106,23 @@ steps:
           args:
           - jib
           - --image=ttl.sh/example:1h
+```
+
+Run nginx in a sidecar and curl it from the main container:
+
+```yaml!
+steps:
+- label: "curl nginx"
+  agents:
+    queue: kubernetes
+  plugins:
+    - kubernetes:
+        podSpec:
+          containers:
+            - image: nginx:latest
+              command: [curl --retry 5 --retry-connrefused localhost]
+            - image: nginx:latest
+              command: [/docker-entrypoint.sh nginx -g "daemon off;"]
 ```
 
 ## Cloning repos via SSH

--- a/integration/fixtures/helloworld.yaml
+++ b/integration/fixtures/helloworld.yaml
@@ -3,15 +3,14 @@ steps:
     agents:
       queue: {{.queue}}
     artifact_paths: "CODE_OF_CONDUCT.md"
-    env:
-      BUILDKITE_SHELL: /bin/sh -e -c
     plugins:
       - kubernetes:
           podSpec:
             containers:
-              - image: alpine:latest
-                command: [cat]
-                args: [README.md]
+              - image: nginx:latest
+                command: [curl --retry 5 --retry-connrefused localhost]
+              - image: nginx:latest
+                command: [/docker-entrypoint.sh nginx -g "daemon off;"]
               - image: buildkite/agent:latest
                 command: [buildkite-agent]
                 args: [artifact upload "README.md"]

--- a/integration/fixtures/secretref.yaml
+++ b/integration/fixtures/secretref.yaml
@@ -3,17 +3,16 @@ steps:
     agents:
       queue: {{.queue}}
     artifact_paths: "CODE_OF_CONDUCT.md"
-    env:
-      BUILDKITE_SHELL: /bin/sh -e -c
     plugins:
       - kubernetes:
           gitEnvFrom: 
           - secretRef: {name: agent-stack-k8s}
           podSpec:
             containers:
-              - image: alpine:latest
-                command: [cat]
-                args: [README.md]
+              - image: nginx:latest
+                command: [curl --retry 5 --retry-connrefused localhost]
+              - image: nginx:latest
+                command: [/docker-entrypoint.sh nginx -g "daemon off;"]
               - image: buildkite/agent:latest
                 command: [buildkite-agent]
                 args: [artifact upload "README.md"]

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -168,14 +168,15 @@ Out:
 	logs, _, err := client.Jobs.GetJobLog(org, pipeline.Name, strconv.Itoa(build.Number), job.Uuid)
 	require.NoError(t, err)
 	require.NotNil(t, logs.Content)
-	require.Contains(t, *logs.Content, "Buildkite Agent Stack for Kubernetes")
+	require.Contains(t, *logs.Content, "Welcome to nginx!")
 
 	artifacts, _, err := client.Artifacts.ListByBuild(org, pipeline.Name, strconv.Itoa(build.Number), nil)
 	require.NoError(t, err)
-	require.Len(t, artifacts, 2)
-	filenames := []string{*artifacts[0].Filename, *artifacts[1].Filename}
+	require.Len(t, artifacts, 3)
+	filenames := []string{*artifacts[0].Filename, *artifacts[1].Filename, *artifacts[2].Filename}
 	require.Contains(t, filenames, "README.md")
 	require.Contains(t, filenames, "CODE_OF_CONDUCT.md")
+	require.Contains(t, filenames, "tmp/nginx-latest.log")
 }
 
 func newk8sClient(t *testing.T) kubernetes.Interface {

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -157,6 +157,9 @@ func (w *worker) k8sify(
 		}, corev1.EnvVar{
 			Name:  "BUILDKITE_CONTAINER_ID",
 			Value: strconv.Itoa(i + systemContainers),
+		}, corev1.EnvVar{
+			Name:  "BUILDKITE_IMAGE_NAME",
+			Value: c.Image,
 		})
 		if c.Name == "" {
 			c.Name = fmt.Sprintf("%s-%d", "container", i)


### PR DESCRIPTION
Switches away from the previous sequential execution mode

Now, the ordering is:
- run the checkout container first
- wait for all sidecars to start
- run the "command" (main) container
- when it exits, terminate all sidecars

Sidecars also now log to files instead of to the Buildkite log stream, and these log files are uploaded as artifacts after they are terminated.

Reopened from #28 and #31 to handle the bug that was discovered after merge