### PR TITLE
Deploy to CI env automatically

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -28,6 +28,7 @@ steps:
                 command: [.buildkite/steps/agent.sh]
 
   - label: ":buildkite: integration tests"
+    key: integration
     depends_on: agent
     agents:
       queue: kubernetes
@@ -61,3 +62,23 @@ steps:
       - test-collector:
           files: "junit-*.xml"
           format: "junit"
+
+  - label: "publish and deploy"
+    if: "build.branch == pipeline.default_branch"
+    depends_on:
+    - agent
+    - integration
+    agents:
+      queue: kubernetes
+    env:
+      BUILDKITE_SHELL: /bin/sh -e -c
+    plugins:
+      - kubernetes:
+          podSpec:
+            containers:
+              - name: deploy
+                image: alpine:latest
+                command: [.buildkite/steps/deploy.sh]
+                envFrom:
+                - secretRef:
+                    name: agent-stack-k8s-secrets

--- a/.buildkite/steps/agent.sh
+++ b/.buildkite/steps/agent.sh
@@ -6,7 +6,7 @@ apk add just go jq
 docker buildx create --driver kubernetes --use
 just agent ttl.sh/buildkite-agent 1h
 
-image=$(cat dist/metadata.json | jq -r '"\(."image.name")@\(."containerimage.digest")"')
+image=$(cat dist/metadata.json | jq -r '"ttl.sh/buildkite-agent@\(."containerimage.digest")"')
 buildkite-agent meta-data set "image" "${image}"
 
 docker buildx rm

--- a/.buildkite/steps/deploy.sh
+++ b/.buildkite/steps/deploy.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euxo pipefail
+
+apk add helm yq skopeo
+
+tag=$(git describe)
+version=$(echo "$tag" | sed 's/v//')
+image=$(buildkite-agent meta-data get "image")
+
+echo $REGISTRY_PASSWORD | skopeo login ghcr.io -u $REGISTRY_USERNAME --password-stdin
+skopeo copy "docker://${image}" "docker://ghcr.io/buildkite/agent-k8s" --additional-tags "$tag"
+
+helm package ./charts/agent-stack-k8s --app-version "$version" -d dist --version "$version"
+helm push ./dist/agent-stack-k8s-*.tgz oci://{{repo}}
+
+just deploy \
+    --set config.org=buildkite-kubernetes-stack \
+    --set agentToken=$BUILDKITE_AGENT_TOKEN \
+    --set graphqlToken=$BUILDKITE_TOKEN


### PR DESCRIPTION
Only when commits land on the default branch

Secrets should be automatically redacted by Buildkite: https://buildkite.com/docs/pipelines/managing-log-output