### PR TITLE
Fix plugin parsing to handle nested '='s

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 )
 
 require (
+	github.com/benbjohnson/clock v1.1.0 // indirect
 	github.com/cenkalti/backoff v1.1.1-0.20171020064038-309aa717adbf // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dnephin/pflag v1.0.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,7 @@ github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
+github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/bradleyjkemp/cupaloy/v2 v2.6.0 h1:knToPYa2xtfg42U3I6punFEjaGFKWQRXJwj0JTv4mTs=
 github.com/bradleyjkemp/cupaloy/v2 v2.6.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
 github.com/buildkite/go-buildkite/v3 v3.1.0 h1:vTAz4R/ZHvTjgmkVEZPqnZJcxAVP80IhowmrX4OhzzY=

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -53,7 +53,7 @@ func (w *worker) k8sify(
 ) (*batchv1.Job, error) {
 	envMap := map[string]string{}
 	for _, val := range job.Env {
-		parts := strings.Split(val, "=")
+		parts := strings.SplitN(val, "=", 2)
 		envMap[parts[0]] = parts[1]
 	}
 
@@ -61,6 +61,7 @@ func (w *worker) k8sify(
 	var plugins []map[string]json.RawMessage
 	if pluginsJson, ok := envMap["BUILDKITE_PLUGINS"]; ok {
 		if err := json.Unmarshal([]byte(pluginsJson), &plugins); err != nil {
+			w.logger.Debug("invalid plugin spec", zap.String("json", pluginsJson))
 			return nil, fmt.Errorf("err parsing plugins: %w", err)
 		}
 	}

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/buildkite/agent-stack-k8s/api"
 	"github.com/buildkite/agent-stack-k8s/monitor"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -17,7 +18,7 @@ func TestJobPluginConversion(t *testing.T) {
 			Containers: []corev1.Container{
 				{
 					Image:   "alpine:latest",
-					Command: []string{"hello world"},
+					Command: []string{"hello world a=b=c"},
 				},
 			},
 		},
@@ -46,7 +47,7 @@ func TestJobPluginConversion(t *testing.T) {
 		},
 		Tag: "queue=kubernetes",
 	}
-	worker := worker{}
+	worker := worker{logger: zaptest.NewLogger(t)}
 	result, err := worker.k8sify(input, "some-secret")
 	require.NoError(t, err)
 


### PR DESCRIPTION
We only want to split the first '=', not any subsequent ones inside the plugins spec