### PR TITLE
Add support for setting annotations and labels

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
@@ -28,6 +29,10 @@ func TagsToLabels(tags []string) []string {
 		labels[i] = TagToLabel(tag)
 	}
 	return labels
+}
+
+func JobName(uuid string) string {
+	return fmt.Sprintf("buildkite-%s", uuid)
 }
 
 type Config struct {

--- a/cmd/linter/schema.json
+++ b/cmd/linter/schema.json
@@ -18,6 +18,17 @@
           "items": {
             "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.Container"
           }
+        },
+        "metadata": {
+          "type": "object",
+          "properties": {
+            "labels": {
+              "type": "object"
+            },
+            "annotations": {
+              "type": "object"
+            }
+          }
         }
       }
     }

--- a/integration/fixtures/helloworld.yaml
+++ b/integration/fixtures/helloworld.yaml
@@ -7,6 +7,11 @@ steps:
       BUILDKITE_SHELL: /bin/sh -e -c
     plugins:
       - kubernetes:
+          metadata:
+            annotations:
+              some-annotation: cool
+            labels:
+              some-label: wow
           podSpec:
             containers:
               - image: alpine:latest


### PR DESCRIPTION
Resolves #116 

Users can now set annotations and labels via the plugin spec:

```yaml
- kubernetes:
    metadata:
      annotations:
        some-annotation: cool
      labels:
        some-label: wow
```

They will be put on both the Job and the Pod.