### PR TITLE
Remove hard-coded chart image

### DIFF
--- a/charts/agent-stack-k8s/values.yaml
+++ b/charts/agent-stack-k8s/values.yaml
@@ -1,6 +1,5 @@
 agentToken: ""
 graphqlToken: ""
-image: "ghcr.io/buildkite/agent-stack-k8s:v0.1.0"
 
 config:
   org: ""


### PR DESCRIPTION
It is defaulted in the released chart images: https://github.com/buildkite/agent-stack-k8s/blob/bb71bc5c9383b6c998bf0c2a522d3ca4d243bafe/.buildkite/steps/deploy.sh#L18-L19