### PR TITLE
Set workspace permissions to 777

### DIFF
--- a/integration/fixtures/helloworld.yaml
+++ b/integration/fixtures/helloworld.yaml
@@ -17,6 +17,13 @@ steps:
               - image: alpine:latest
                 command: [cat]
                 args: [README.md]
+              - image: alpine:latest
+                command: [touch]
+                args: [some-file]
+                securityContext:
+                  runAsNonRoot: true
+                  runAsUser: 1000
+                  runAsGroup: 1001
               - image: buildkite/agent:latest
                 command: [buildkite-agent]
                 args: [artifact upload "README.md"]

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -346,7 +346,7 @@ func (w *jobWrapper) Build() (*batchv1.Job, error) {
 			Value: "0",
 		}, {
 			Name:  "BUILDKITE_COMMAND",
-			Value: "cp -r ~/.ssh /workspace/.ssh",
+			Value: "cp -r ~/.ssh /workspace/.ssh && chmod -R 777 /workspace",
 		}},
 		EnvFrom: w.k8sPlugin.GitEnvFrom,
 	}


### PR DESCRIPTION
World read-write-executable, so that containers which run as non-root can still read/write/execute files in the workspace

Fixes #84