### PR TITLE
Fix agent not failing when plugin errors

### DIFF
--- a/.buildkite/steps/agent.sh
+++ b/.buildkite/steps/agent.sh
@@ -4,7 +4,7 @@ set -euxo pipefail
 apk add just go jq
 
 docker buildx create --driver kubernetes --use
-just agent ttl.sh/buildkite-agent 1h
+just agent ttl.sh/buildkite-agent:1h
 
 image=$(cat dist/metadata.json | jq -r '"\(."image.name")@\(."containerimage.digest")"')
 buildkite-agent meta-data set "image" "${image}"

--- a/api/generated.go
+++ b/api/generated.go
@@ -11,6 +11,36 @@ import (
 	"github.com/Khan/genqlient/graphql"
 )
 
+// Build includes the GraphQL fields of Build requested by the fragment Build.
+// The GraphQL type's documentation follows.
+//
+// A build from a pipeline
+type Build struct {
+	// The UUID for the build
+	Uuid string `json:"uuid"`
+	Id   string `json:"id"`
+	// The number of the build
+	Number int `json:"number"`
+	// The current state of the build
+	State BuildStates            `json:"state"`
+	Jobs  BuildJobsJobConnection `json:"jobs"`
+}
+
+// GetUuid returns Build.Uuid, and is useful for accessing the field via an interface.
+func (v *Build) GetUuid() string { return v.Uuid }
+
+// GetId returns Build.Id, and is useful for accessing the field via an interface.
+func (v *Build) GetId() string { return v.Id }
+
+// GetNumber returns Build.Number, and is useful for accessing the field via an interface.
+func (v *Build) GetNumber() int { return v.Number }
+
+// GetState returns Build.State, and is useful for accessing the field via an interface.
+func (v *Build) GetState() BuildStates { return v.State }
+
+// GetJobs returns Build.Jobs, and is useful for accessing the field via an interface.
+func (v *Build) GetJobs() BuildJobsJobConnection { return v.Jobs }
+
 // Author for a build
 type BuildAuthorInput struct {
 	// The name for the build author
@@ -81,86 +111,64 @@ func (v *BuildCreateBuildCreateBuildCreatePayload) GetBuild() BuildCreateBuildCr
 //
 // A build from a pipeline
 type BuildCreateBuildCreateBuildCreatePayloadBuild struct {
-	// The UUID for the build
-	Uuid string `json:"uuid"`
-	Id   string `json:"id"`
-	// The number of the build
-	Number int                                                            `json:"number"`
-	Jobs   BuildCreateBuildCreateBuildCreatePayloadBuildJobsJobConnection `json:"jobs"`
+	Build `json:"-"`
 }
 
 // GetUuid returns BuildCreateBuildCreateBuildCreatePayloadBuild.Uuid, and is useful for accessing the field via an interface.
-func (v *BuildCreateBuildCreateBuildCreatePayloadBuild) GetUuid() string { return v.Uuid }
+func (v *BuildCreateBuildCreateBuildCreatePayloadBuild) GetUuid() string { return v.Build.Uuid }
 
 // GetId returns BuildCreateBuildCreateBuildCreatePayloadBuild.Id, and is useful for accessing the field via an interface.
-func (v *BuildCreateBuildCreateBuildCreatePayloadBuild) GetId() string { return v.Id }
+func (v *BuildCreateBuildCreateBuildCreatePayloadBuild) GetId() string { return v.Build.Id }
 
 // GetNumber returns BuildCreateBuildCreateBuildCreatePayloadBuild.Number, and is useful for accessing the field via an interface.
-func (v *BuildCreateBuildCreateBuildCreatePayloadBuild) GetNumber() int { return v.Number }
+func (v *BuildCreateBuildCreateBuildCreatePayloadBuild) GetNumber() int { return v.Build.Number }
+
+// GetState returns BuildCreateBuildCreateBuildCreatePayloadBuild.State, and is useful for accessing the field via an interface.
+func (v *BuildCreateBuildCreateBuildCreatePayloadBuild) GetState() BuildStates { return v.Build.State }
 
 // GetJobs returns BuildCreateBuildCreateBuildCreatePayloadBuild.Jobs, and is useful for accessing the field via an interface.
-func (v *BuildCreateBuildCreateBuildCreatePayloadBuild) GetJobs() BuildCreateBuildCreateBuildCreatePayloadBuildJobsJobConnection {
-	return v.Jobs
+func (v *BuildCreateBuildCreateBuildCreatePayloadBuild) GetJobs() BuildJobsJobConnection {
+	return v.Build.Jobs
 }
 
-// BuildCreateBuildCreateBuildCreatePayloadBuildJobsJobConnection includes the requested fields of the GraphQL type JobConnection.
-type BuildCreateBuildCreateBuildCreatePayloadBuildJobsJobConnection struct {
-	Edges []BuildCreateBuildCreateBuildCreatePayloadBuildJobsJobConnectionEdgesJobEdge `json:"edges"`
-}
-
-// GetEdges returns BuildCreateBuildCreateBuildCreatePayloadBuildJobsJobConnection.Edges, and is useful for accessing the field via an interface.
-func (v *BuildCreateBuildCreateBuildCreatePayloadBuildJobsJobConnection) GetEdges() []BuildCreateBuildCreateBuildCreatePayloadBuildJobsJobConnectionEdgesJobEdge {
-	return v.Edges
-}
-
-// BuildCreateBuildCreateBuildCreatePayloadBuildJobsJobConnectionEdgesJobEdge includes the requested fields of the GraphQL type JobEdge.
-type BuildCreateBuildCreateBuildCreatePayloadBuildJobsJobConnectionEdgesJobEdge struct {
-	Node Job `json:"-"`
-}
-
-// GetNode returns BuildCreateBuildCreateBuildCreatePayloadBuildJobsJobConnectionEdgesJobEdge.Node, and is useful for accessing the field via an interface.
-func (v *BuildCreateBuildCreateBuildCreatePayloadBuildJobsJobConnectionEdgesJobEdge) GetNode() Job {
-	return v.Node
-}
-
-func (v *BuildCreateBuildCreateBuildCreatePayloadBuildJobsJobConnectionEdgesJobEdge) UnmarshalJSON(b []byte) error {
+func (v *BuildCreateBuildCreateBuildCreatePayloadBuild) UnmarshalJSON(b []byte) error {
 
 	if string(b) == "null" {
 		return nil
 	}
 
 	var firstPass struct {
-		*BuildCreateBuildCreateBuildCreatePayloadBuildJobsJobConnectionEdgesJobEdge
-		Node json.RawMessage `json:"node"`
+		*BuildCreateBuildCreateBuildCreatePayloadBuild
 		graphql.NoUnmarshalJSON
 	}
-	firstPass.BuildCreateBuildCreateBuildCreatePayloadBuildJobsJobConnectionEdgesJobEdge = v
+	firstPass.BuildCreateBuildCreateBuildCreatePayloadBuild = v
 
 	err := json.Unmarshal(b, &firstPass)
 	if err != nil {
 		return err
 	}
 
-	{
-		dst := &v.Node
-		src := firstPass.Node
-		if len(src) != 0 && string(src) != "null" {
-			err = __unmarshalJob(
-				src, dst)
-			if err != nil {
-				return fmt.Errorf(
-					"Unable to unmarshal BuildCreateBuildCreateBuildCreatePayloadBuildJobsJobConnectionEdgesJobEdge.Node: %w", err)
-			}
-		}
+	err = json.Unmarshal(
+		b, &v.Build)
+	if err != nil {
+		return err
 	}
 	return nil
 }
 
-type __premarshalBuildCreateBuildCreateBuildCreatePayloadBuildJobsJobConnectionEdgesJobEdge struct {
-	Node json.RawMessage `json:"node"`
+type __premarshalBuildCreateBuildCreateBuildCreatePayloadBuild struct {
+	Uuid string `json:"uuid"`
+
+	Id string `json:"id"`
+
+	Number int `json:"number"`
+
+	State BuildStates `json:"state"`
+
+	Jobs BuildJobsJobConnection `json:"jobs"`
 }
 
-func (v *BuildCreateBuildCreateBuildCreatePayloadBuildJobsJobConnectionEdgesJobEdge) MarshalJSON() ([]byte, error) {
+func (v *BuildCreateBuildCreateBuildCreatePayloadBuild) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -168,21 +176,14 @@ func (v *BuildCreateBuildCreateBuildCreatePayloadBuildJobsJobConnectionEdgesJobE
 	return json.Marshal(premarshaled)
 }
 
-func (v *BuildCreateBuildCreateBuildCreatePayloadBuildJobsJobConnectionEdgesJobEdge) __premarshalJSON() (*__premarshalBuildCreateBuildCreateBuildCreatePayloadBuildJobsJobConnectionEdgesJobEdge, error) {
-	var retval __premarshalBuildCreateBuildCreateBuildCreatePayloadBuildJobsJobConnectionEdgesJobEdge
+func (v *BuildCreateBuildCreateBuildCreatePayloadBuild) __premarshalJSON() (*__premarshalBuildCreateBuildCreateBuildCreatePayloadBuild, error) {
+	var retval __premarshalBuildCreateBuildCreateBuildCreatePayloadBuild
 
-	{
-
-		dst := &retval.Node
-		src := v.Node
-		var err error
-		*dst, err = __marshalJob(
-			&src)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"Unable to marshal BuildCreateBuildCreateBuildCreatePayloadBuildJobsJobConnectionEdgesJobEdge.Node: %w", err)
-		}
-	}
+	retval.Uuid = v.Build.Uuid
+	retval.Id = v.Build.Id
+	retval.Number = v.Build.Number
+	retval.State = v.Build.State
+	retval.Jobs = v.Build.Jobs
 	return &retval, nil
 }
 
@@ -237,6 +238,85 @@ type BuildCreateResponse struct {
 // GetBuildCreate returns BuildCreateResponse.BuildCreate, and is useful for accessing the field via an interface.
 func (v *BuildCreateResponse) GetBuildCreate() BuildCreateBuildCreateBuildCreatePayload {
 	return v.BuildCreate
+}
+
+// BuildJobsJobConnection includes the requested fields of the GraphQL type JobConnection.
+type BuildJobsJobConnection struct {
+	Edges []BuildJobsJobConnectionEdgesJobEdge `json:"edges"`
+}
+
+// GetEdges returns BuildJobsJobConnection.Edges, and is useful for accessing the field via an interface.
+func (v *BuildJobsJobConnection) GetEdges() []BuildJobsJobConnectionEdgesJobEdge { return v.Edges }
+
+// BuildJobsJobConnectionEdgesJobEdge includes the requested fields of the GraphQL type JobEdge.
+type BuildJobsJobConnectionEdgesJobEdge struct {
+	Node Job `json:"-"`
+}
+
+// GetNode returns BuildJobsJobConnectionEdgesJobEdge.Node, and is useful for accessing the field via an interface.
+func (v *BuildJobsJobConnectionEdgesJobEdge) GetNode() Job { return v.Node }
+
+func (v *BuildJobsJobConnectionEdgesJobEdge) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*BuildJobsJobConnectionEdgesJobEdge
+		Node json.RawMessage `json:"node"`
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.BuildJobsJobConnectionEdgesJobEdge = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	{
+		dst := &v.Node
+		src := firstPass.Node
+		if len(src) != 0 && string(src) != "null" {
+			err = __unmarshalJob(
+				src, dst)
+			if err != nil {
+				return fmt.Errorf(
+					"Unable to unmarshal BuildJobsJobConnectionEdgesJobEdge.Node: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+type __premarshalBuildJobsJobConnectionEdgesJobEdge struct {
+	Node json.RawMessage `json:"node"`
+}
+
+func (v *BuildJobsJobConnectionEdgesJobEdge) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *BuildJobsJobConnectionEdgesJobEdge) __premarshalJSON() (*__premarshalBuildJobsJobConnectionEdgesJobEdge, error) {
+	var retval __premarshalBuildJobsJobConnectionEdgesJobEdge
+
+	{
+
+		dst := &retval.Node
+		src := v.Node
+		var err error
+		*dst, err = __marshalJob(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"Unable to marshal BuildJobsJobConnectionEdgesJobEdge.Node: %w", err)
+		}
+	}
+	return &retval, nil
 }
 
 // Meta-data key/value pairs for a build
@@ -318,12 +398,79 @@ func (v *CommandJob) GetCommand() string { return v.Command }
 //
 // A build from a pipeline
 type GetBuildBuild struct {
-	// The current state of the build
-	State BuildStates `json:"state"`
+	Build `json:"-"`
 }
 
+// GetUuid returns GetBuildBuild.Uuid, and is useful for accessing the field via an interface.
+func (v *GetBuildBuild) GetUuid() string { return v.Build.Uuid }
+
+// GetId returns GetBuildBuild.Id, and is useful for accessing the field via an interface.
+func (v *GetBuildBuild) GetId() string { return v.Build.Id }
+
+// GetNumber returns GetBuildBuild.Number, and is useful for accessing the field via an interface.
+func (v *GetBuildBuild) GetNumber() int { return v.Build.Number }
+
 // GetState returns GetBuildBuild.State, and is useful for accessing the field via an interface.
-func (v *GetBuildBuild) GetState() BuildStates { return v.State }
+func (v *GetBuildBuild) GetState() BuildStates { return v.Build.State }
+
+// GetJobs returns GetBuildBuild.Jobs, and is useful for accessing the field via an interface.
+func (v *GetBuildBuild) GetJobs() BuildJobsJobConnection { return v.Build.Jobs }
+
+func (v *GetBuildBuild) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*GetBuildBuild
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.GetBuildBuild = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.Build)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalGetBuildBuild struct {
+	Uuid string `json:"uuid"`
+
+	Id string `json:"id"`
+
+	Number int `json:"number"`
+
+	State BuildStates `json:"state"`
+
+	Jobs BuildJobsJobConnection `json:"jobs"`
+}
+
+func (v *GetBuildBuild) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *GetBuildBuild) __premarshalJSON() (*__premarshalGetBuildBuild, error) {
+	var retval __premarshalGetBuildBuild
+
+	retval.Uuid = v.Build.Uuid
+	retval.Id = v.Build.Id
+	retval.Number = v.Build.Number
+	retval.State = v.Build.State
+	retval.Jobs = v.Build.Jobs
+	return &retval, nil
+}
 
 // GetBuildResponse is returned by GetBuild on success.
 type GetBuildResponse struct {
@@ -371,11 +518,89 @@ func (v *GetBuildsPipelineBuildsBuildConnectionEdgesBuildEdge) GetNode() GetBuil
 //
 // A build from a pipeline
 type GetBuildsPipelineBuildsBuildConnectionEdgesBuildEdgeNodeBuild struct {
-	Id string `json:"id"`
+	Build `json:"-"`
+}
+
+// GetUuid returns GetBuildsPipelineBuildsBuildConnectionEdgesBuildEdgeNodeBuild.Uuid, and is useful for accessing the field via an interface.
+func (v *GetBuildsPipelineBuildsBuildConnectionEdgesBuildEdgeNodeBuild) GetUuid() string {
+	return v.Build.Uuid
 }
 
 // GetId returns GetBuildsPipelineBuildsBuildConnectionEdgesBuildEdgeNodeBuild.Id, and is useful for accessing the field via an interface.
-func (v *GetBuildsPipelineBuildsBuildConnectionEdgesBuildEdgeNodeBuild) GetId() string { return v.Id }
+func (v *GetBuildsPipelineBuildsBuildConnectionEdgesBuildEdgeNodeBuild) GetId() string {
+	return v.Build.Id
+}
+
+// GetNumber returns GetBuildsPipelineBuildsBuildConnectionEdgesBuildEdgeNodeBuild.Number, and is useful for accessing the field via an interface.
+func (v *GetBuildsPipelineBuildsBuildConnectionEdgesBuildEdgeNodeBuild) GetNumber() int {
+	return v.Build.Number
+}
+
+// GetState returns GetBuildsPipelineBuildsBuildConnectionEdgesBuildEdgeNodeBuild.State, and is useful for accessing the field via an interface.
+func (v *GetBuildsPipelineBuildsBuildConnectionEdgesBuildEdgeNodeBuild) GetState() BuildStates {
+	return v.Build.State
+}
+
+// GetJobs returns GetBuildsPipelineBuildsBuildConnectionEdgesBuildEdgeNodeBuild.Jobs, and is useful for accessing the field via an interface.
+func (v *GetBuildsPipelineBuildsBuildConnectionEdgesBuildEdgeNodeBuild) GetJobs() BuildJobsJobConnection {
+	return v.Build.Jobs
+}
+
+func (v *GetBuildsPipelineBuildsBuildConnectionEdgesBuildEdgeNodeBuild) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*GetBuildsPipelineBuildsBuildConnectionEdgesBuildEdgeNodeBuild
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.GetBuildsPipelineBuildsBuildConnectionEdgesBuildEdgeNodeBuild = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.Build)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalGetBuildsPipelineBuildsBuildConnectionEdgesBuildEdgeNodeBuild struct {
+	Uuid string `json:"uuid"`
+
+	Id string `json:"id"`
+
+	Number int `json:"number"`
+
+	State BuildStates `json:"state"`
+
+	Jobs BuildJobsJobConnection `json:"jobs"`
+}
+
+func (v *GetBuildsPipelineBuildsBuildConnectionEdgesBuildEdgeNodeBuild) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *GetBuildsPipelineBuildsBuildConnectionEdgesBuildEdgeNodeBuild) __premarshalJSON() (*__premarshalGetBuildsPipelineBuildsBuildConnectionEdgesBuildEdgeNodeBuild, error) {
+	var retval __premarshalGetBuildsPipelineBuildsBuildConnectionEdgesBuildEdgeNodeBuild
+
+	retval.Uuid = v.Build.Uuid
+	retval.Id = v.Build.Id
+	retval.Number = v.Build.Number
+	retval.State = v.Build.State
+	retval.Jobs = v.Build.Jobs
+	return &retval, nil
+}
 
 // GetBuildsResponse is returned by GetBuilds on success.
 type GetBuildsResponse struct {
@@ -1161,16 +1386,20 @@ func BuildCreate(
 mutation BuildCreate ($input: BuildCreateInput!) {
 	buildCreate(input: $input) {
 		build {
-			uuid
-			id
-			number
-			jobs(first: 100) {
-				edges {
-					node {
-						__typename
-						... Job
-					}
-				}
+			... Build
+		}
+	}
+}
+fragment Build on Build {
+	uuid
+	id
+	number
+	state
+	jobs(first: 100) {
+		edges {
+			node {
+				__typename
+				... Job
 			}
 		}
 	}
@@ -1216,8 +1445,34 @@ func GetBuild(
 		Query: `
 query GetBuild ($uuid: ID!) {
 	build(uuid: $uuid) {
-		state
+		... Build
 	}
+}
+fragment Build on Build {
+	uuid
+	id
+	number
+	state
+	jobs(first: 100) {
+		edges {
+			node {
+				__typename
+				... Job
+			}
+		}
+	}
+}
+fragment Job on Job {
+	... on JobTypeCommand {
+		... CommandJob
+	}
+}
+fragment CommandJob on JobTypeCommand {
+	uuid
+	env
+	scheduledAt
+	agentQueryRules
+	command
 }
 `,
 		Variables: &__GetBuildInput{
@@ -1253,11 +1508,37 @@ query GetBuilds ($slug: ID!, $state: [BuildStates!], $first: Int) {
 		builds(state: $state, first: $first) {
 			edges {
 				node {
-					id
+					... Build
 				}
 			}
 		}
 	}
+}
+fragment Build on Build {
+	uuid
+	id
+	number
+	state
+	jobs(first: 100) {
+		edges {
+			node {
+				__typename
+				... Job
+			}
+		}
+	}
+}
+fragment Job on Job {
+	... on JobTypeCommand {
+		... CommandJob
+	}
+}
+fragment CommandJob on JobTypeCommand {
+	uuid
+	env
+	scheduledAt
+	agentQueryRules
+	command
 }
 `,
 		Variables: &__GetBuildsInput{

--- a/api/genqlient.graphql
+++ b/api/genqlient.graphql
@@ -12,6 +12,21 @@ fragment CommandJob on JobTypeCommand {
   command
 }
 
+fragment Build on Build {
+  uuid
+  id
+  number
+  state
+  jobs(first: 100) {
+    edges {
+      # @genqlient(flatten: true)
+      node {
+        ...Job
+      }
+    }
+  }
+}
+
 # @genqlient(omitempty: true)
 mutation PipelineCreate(
   # need line break here due to https://github.com/Khan/genqlient/issues/151
@@ -47,17 +62,7 @@ query SearchPipelines($slug: ID!, $search: String!, $first: Int!) {
 mutation BuildCreate($input: BuildCreateInput!) {
   buildCreate(input: $input) {
     build {
-      uuid
-      id
-      number
-      jobs(first: 100) {
-        edges {
-          # @genqlient(flatten: true)
-          node {
-            ...Job
-          }
-        }
-      }
+      ...Build
     }
   }
 }
@@ -76,7 +81,7 @@ query GetOrganization($slug: ID!) {
 
 query GetBuild($uuid: ID!) {
   build(uuid: $uuid) {
-    state
+    ...Build
   }
 }
 
@@ -107,7 +112,7 @@ query GetBuilds($slug: ID!, $state: [BuildStates!], $first: Int) {
     builds(state: $state, first: $first) {
       edges {
         node {
-          id
+          ...Build
         }
       }
     }

--- a/integration/fixtures/unknown-plugin.yaml
+++ b/integration/fixtures/unknown-plugin.yaml
@@ -1,0 +1,15 @@
+steps:
+  - label: ":wave:"
+    agents:
+      queue: {{.queue}}
+    env:
+      BUILDKITE_SHELL: /bin/sh -e -c
+    plugins:
+      - kubernetes:
+          podSpec:
+            containers:
+              - image: alpine:latest
+                command: [cat]
+                args: [README.md]
+      - ssh://git@github.com/fake-org/fake-plugin.git:
+          this: "won't work"

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -13,15 +13,18 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/Khan/genqlient/graphql"
 	"github.com/buildkite/agent-stack-k8s/api"
 	"github.com/buildkite/agent-stack-k8s/cmd/controller"
 	"github.com/buildkite/go-buildkite/v3/buildkite"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
+	restconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
 const (
@@ -66,138 +69,35 @@ func TestMain(m *testing.M) {
 }
 
 func TestWalkingSkeleton(t *testing.T) {
-	basicTest(t, "helloworld.yaml", repoHTTP)
+	tc := testcase{
+		T:       t,
+		Fixture: "helloworld.yaml",
+		Repo:    repoHTTP,
+		GraphQL: api.NewClient(cfg.BuildkiteToken),
+	}.Init()
+	ctx := context.Background()
+	pipelineID := tc.CreatePipeline(ctx)
+	tc.StartController(ctx)
+	build := tc.TriggerBuild(ctx, pipelineID)
+	tc.AssertSuccess(ctx, build)
 }
 
 func TestSSHRepoClone(t *testing.T) {
-	k8s := newk8sClient(t)
-	_, err := k8s.CoreV1().Secrets(cfg.Namespace).Get(context.Background(), "agent-stack-k8s", v1.GetOptions{})
-	require.NoError(t, err, "agent-stack-k8s secret must exist")
-	basicTest(t, "secretref.yaml", repoSSH)
-}
+	tc := testcase{
+		T:       t,
+		Fixture: "secretref.yaml",
+		Repo:    repoSSH,
+		GraphQL: api.NewClient(cfg.BuildkiteToken),
+	}.Init()
 
-func basicTest(t *testing.T, fixture, repo string) {
-	t.Helper()
-	// create pipeline
 	ctx := context.Background()
-	graphqlClient := api.NewClient(cfg.BuildkiteToken)
+	_, err := tc.Kubernetes.CoreV1().Secrets(cfg.Namespace).Get(ctx, "agent-stack-k8s", v1.GetOptions{})
+	require.NoError(t, err, "agent-stack-k8s secret must exist")
 
-	getOrg, err := api.GetOrganization(ctx, graphqlClient, cfg.Org)
-	require.NoError(t, err)
-
-	tpl, err := template.ParseFS(fixtures, fmt.Sprintf("fixtures/%s", fixture))
-	require.NoError(t, err)
-
-	pipelineName := fmt.Sprintf("agent-k8s-%d", time.Now().UnixNano())
-	var steps bytes.Buffer
-	require.NoError(t, tpl.Execute(&steps, map[string]string{
-		"queue": pipelineName,
-	}))
-	createPipeline, err := api.PipelineCreate(ctx, graphqlClient, api.PipelineCreateInput{
-		OrganizationId: getOrg.Organization.Id,
-		Name:           pipelineName,
-		Repository: api.PipelineRepositoryInput{
-			Url: repo,
-		},
-		Steps: api.PipelineStepsInput{
-			Yaml: steps.String(),
-		},
-	})
-	require.NoError(t, err)
-
-	pipeline := createPipeline.PipelineCreate.Pipeline
-	if !preservePipelines {
-		EnsureCleanup(t, func() {
-			_, err = api.PipelineDelete(ctx, graphqlClient, api.PipelineDeleteInput{
-				Id: pipeline.Id,
-			})
-			assert.NoError(t, err)
-			t.Logf("deleted pipeline! %v", pipeline.Name)
-		})
-	}
-
-	//start controller
-	logger, err := zap.NewDevelopment()
-	require.NoError(t, err)
-
-	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
-	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, nil)
-	clientConfig, err := kubeConfig.ClientConfig()
-	require.NoError(t, err)
-
-	k8sClient, err := kubernetes.NewForConfig(clientConfig)
-	require.NoError(t, err)
-
-	runCtx, cancel := context.WithCancel(context.Background())
-	EnsureCleanup(t, cancel)
-
-	cfg.Tags = []string{fmt.Sprintf("queue=%s", pipelineName)}
-	go controller.Run(runCtx, k8sClient, cfg)
-
-	// trigger build
-	createBuild, err := api.BuildCreate(ctx, graphqlClient, api.BuildCreateInput{
-		PipelineID: pipeline.Id,
-		Commit:     "HEAD",
-		Branch:     branch,
-	})
-	require.NoError(t, err)
-	EnsureCleanup(t, func() {
-		if _, err := api.BuildCancel(ctx, graphqlClient, api.BuildCancelInput{
-			Id: createBuild.BuildCreate.Build.Id,
-		}); err != nil {
-			t.Logf("failed to cancel build: %v", err)
-		}
-	})
-	build := createBuild.BuildCreate.Build
-	require.Len(t, build.Jobs.Edges, 1)
-	node := build.Jobs.Edges[0].Node
-	job, ok := node.(*api.JobJobTypeCommand)
-	require.True(t, ok)
-
-	// assert build success
-Out:
-	for {
-		getBuild, err := api.GetBuild(ctx, graphqlClient, build.Uuid)
-		require.NoError(t, err)
-		switch getBuild.Build.State {
-		case api.BuildStatesPassed:
-			logger.Debug("build passed!")
-			break Out
-		case api.BuildStatesFailed:
-			t.Fatalf("build failed")
-		default:
-			logger.Debug("sleeping", zap.Any("build state", getBuild.Build.State))
-			time.Sleep(time.Second)
-		}
-	}
-
-	config, err := buildkite.NewTokenConfig(cfg.BuildkiteToken, false)
-	require.NoError(t, err)
-
-	client := buildkite.NewClient(config.Client())
-	logs, _, err := client.Jobs.GetJobLog(cfg.Org, pipeline.Name, strconv.Itoa(build.Number), job.Uuid)
-	require.NoError(t, err)
-	require.NotNil(t, logs.Content)
-	require.Contains(t, *logs.Content, "Buildkite Agent Stack for Kubernetes")
-
-	artifacts, _, err := client.Artifacts.ListByBuild(cfg.Org, pipeline.Name, strconv.Itoa(build.Number), nil)
-	require.NoError(t, err)
-	require.Len(t, artifacts, 2)
-	filenames := []string{*artifacts[0].Filename, *artifacts[1].Filename}
-	require.Contains(t, filenames, "README.md")
-	require.Contains(t, filenames, "CODE_OF_CONDUCT.md")
-}
-
-func newk8sClient(t *testing.T) kubernetes.Interface {
-	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
-	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, nil)
-	clientConfig, err := kubeConfig.ClientConfig()
-	require.NoError(t, err)
-
-	clientset, err := kubernetes.NewForConfig(clientConfig)
-	require.NoError(t, err)
-
-	return clientset
+	pipelineID := tc.CreatePipeline(ctx)
+	tc.StartController(ctx)
+	build := tc.TriggerBuild(ctx, pipelineID)
+	tc.AssertSuccess(ctx, build)
 }
 
 func TestCleanupOrphanedPipelines(t *testing.T) {
@@ -222,4 +122,152 @@ func TestCleanupOrphanedPipelines(t *testing.T) {
 		require.NoError(t, err)
 		t.Logf("deleted orphaned pipeline! %v", pipeline.Node.Name)
 	}
+}
+
+type testcase struct {
+	*testing.T
+	Logger       *zap.Logger
+	Fixture      string
+	Repo         string
+	GraphQL      graphql.Client
+	Kubernetes   kubernetes.Interface
+	PipelineName string // autogenerated
+}
+
+func (t testcase) Init() testcase {
+	t.Helper()
+	t.Parallel()
+
+	t.PipelineName = fmt.Sprintf("agent-k8s-%s-%d", strings.ToLower(t.Name()), time.Now().UnixNano())
+	t.Logger = zaptest.NewLogger(t)
+
+	clientConfig, err := restconfig.GetConfig()
+	require.NoError(t, err)
+	clientset, err := kubernetes.NewForConfig(clientConfig)
+	require.NoError(t, err)
+	t.Kubernetes = clientset
+
+	return t
+}
+
+func (t testcase) CreatePipeline(ctx context.Context) string {
+	t.Helper()
+
+	getOrg, err := api.GetOrganization(ctx, t.GraphQL, cfg.Org)
+	require.NoError(t, err)
+
+	tpl, err := template.ParseFS(fixtures, fmt.Sprintf("fixtures/%s", t.Fixture))
+	require.NoError(t, err)
+
+	var steps bytes.Buffer
+	require.NoError(t, tpl.Execute(&steps, map[string]string{
+		"queue": t.PipelineName,
+	}))
+	createPipeline, err := api.PipelineCreate(ctx, t.GraphQL, api.PipelineCreateInput{
+		OrganizationId: getOrg.Organization.Id,
+		Name:           t.PipelineName,
+		Repository: api.PipelineRepositoryInput{
+			Url: t.Repo,
+		},
+		Steps: api.PipelineStepsInput{
+			Yaml: steps.String(),
+		},
+	})
+	require.NoError(t, err)
+
+	pipeline := createPipeline.PipelineCreate.Pipeline
+	if !preservePipelines {
+		EnsureCleanup(t.T, func() {
+			_, err = api.PipelineDelete(ctx, t.GraphQL, api.PipelineDeleteInput{
+				Id: pipeline.Id,
+			})
+			assert.NoError(t, err)
+			t.Logf("deleted pipeline! %v", pipeline.Name)
+		})
+	}
+
+	return pipeline.Id
+}
+
+func (t testcase) StartController(ctx context.Context) {
+	t.Helper()
+
+	//start controller
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, nil)
+	clientConfig, err := kubeConfig.ClientConfig()
+	require.NoError(t, err)
+
+	k8sClient, err := kubernetes.NewForConfig(clientConfig)
+	require.NoError(t, err)
+
+	runCtx, cancel := context.WithCancel(ctx)
+	EnsureCleanup(t.T, cancel)
+
+	cfg.Tags = []string{fmt.Sprintf("queue=%s", t.PipelineName)}
+	go controller.Run(runCtx, k8sClient, cfg)
+}
+
+func (t testcase) TriggerBuild(ctx context.Context, pipelineID string) api.Build {
+	t.Helper()
+
+	// trigger build
+	createBuild, err := api.BuildCreate(ctx, t.GraphQL, api.BuildCreateInput{
+		PipelineID: pipelineID,
+		Commit:     "HEAD",
+		Branch:     branch,
+	})
+	require.NoError(t, err)
+	EnsureCleanup(t.T, func() {
+		if _, err := api.BuildCancel(ctx, t.GraphQL, api.BuildCancelInput{
+			Id: createBuild.BuildCreate.Build.Id,
+		}); err != nil {
+			if !strings.Contains(err.Error(), "Build can't be canceled because it's already finished") {
+				t.Logf("failed to cancel build: %v", err)
+			}
+		}
+	})
+	build := createBuild.BuildCreate.Build
+	require.Len(t, build.Jobs.Edges, 1)
+	node := build.Jobs.Edges[0].Node
+	_, ok := node.(*api.JobJobTypeCommand)
+	require.True(t, ok)
+
+	return build.Build
+}
+
+func (t testcase) AssertSuccess(ctx context.Context, build api.Build) {
+	t.Helper()
+Out:
+	for {
+		getBuild, err := api.GetBuild(ctx, t.GraphQL, build.Uuid)
+		require.NoError(t, err)
+		switch getBuild.Build.State {
+		case api.BuildStatesPassed:
+			t.Logger.Debug("build passed!")
+			break Out
+		case api.BuildStatesFailed:
+			t.Fatalf("build failed")
+		default:
+			t.Logger.Debug("sleeping", zap.Any("build state", getBuild.Build.State))
+			time.Sleep(time.Second)
+		}
+	}
+
+	config, err := buildkite.NewTokenConfig(cfg.BuildkiteToken, false)
+	require.NoError(t, err)
+
+	client := buildkite.NewClient(config.Client())
+	job := build.Jobs.Edges[0].Node.(*api.JobJobTypeCommand)
+	logs, _, err := client.Jobs.GetJobLog(cfg.Org, t.PipelineName, strconv.Itoa(build.Number), job.Uuid)
+	require.NoError(t, err)
+	require.NotNil(t, logs.Content)
+	require.Contains(t, *logs.Content, "Buildkite Agent Stack for Kubernetes")
+
+	artifacts, _, err := client.Artifacts.ListByBuild(cfg.Org, t.PipelineName, strconv.Itoa(build.Number), nil)
+	require.NoError(t, err)
+	require.Len(t, artifacts, 2)
+	filenames := []string{*artifacts[0].Filename, *artifacts[1].Filename}
+	require.Contains(t, filenames, "README.md")
+	require.Contains(t, filenames, "CODE_OF_CONDUCT.md")
 }


### PR DESCRIPTION
Fixes #70 

The fix in the agent was embarrassingly simple, since they already had named returns [on the method](https://github.com/buildkite/agent/blob/kubernetes-job-runner/bootstrap/bootstrap.go#L68), we just have to send the same `exitCode` to our rpc server.