### PR TITLE
Use `/bin/sh` as the default shell for buildkite agent start

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "agent"]
 path = agent
 url = https://github.com/buildkite/agent.git
-branch = "kubernetes-job-runner"
+	branch = triarius/less-bash

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -250,6 +250,9 @@ func (w *jobWrapper) Build() (*batchv1.Job, error) {
 		}, corev1.EnvVar{
 			Name:  clicommand.RedactedVars.EnvVar,
 			Value: strings.Join(clicommand.RedactedVars.Value.Value(), ","),
+		}, corev1.EnvVar{
+			Name:  "BUILDKITE_SHELL",
+			Value: "/bin/sh -ec",
 		})
 		if c.Name == "" {
 			c.Name = fmt.Sprintf("%s-%d", "container", i)


### PR DESCRIPTION
This will allow jobs to run containers based on the alpine images. These are small and should start up quicker, so are an attractive image to use for our users.