### PR TITLE
Move images to under agent-stack-k8s prefix

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -63,8 +63,6 @@ steps:
                 image: golang:latest
                 command: [.buildkite/steps/controller.sh]
                 envFrom:
-                - configMapRef:
-                    name: build-config
                 - secretRef:
                     name: deploy-secrets
 

--- a/.buildkite/steps/controller.sh
+++ b/.buildkite/steps/controller.sh
@@ -13,6 +13,7 @@ curl -sSfL "https://github.com/ko-build/ko/releases/download/${latest}/ko_${late
 
 tag=$(git describe)
 ko login ghcr.io -u $REGISTRY_USERNAME --password $REGISTRY_PASSWORD
-controller_image=$(ko build -B --tags "$tag" --platform linux/amd64,linux/arm64)
+export KO_DOCKER_REPO=ghcr.io/buildkite/agent-stack-k8s/controller
+controller_image=$(ko build --bare --tags "$tag" --platform linux/amd64,linux/arm64)
 
 buildkite-agent meta-data set "controller-image" "${controller_image}"

--- a/justfile
+++ b/justfile
@@ -20,7 +20,7 @@ gomod:
   go mod tidy
   git diff --no-ext-diff --exit-code go.mod go.sum
 
-agent target=("ghcr.io/buildkite/agent-k8s:latest") os=("linux") arch=("amd64 arm64"):
+agent target os=("linux") arch=("amd64 arm64"):
   #!/usr/bin/env bash
   set -euxo pipefail
   pushd agent


### PR DESCRIPTION
ghcr.io/buildkite/agent-k8s -> ghcr.io/buildkite/agent-stack-k8s/agent
ghcr.io/buildkite/agent-stack-k8s -> ghcr.io/buildkite/agent-stack-k8s/controller

We don't have as much control over where helm puts the image, so that is going to remain the same for now.

Removing `KO_DOCKER_REPO` from being injected by secrets/configmaps to make it more clear where images are going, we can change this later if needed

Fixes #77 