### PR TITLE
Add experimental sidecar support

### DIFF
--- a/.buildkite/rbac.yaml
+++ b/.buildkite/rbac.yaml
@@ -19,6 +19,14 @@ rules:
   - watch
   - create
   - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -142,8 +142,8 @@ func Run(ctx context.Context, k8sClient kubernetes.Interface, cfg api.Config) {
 		log.Fatal("failed to create monitor", zap.Error(err))
 	}
 	sched := scheduler.New(log.Named("scheduler"), k8sClient, cfg)
-	limiter := scheduler.NewLimiter(log.Named("limiter"), sched, cfg.MaxInFlight)
-	if err := scheduler.RegisterInformer(ctx, k8sClient, cfg.Tags, limiter); err != nil {
+	limiter := scheduler.NewLimiter(log.Named("limiter"), sched, k8sClient, cfg.MaxInFlight)
+	if err := limiter.RegisterInformer(ctx, cfg.Tags); err != nil {
 		log.Fatal("failed to register job informer", zap.Error(err))
 	}
 

--- a/integration/fixtures/sidecars.yaml
+++ b/integration/fixtures/sidecars.yaml
@@ -1,0 +1,15 @@
+steps:
+  - label: ":wave:"
+    agents:
+      queue: {{.queue}}
+    env:
+      BUILDKITE_SHELL: /bin/sh -e -c
+    plugins:
+      - kubernetes:
+          sidecars:
+          - image: nginx:latest
+          podSpec:
+            containers:
+              - image: alpine:latest
+                command: [wget]
+                args: ["-qO-", "localhost:80"]

--- a/scheduler/completions.go
+++ b/scheduler/completions.go
@@ -1,0 +1,89 @@
+package scheduler
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/buildkite/agent-stack-k8s/api"
+	"go.uber.org/zap"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	_ "k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/utils/pointer"
+)
+
+type completionsWatcher struct {
+	logger *zap.Logger
+	k8s    kubernetes.Interface
+}
+
+func NewPodCompletionWatcher(logger *zap.Logger, k8s kubernetes.Interface) *completionsWatcher {
+	watcher := &completionsWatcher{
+		logger: logger,
+		k8s:    k8s,
+	}
+	return watcher
+}
+
+// Creates a Pods informer and registers the handler on it
+func (w *completionsWatcher) RegisterInformer(ctx context.Context, factory informers.SharedInformerFactory) error {
+	informer := factory.Core().V1().Pods().Informer()
+	if _, err := informer.AddEventHandler(w); err != nil {
+		return fmt.Errorf("failed to register pod event handler: %w", err)
+	}
+	go factory.Start(ctx.Done())
+	return nil
+}
+
+// ignored
+func (w *completionsWatcher) OnDelete(obj interface{}) {}
+
+// handle pods completed while the controller wasn't running
+func (w *completionsWatcher) OnAdd(obj interface{}) {
+	pod := obj.(*v1.Pod)
+	w.cleanupSidecars(pod)
+}
+
+func (w *completionsWatcher) OnUpdate(old interface{}, new interface{}) {
+	oldPod := old.(*v1.Pod)
+	if terminated := getTermination(oldPod); terminated != nil {
+		// skip subsequent reconciles after we've already handled termination
+		return
+	}
+
+	newPod := new.(*v1.Pod)
+	w.cleanupSidecars(newPod)
+}
+
+func (w *completionsWatcher) cleanupSidecars(pod *v1.Pod) {
+	if terminated := getTermination(pod); terminated != nil {
+		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			job, err := w.k8s.BatchV1().Jobs(pod.Namespace).Get(context.TODO(), pod.Labels["job-name"], metav1.GetOptions{})
+			if err != nil {
+				return err
+			} else {
+				job.Spec.ActiveDeadlineSeconds = pointer.Int64(1)
+				_, err = w.k8s.BatchV1().Jobs(pod.Namespace).Update(context.TODO(), job, metav1.UpdateOptions{})
+				return err
+			}
+		}); err != nil {
+			w.logger.Error("failed to update job", zap.Error(err))
+		}
+		w.logger.Debug("agent finished", zap.String("uuid", pod.Labels[api.UUIDLabel]), zap.Int32("exit code", terminated.ExitCode))
+	}
+}
+
+func getTermination(pod *v1.Pod) *v1.ContainerStateTerminated {
+	for _, container := range pod.Status.ContainerStatuses {
+		if container.Name == AgentContainerName {
+			if container.State.Terminated != nil {
+				// oldPod is not terminated, but newPod is
+				return container.State.Terminated
+			}
+		}
+	}
+	return nil
+}

--- a/scheduler/limiter.go
+++ b/scheduler/limiter.go
@@ -8,18 +8,21 @@ import (
 	"github.com/buildkite/agent-stack-k8s/api"
 	"github.com/buildkite/agent-stack-k8s/monitor"
 	"go.uber.org/zap"
-	batchv1 "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/utils/pointer"
 )
 
 type MaxInFlightLimiter struct {
 	scheduler   monitor.JobHandler
 	MaxInFlight int
+	k8s         kubernetes.Interface
 
 	logger      *zap.Logger
 	mu          sync.RWMutex
@@ -27,19 +30,20 @@ type MaxInFlightLimiter struct {
 	completions *sync.Cond
 }
 
-func NewLimiter(logger *zap.Logger, scheduler monitor.JobHandler, maxInFlight int) *MaxInFlightLimiter {
+func NewLimiter(logger *zap.Logger, scheduler monitor.JobHandler, k8s kubernetes.Interface, maxInFlight int) *MaxInFlightLimiter {
 	l := &MaxInFlightLimiter{
 		scheduler:   scheduler,
 		MaxInFlight: maxInFlight,
 		logger:      logger,
 		inFlight:    make(map[string]struct{}),
+		k8s:         k8s,
 	}
 	l.completions = sync.NewCond(&l.mu)
 	return l
 }
 
 // Creates a Jobs informer, registers the handler on it, and waits for cache sync
-func RegisterInformer(ctx context.Context, clientset kubernetes.Interface, tags []string, handler cache.ResourceEventHandler) error {
+func (l *MaxInFlightLimiter) RegisterInformer(ctx context.Context, tags []string) error {
 	hasTag, err := labels.NewRequirement(api.TagLabel, selection.In, api.TagsToLabels(tags))
 	if err != nil {
 		return fmt.Errorf("failed to build tag label selector for job manager: %w", err)
@@ -48,18 +52,17 @@ func RegisterInformer(ctx context.Context, clientset kubernetes.Interface, tags 
 	if err != nil {
 		return fmt.Errorf("failed to build uuid label selector for job manager: %w", err)
 	}
-	factory := informers.NewSharedInformerFactoryWithOptions(clientset, 0, informers.WithTweakListOptions(func(opt *metav1.ListOptions) {
+	factory := informers.NewSharedInformerFactoryWithOptions(l.k8s, 0, informers.WithTweakListOptions(func(opt *metav1.ListOptions) {
 		opt.LabelSelector = labels.NewSelector().Add(*hasTag, *hasUUID).String()
 	}))
-	informer := factory.Batch().V1().Jobs()
-	jobInformer := informer.Informer()
-	if _, err := jobInformer.AddEventHandler(handler); err != nil {
-		return fmt.Errorf("failed to register event handler: %w", err)
+	informer := factory.Core().V1().Pods().Informer()
+	if _, err := informer.AddEventHandler(l); err != nil {
+		return fmt.Errorf("failed to register job event handler: %w", err)
 	}
 
 	go factory.Start(ctx.Done())
 
-	if !cache.WaitForCacheSync(ctx.Done(), jobInformer.HasSynced) {
+	if !cache.WaitForCacheSync(ctx.Done(), informer.HasSynced) {
 		return fmt.Errorf("failed to sync informer cache")
 	}
 
@@ -100,8 +103,8 @@ func (l *MaxInFlightLimiter) OnAdd(obj interface{}) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	job := obj.(*batchv1.Job)
-	if !isFinished(job) {
+	job, ok := obj.(*v1.Pod)
+	if ok && !isFinished(job) {
 		uuid := job.Labels[api.UUIDLabel]
 		if _, alreadyInFlight := l.inFlight[uuid]; !alreadyInFlight {
 			l.logger.Debug("adding in-flight job", zap.String("uuid", uuid), zap.Int("in-flight", len(l.inFlight)))
@@ -115,7 +118,7 @@ func (l *MaxInFlightLimiter) OnUpdate(_, obj interface{}) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	job := obj.(*batchv1.Job)
+	job := obj.(*v1.Pod)
 	uuid := job.Labels[api.UUIDLabel]
 	if isFinished(job) {
 		l.markComplete(job)
@@ -132,25 +135,37 @@ func (l *MaxInFlightLimiter) OnDelete(obj interface{}) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	l.markComplete(obj.(*batchv1.Job))
+	l.markComplete(obj.(*v1.Pod))
 }
 
-func (l *MaxInFlightLimiter) markComplete(job *batchv1.Job) {
-	uuid := job.Labels[api.UUIDLabel]
+func (l *MaxInFlightLimiter) markComplete(pod *v1.Pod) {
+	uuid := pod.Labels[api.UUIDLabel]
 	if _, alreadyInFlight := l.inFlight[uuid]; alreadyInFlight {
 		delete(l.inFlight, uuid)
+		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			job, err := l.k8s.BatchV1().Jobs(pod.Namespace).Get(context.TODO(), pod.Labels["job-name"], metav1.GetOptions{})
+			if err != nil {
+				return err
+			} else {
+				job.Spec.ActiveDeadlineSeconds = pointer.Int64(1)
+				_, err = l.k8s.BatchV1().Jobs(pod.Namespace).Update(context.TODO(), job, metav1.UpdateOptions{})
+				return err
+			}
+		}); err != nil {
+			l.logger.Error("failed to update job", zap.Error(err))
+		}
 		l.logger.Debug("job complete", zap.String("uuid", uuid), zap.Int("in-flight", len(l.inFlight)))
 		l.completions.Signal()
 	}
 }
 
-func isFinished(job *batchv1.Job) bool {
-	var finished bool
-	for _, cond := range job.Status.Conditions {
-		switch cond.Type {
-		case batchv1.JobComplete, batchv1.JobFailed:
-			finished = true
+func isFinished(job *v1.Pod) bool {
+	for _, container := range job.Status.ContainerStatuses {
+		if container.Name == AgentContainerName {
+			if container.State.Terminated != nil {
+				return true
+			}
 		}
 	}
-	return finished
+	return false
 }

--- a/scheduler/limiter.go
+++ b/scheduler/limiter.go
@@ -8,21 +8,14 @@ import (
 	"github.com/buildkite/agent-stack-k8s/api"
 	"github.com/buildkite/agent-stack-k8s/monitor"
 	"go.uber.org/zap"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/selection"
+	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/client-go/informers"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/util/retry"
-	"k8s.io/utils/pointer"
 )
 
 type MaxInFlightLimiter struct {
 	scheduler   monitor.JobHandler
 	MaxInFlight int
-	k8s         kubernetes.Interface
 
 	logger      *zap.Logger
 	mu          sync.RWMutex
@@ -30,39 +23,28 @@ type MaxInFlightLimiter struct {
 	completions *sync.Cond
 }
 
-func NewLimiter(logger *zap.Logger, scheduler monitor.JobHandler, k8s kubernetes.Interface, maxInFlight int) *MaxInFlightLimiter {
+func NewLimiter(logger *zap.Logger, scheduler monitor.JobHandler, maxInFlight int) *MaxInFlightLimiter {
 	l := &MaxInFlightLimiter{
 		scheduler:   scheduler,
 		MaxInFlight: maxInFlight,
 		logger:      logger,
 		inFlight:    make(map[string]struct{}),
-		k8s:         k8s,
 	}
 	l.completions = sync.NewCond(&l.mu)
 	return l
 }
 
 // Creates a Jobs informer, registers the handler on it, and waits for cache sync
-func (l *MaxInFlightLimiter) RegisterInformer(ctx context.Context, tags []string) error {
-	hasTag, err := labels.NewRequirement(api.TagLabel, selection.In, api.TagsToLabels(tags))
-	if err != nil {
-		return fmt.Errorf("failed to build tag label selector for job manager: %w", err)
-	}
-	hasUUID, err := labels.NewRequirement(api.UUIDLabel, selection.Exists, nil)
-	if err != nil {
-		return fmt.Errorf("failed to build uuid label selector for job manager: %w", err)
-	}
-	factory := informers.NewSharedInformerFactoryWithOptions(l.k8s, 0, informers.WithTweakListOptions(func(opt *metav1.ListOptions) {
-		opt.LabelSelector = labels.NewSelector().Add(*hasTag, *hasUUID).String()
-	}))
-	informer := factory.Core().V1().Pods().Informer()
-	if _, err := informer.AddEventHandler(l); err != nil {
-		return fmt.Errorf("failed to register job event handler: %w", err)
-	}
+func (l *MaxInFlightLimiter) RegisterInformer(ctx context.Context, factory informers.SharedInformerFactory) error {
+	informer := factory.Batch().V1().Jobs()
+	jobInformer := informer.Informer()
+	if _, err := jobInformer.AddEventHandler(l); err != nil {
+		return fmt.Errorf("failed to register event handler: %w", err)
 
+	}
 	go factory.Start(ctx.Done())
 
-	if !cache.WaitForCacheSync(ctx.Done(), informer.HasSynced) {
+	if !cache.WaitForCacheSync(ctx.Done(), jobInformer.HasSynced) {
 		return fmt.Errorf("failed to sync informer cache")
 	}
 
@@ -103,8 +85,8 @@ func (l *MaxInFlightLimiter) OnAdd(obj interface{}) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	job, ok := obj.(*v1.Pod)
-	if ok && !isFinished(job) {
+	job := obj.(*batchv1.Job)
+	if !jobFinished(job) {
 		uuid := job.Labels[api.UUIDLabel]
 		if _, alreadyInFlight := l.inFlight[uuid]; !alreadyInFlight {
 			l.logger.Debug("adding in-flight job", zap.String("uuid", uuid), zap.Int("in-flight", len(l.inFlight)))
@@ -118,9 +100,9 @@ func (l *MaxInFlightLimiter) OnUpdate(_, obj interface{}) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	job := obj.(*v1.Pod)
+	job := obj.(*batchv1.Job)
 	uuid := job.Labels[api.UUIDLabel]
-	if isFinished(job) {
+	if jobFinished(job) {
 		l.markComplete(job)
 	} else {
 		if _, alreadyInFlight := l.inFlight[uuid]; !alreadyInFlight {
@@ -135,36 +117,23 @@ func (l *MaxInFlightLimiter) OnDelete(obj interface{}) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	l.markComplete(obj.(*v1.Pod))
+	l.markComplete(obj.(*batchv1.Job))
 }
 
-func (l *MaxInFlightLimiter) markComplete(pod *v1.Pod) {
-	uuid := pod.Labels[api.UUIDLabel]
+func (l *MaxInFlightLimiter) markComplete(job *batchv1.Job) {
+	uuid := job.Labels[api.UUIDLabel]
 	if _, alreadyInFlight := l.inFlight[uuid]; alreadyInFlight {
 		delete(l.inFlight, uuid)
-		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			job, err := l.k8s.BatchV1().Jobs(pod.Namespace).Get(context.TODO(), pod.Labels["job-name"], metav1.GetOptions{})
-			if err != nil {
-				return err
-			} else {
-				job.Spec.ActiveDeadlineSeconds = pointer.Int64(1)
-				_, err = l.k8s.BatchV1().Jobs(pod.Namespace).Update(context.TODO(), job, metav1.UpdateOptions{})
-				return err
-			}
-		}); err != nil {
-			l.logger.Error("failed to update job", zap.Error(err))
-		}
 		l.logger.Debug("job complete", zap.String("uuid", uuid), zap.Int("in-flight", len(l.inFlight)))
 		l.completions.Signal()
 	}
 }
 
-func isFinished(job *v1.Pod) bool {
-	for _, container := range job.Status.ContainerStatuses {
-		if container.Name == AgentContainerName {
-			if container.State.Terminated != nil {
-				return true
-			}
+func jobFinished(job *batchv1.Job) bool {
+	for _, cond := range job.Status.Conditions {
+		switch cond.Type {
+		case batchv1.JobComplete, batchv1.JobFailed:
+			return true
 		}
 	}
 	return false

--- a/scheduler/limiter_test.go
+++ b/scheduler/limiter_test.go
@@ -14,8 +14,9 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
-	batchv1 "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 //go:generate mockgen -destination=mock_handler_test.go -source=../monitor/monitor.go -package scheduler_test
@@ -26,7 +27,7 @@ func TestLimiter(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	handler := NewMockJobHandler(ctrl)
-	limiter := scheduler.NewLimiter(zaptest.NewLogger(t), handler, 1)
+	limiter := scheduler.NewLimiter(zaptest.NewLogger(t), handler, fake.NewSimpleClientset(), 1)
 	var inFlight int64
 
 	handler.EXPECT().Create(gomock.Eq(ctx), gomock.Any()).Times(5).
@@ -36,15 +37,20 @@ func TestLimiter(t *testing.T) {
 
 			// mark job as completed
 			go func() {
-				limiter.OnUpdate(nil, &batchv1.Job{
+				limiter.OnUpdate(nil, &v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
 							api.UUIDLabel: job.Uuid,
 						},
 					},
-					Status: batchv1.JobStatus{
-						Conditions: []batchv1.JobCondition{
-							{Type: batchv1.JobComplete},
+					Status: v1.PodStatus{
+						ContainerStatuses: []v1.ContainerStatus{
+							{
+								Name: scheduler.AgentContainerName,
+								State: v1.ContainerState{
+									Terminated: &v1.ContainerStateTerminated{},
+								},
+							},
 						},
 					},
 				})
@@ -78,7 +84,7 @@ func TestSkipsDuplicateJobs(t *testing.T) {
 	defer ctrl.Finish()
 	handler := NewMockJobHandler(ctrl)
 	// no max-in-flight
-	limiter := scheduler.NewLimiter(zaptest.NewLogger(t), handler, 0)
+	limiter := scheduler.NewLimiter(zaptest.NewLogger(t), handler, fake.NewSimpleClientset(), 0)
 
 	// only expect 1
 	handler.EXPECT().Create(gomock.Eq(ctx), gomock.Any()).Times(1)
@@ -96,7 +102,7 @@ func TestSkipsCreateErrors(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	handler := NewMockJobHandler(ctrl)
-	limiter := scheduler.NewLimiter(zaptest.NewLogger(t), handler, 1)
+	limiter := scheduler.NewLimiter(zaptest.NewLogger(t), handler, fake.NewSimpleClientset(), 1)
 	invalid := errors.New("invalid")
 
 	handler.EXPECT().Create(gomock.Eq(ctx), gomock.Any()).Times(5).


### PR DESCRIPTION
Adds the ability to specify `sidecars` as a new top-level field, aside `podSpec` and `gitEnvFrom`. 

It's a list of `v1.Container` objects, like in the pod spec, but which will be started immediately and will run in parallel with the regular job containers. The controller will now terminate the whole pod when the agent container exits, because otherwise these containers would cause the pod/job to never complete.

An unfortunate consequence is that now the Kubernetes Jobs will always be considered failures, since the pod will be terminated instead of exiting on its own. This doesn't really matter from the perspective of the Buildkite job.

We might want to revisit whether we need Kubernetes Jobs at all anymore, or if we just want to run regular pods.