### PR TITLE
Fix flakiness of sidecar test

### DIFF
--- a/integration/fixtures/sidecars.yaml
+++ b/integration/fixtures/sidecars.yaml
@@ -10,6 +10,7 @@ steps:
           - image: nginx:latest
           podSpec:
             containers:
-              - image: alpine:latest
-                command: [wget]
-                args: ["-qO-", "localhost:80"]
+              - image: curlimages/curl:latest
+                name: curl
+                command: [curl]
+                args: ["--retry 5", "--retry-all-errors", "localhost:80"]


### PR DESCRIPTION
Should have known this would be flaky, but I thought maybe wget was automatically doing retries.

Saw this flake already in #113
https://buildkite.com/buildkite-kubernetes-stack/kubernetes-agent-stack/builds/329#01863c5f-1eef-42d0-ac2b-9ee5e63529af/860-938