### PR TITLE
Switch to debian-based golang

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -24,7 +24,7 @@ steps:
             serviceAccountName: docker
             containers:
               - name: docker
-                image: crazymax/docker:latest
+                image: golang:latest
                 command: [.buildkite/steps/agent.sh]
 
   - label: ":buildkite: integration tests"
@@ -65,10 +65,29 @@ steps:
           files: "junit-*.xml"
           format: "junit"
 
-  - label: "publish and deploy"
+  - label: ":docker: build controller"
+    key: controller
+    if: "build.branch == pipeline.default_branch"
+    agents:
+      queue: kubernetes
+    plugins:
+      - kubernetes:
+          podSpec:
+            containers:
+              - name: ko
+                image: golang:latest
+                command: [.buildkite/steps/controller.sh]
+                envFrom:
+                - configMapRef:
+                    name: build-config
+                - secretRef:
+                    name: deploy-secrets
+
+  - label: ":shipit: deploy"
     if: "build.branch == pipeline.default_branch"
     depends_on:
     - agent
+    - controller
     - integration
     agents:
       queue: kubernetes

--- a/.buildkite/steps/agent.sh
+++ b/.buildkite/steps/agent.sh
@@ -1,7 +1,15 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euxo pipefail
 
-apk add just go jq --quiet --no-progress
+apt update && apt install -y --no-install-recommends ca-certificates curl gnupg lsb-release jq
+mkdir -p /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+echo \
+    "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
+  $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list >/dev/null
+apt update && apt install -y docker-ce-cli
+
+curl --proto '=https' --tlsv1.3 -sSf https://just.systems/install.sh | bash -s -- --to /bin
 
 docker buildx create --driver kubernetes --use
 function cleanup {

--- a/.buildkite/steps/controller.sh
+++ b/.buildkite/steps/controller.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+apt update && apt install -y --no-install-recommends jq
+
+OS=$(go env GOOS)
+ARCH=$(go env GOARCH)
+latest=$(curl -L -s https://api.github.com/repos/ko-build/ko/releases/latest | jq -r '.tag_name')
+curl -sSfL "https://github.com/ko-build/ko/releases/download/${latest}/ko_${latest:1}_${OS^}_${ARCH}.tar.gz" | tar -xzv -C /bin ko
+
+tag=$(git describe)
+ko login ghcr.io -u $REGISTRY_USERNAME --password $REGISTRY_PASSWORD
+controller_image=$(ko build -B --tags "$tag")
+
+buildkite-agent meta-data set "controller-image" "${controller_image}"

--- a/.buildkite/steps/lint.sh
+++ b/.buildkite/steps/lint.sh
@@ -1,11 +1,7 @@
 #!/bin/bash
 set -euxo pipefail
 
-apt update && apt install -y lsb-release
-curl -q 'https://proget.makedeb.org/debian-feeds/prebuilt-mpr.pub' | gpg --dearmor | tee /usr/share/keyrings/prebuilt-mpr-archive-keyring.gpg 1>/dev/null
-echo "deb [signed-by=/usr/share/keyrings/prebuilt-mpr-archive-keyring.gpg] https://proget.makedeb.org prebuilt-mpr $(lsb_release -cs)" | tee /etc/apt/sources.list.d/prebuilt-mpr.list
-apt update && apt install -y just
-
+curl --proto '=https' --tlsv1.3 -sSf https://just.systems/install.sh | bash -s -- --to /bin
 curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.50.1
 
 just lint -v

--- a/justfile
+++ b/justfile
@@ -22,6 +22,7 @@ gomod:
 agent target=("ghcr.io/buildkite/agent-k8s:latest") os=("linux") arch=("amd64 arm64"):
   #!/usr/bin/env bash
   set -euxo pipefail
+  export CGO_ENABLED=0
   pushd agent/packaging/docker/alpine
   platforms=()
   for os in {{os}}; do


### PR DESCRIPTION
Follow-up to the earlier CI-based build process, alpine/musl go is not considered stable