### PR TITLE
Guard cleanup-orphans test behind flag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -89,7 +89,7 @@ require (
 	github.com/alexflint/go-arg v1.4.2 // indirect
 	github.com/alexflint/go-scalar v1.0.0 // indirect
 	github.com/buildkite/agent/v3 v3.40.0
-	github.com/spf13/pflag v1.0.5
+	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/testify v1.8.1
 	github.com/vektah/gqlparser/v2 v2.4.5 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect

--- a/justfile
+++ b/justfile
@@ -1,4 +1,5 @@
-default: lint generate test
+default:
+  just --list
 
 run *FLAGS:
   go run ./... {{FLAGS}}
@@ -63,3 +64,6 @@ release repo=("ghcr.io/buildkite/helm"):
   \`\`\`
   EOF
   gh release edit "$tag" -F dist/body.txt
+
+cleanup-orphans:
+  go test -v -run TestCleanupOrphanedPipelines ./integration --delete-orphaned-pipelines


### PR DESCRIPTION
We only want to run this explicitly, not on normal test runs, especially when running on CI