### PR TITLE
Add a timeout to the graphql client

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -13,6 +13,7 @@ import (
 
 func NewClient(token string) graphql.Client {
 	httpClient := http.Client{
+		Timeout: 60 * time.Second,
 		Transport: NewLogger(&authedTransport{
 			key:     token,
 			wrapped: http.DefaultTransport,


### PR DESCRIPTION
Default is no timeout, which means a hung client