### PR TITLE
Add tags to agents launched by the controller

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -27,7 +27,7 @@ steps:
             containers:
               - name: tests
                 image: golang:latest
-                command: [.buildkite/steps/integration_tests.sh]
+                command: [.buildkite/steps/tests.sh]
                 env:
                 - name: CONFIG
                   value: /etc/config.yaml

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,8 +1,8 @@
+agents:
+  queue: kubernetes
 steps:
   - label: ":docker: build agent"
     key: agent
-    agents:
-      queue: kubernetes
     plugins:
       - kubernetes:
           podSpec:
@@ -15,8 +15,6 @@ steps:
   - label: ":buildkite: integration tests"
     key: integration
     depends_on: agent
-    agents:
-      queue: kubernetes
     artifact_paths: junit-*.xml
     plugins:
       - kubernetes:
@@ -53,8 +51,6 @@ steps:
   - label: ":docker: build controller"
     key: controller
     if: "build.branch == pipeline.default_branch"
-    agents:
-      queue: kubernetes
     plugins:
       - kubernetes:
           podSpec:
@@ -72,8 +68,6 @@ steps:
     - agent
     - controller
     - integration
-    agents:
-      queue: kubernetes
     env:
       BUILDKITE_GIT_FETCH_FLAGS: "-v --tags"
     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -86,7 +86,7 @@ steps:
                 command: [.buildkite/steps/deploy.sh]
                 env:
                 - name: BUILDKITE_SHELL
-                  value: /bin/sh -e
+                  value: /bin/sh -ec
                 envFrom:
                 - secretRef:
                     name: deploy-secrets

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -50,7 +50,6 @@ steps:
 
   - label: ":docker: build controller"
     key: controller
-    if: "build.branch == pipeline.default_branch"
     plugins:
       - kubernetes:
           podSpec:
@@ -58,6 +57,27 @@ steps:
               - name: ko
                 image: golang:latest
                 command: [.buildkite/steps/controller.sh]
+                envFrom:
+                - secretRef:
+                    name: deploy-secrets
+
+  - label: ":helm::docker: push helm chart"
+    depends_on:
+    - agent
+    - controller
+    env:
+      BUILDKITE_GIT_FETCH_FLAGS: "-v --tags"
+    plugins:
+      - kubernetes:
+          podSpec:
+            serviceAccountName: deploy
+            containers:
+              - name: deploy
+                image: alpine:latest
+                command: [.buildkite/steps/build_and_push.sh]
+                env:
+                - name: BUILDKITE_SHELL
+                  value: /bin/sh -ec
                 envFrom:
                 - secretRef:
                     name: deploy-secrets

--- a/.buildkite/steps/build_and_push.sh
+++ b/.buildkite/steps/build_and_push.sh
@@ -1,0 +1,28 @@
+#!/bin/ash
+
+set -euo pipefail
+
+echo --- :hammer: Installing tools
+apk add helm yq skopeo git --quiet --no-progress
+
+tag=$(git describe)
+version=$(echo "$tag" | sed 's/v//')
+temp_agent_image=$(buildkite-agent meta-data get "agent-image")
+agent_image="${KO_DOCKER_REPO}/agent-k8s:${tag}"
+controller_image=$(buildkite-agent meta-data get "controller-image")
+
+echo --- :docker: Logging into ghcr.io
+skopeo login ghcr.io -u "$REGISTRY_USERNAME" --password "$REGISTRY_PASSWORD" --authfile ~/.docker/config.json
+
+echo --- :docker: Copying image to ghcr.io
+skopeo copy --multi-arch=all "docker://${temp_agent_image}" "docker://${agent_image}" --authfile ~/.docker/config.json
+
+
+echo --- :helm: Packaging helm chart
+yq -i ".image = \"$controller_image\"" charts/agent-stack-k8s/values.yaml
+yq -i ".config.image = \"$agent_image\"" charts/agent-stack-k8s/values.yaml
+helm package ./charts/agent-stack-k8s --app-version "$version" -d dist --version "$version"
+helm_image="oci://${KO_DOCKER_REPO}/helm"
+
+echo --- :helm: Pushing helm chart to ghcr.io
+helm push ./dist/agent-stack-k8s-*.tgz ${helm_image}

--- a/.buildkite/steps/controller.sh
+++ b/.buildkite/steps/controller.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-set -euxo pipefail
+
+set -Eeufo pipefail
 
 apt update && apt install -y --no-install-recommends jq
 
@@ -12,8 +13,8 @@ latest=$(curl -L -s https://api.github.com/repos/ko-build/ko/releases/latest | j
 curl -sSfL "https://github.com/ko-build/ko/releases/download/${latest}/ko_${latest:1}_${OS^}_${ARCH}.tar.gz" | tar -xzv -C /bin ko
 
 tag=$(git describe)
-ko login ghcr.io -u $REGISTRY_USERNAME --password $REGISTRY_PASSWORD
+ko login ghcr.io -u "$REGISTRY_USERNAME" --password "$REGISTRY_PASSWORD"
 export KO_DOCKER_REPO=ghcr.io/buildkite/agent-stack-k8s/controller
-controller_image=$(ko build --bare --tags "$tag" --platform linux/amd64,linux/arm64)
+controller_image=$(VERSION="$tag" ko build --bare --tags "$tag" --platform linux/amd64,linux/arm64)
 
-buildkite-agent meta-data set "controller-image" "${controller_image}"
+buildkite-agent meta-data set controller-image "${controller_image}"

--- a/.buildkite/steps/deploy.sh
+++ b/.buildkite/steps/deploy.sh
@@ -1,6 +1,8 @@
-#!/bin/ash
-set -euxo pipefail
+#!/usr/bin/env ash
 
+set -euo pipefail
+
+echo --- :hammer: Installing tools
 apk add helm yq skopeo git --quiet --no-progress
 
 tag=$(git describe)
@@ -9,29 +11,16 @@ temp_agent_image=$(buildkite-agent meta-data get "agent-image")
 agent_image="ghcr.io/buildkite/agent-stack-k8s/agent:${tag}"
 controller_image=$(buildkite-agent meta-data get "controller-image")
 
-set +x
-skopeo login ghcr.io -u $REGISTRY_USERNAME --password $REGISTRY_PASSWORD --authfile ~/.docker/config.json
-set -x
-
-skopeo copy "docker://${temp_agent_image}" "docker://${agent_image}" --authfile ~/.docker/config.json
-
-yq -i ".image = \"$controller_image\"" charts/agent-stack-k8s/values.yaml
-yq -i ".config.image = \"$agent_image\"" charts/agent-stack-k8s/values.yaml
-helm package ./charts/agent-stack-k8s --app-version "$version" -d dist --version "$version"
-helm_image="oci://ghcr.io/buildkite/helm"
-helm push ./dist/agent-stack-k8s-*.tgz ${helm_image}
-
-set +x
+echo --- :helm: Help upgrade
 helm upgrade agent-stack-k8s ${helm_image}/agent-stack-k8s \
     --version ${version} \
     --namespace buildkite \
     --install \
     --create-namespace \
     --wait \
-    --set config.org=$BUILDKITE_ORGANIZATION_SLUG \
-    --set agentToken=$BUILDKITE_AGENT_TOKEN \
-    --set graphqlToken=$BUILDKITE_TOKEN \
-    --set config.image=$agent_image \
+    --set config.org="$BUILDKITE_ORGANIZATION_SLUG" \
+    --set agentToken="$BUILDKITE_AGENT_TOKEN" \
+    --set graphqlToken="$BUILDKITE_TOKEN" \
+    --set config.image="$agent_image" \
     --set config.debug=true \
     --set config.profiler-address=localhost:6060
-set -x

--- a/.buildkite/steps/tests.sh
+++ b/.buildkite/steps/tests.sh
@@ -5,7 +5,7 @@ set -eufo pipefail
 echo "+++ Installing gotestsum :golang::test_tube:"
 go install gotest.tools/gotestsum
 
-echo '+++ Running integration tests :test:'
+echo '+++ Running integration tests :test_tube:'
 IMAGE=$(buildkite-agent meta-data get "agent-image")
 export IMAGE
 

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,0 +1,14 @@
+defaultPlatforms:
+- linux/amd64
+- linux/arm64
+builds:
+- id: agent-k8s-stack
+  dir: .
+  main: .
+  env:
+  - CGO_ENABLED=0
+  ldflags:
+  - -s
+  - -w
+  - -extldflags "-static"
+  - -X github.com/buildkite/agent-stack-k8s/v2/internal/version.version={{.Env.VERSION}}

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/buildkite/agent-stack-k8s/v2/api"
 	"github.com/buildkite/agent-stack-k8s/v2/cmd/linter"
+	"github.com/buildkite/agent-stack-k8s/v2/cmd/version"
 	"github.com/buildkite/agent-stack-k8s/v2/internal/monitor"
 	"github.com/buildkite/agent-stack-k8s/v2/internal/scheduler"
 	"github.com/go-playground/locales/en"
@@ -109,6 +110,7 @@ func New() *cobra.Command {
 	}
 	addFlags(cmd)
 	cmd.AddCommand(linter.New())
+	cmd.AddCommand(version.New())
 	if err := en_translations.RegisterDefaultTranslations(validate, trans); err != nil {
 		log.Fatalf("failed to register translations: %v", err)
 	}

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -1,0 +1,27 @@
+package version
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/buildkite/agent-stack-k8s/v2/internal/version"
+	"github.com/spf13/cobra"
+)
+
+func New() *cobra.Command {
+	return &cobra.Command{
+		Use:          "version",
+		Short:        "Prints the version",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return Version(cmd.Context(), os.Stdout)
+		},
+	}
+}
+
+func Version(ctx context.Context, out io.WriteCloser) error {
+	fmt.Fprintf(out, "%s\n", version.Version())
+	return nil
+}

--- a/internal/integration/fixtures/env.yaml
+++ b/internal/integration/fixtures/env.yaml
@@ -1,0 +1,17 @@
+steps:
+  - label: ":earth_asia:"
+    agents:
+      queue: {{.queue}}
+    env:
+      BUILDKITE_SHELL: /bin/sh -ec
+    plugins:
+      - kubernetes:
+          podSpec:
+            containers:
+              - image: alpine:latest
+                command:
+                - echo
+                args:
+                - >-
+                  Testing some env variables:
+                  $${BUILDKITE_AGENT_TOKEN+set}

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -272,3 +272,21 @@ func TestCleanupOrphanedPipelines(t *testing.T) {
 		})
 	}
 }
+
+func TestEnvVariables(t *testing.T) {
+	tc := testcase{
+		T:       t,
+		Fixture: "env.yaml",
+		Repo:    repoHTTP,
+		GraphQL: api.NewClient(cfg.BuildkiteToken),
+	}.Init()
+	ctx := context.Background()
+	pipelineID := tc.CreatePipeline(ctx)
+	tc.StartController(ctx, cfg)
+	build := tc.TriggerBuild(ctx, pipelineID)
+	tc.AssertSuccess(ctx, build)
+	tc.AssertLogsContain(
+		build,
+		"Testing some env variables: set",
+	)
+}

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -1,35 +1,22 @@
 package integration_test
 
 import (
-	"bytes"
 	"context"
 	"embed"
 	"fmt"
 	"log"
-	"net/http"
 	"os"
 	"reflect"
-	"strconv"
 	"strings"
 	"sync"
 	"testing"
-	"text/template"
 	"time"
 
-	"github.com/Khan/genqlient/graphql"
 	"github.com/buildkite/agent-stack-k8s/v2/api"
 	"github.com/buildkite/agent-stack-k8s/v2/cmd/controller"
-	"github.com/buildkite/go-buildkite/v3/buildkite"
-	"github.com/buildkite/roko"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zaptest"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/selection"
-	"k8s.io/client-go/kubernetes"
-	restconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
 const (
@@ -284,225 +271,4 @@ func TestCleanupOrphanedPipelines(t *testing.T) {
 			tc.deletePipeline(context.Background())
 		})
 	}
-}
-
-type testcase struct {
-	*testing.T
-	Logger       *zap.Logger
-	Fixture      string
-	Repo         string
-	GraphQL      graphql.Client
-	Kubernetes   kubernetes.Interface
-	Buildkite    *buildkite.Client
-	PipelineName string
-}
-
-func (t testcase) Init() testcase {
-	t.Helper()
-	t.Parallel()
-
-	t.PipelineName = fmt.Sprintf("agent-k8s-%s-%d", strings.ToLower(t.Name()), time.Now().UnixNano())
-	t.Logger = zaptest.NewLogger(t).Named(t.Name())
-
-	clientConfig, err := restconfig.GetConfig()
-	require.NoError(t, err)
-	clientset, err := kubernetes.NewForConfig(clientConfig)
-	require.NoError(t, err)
-	t.Kubernetes = clientset
-	config, err := buildkite.NewTokenConfig(cfg.BuildkiteToken, false)
-	require.NoError(t, err)
-
-	t.Buildkite = buildkite.NewClient(config.Client())
-
-	return t
-}
-
-func (t testcase) CreatePipeline(ctx context.Context) string {
-	t.Helper()
-
-	tpl, err := template.ParseFS(fixtures, fmt.Sprintf("fixtures/%s", t.Fixture))
-	require.NoError(t, err)
-
-	var steps bytes.Buffer
-	require.NoError(t, tpl.Execute(&steps, map[string]string{
-		"queue": t.PipelineName,
-	}))
-	pipeline, _, err := t.Buildkite.Pipelines.Create(cfg.Org, &buildkite.CreatePipeline{
-		Name:       t.PipelineName,
-		Repository: t.Repo,
-		ProviderSettings: &buildkite.GitHubSettings{
-			TriggerMode: strPtr("none"),
-		},
-		Configuration: steps.String(),
-	})
-	require.NoError(t, err)
-
-	if !preservePipelines {
-		t.deletePipeline(ctx)
-	}
-
-	return *pipeline.GraphQLID
-}
-
-func (t testcase) StartController(ctx context.Context, cfg api.Config) {
-	t.Helper()
-
-	runCtx, cancel := context.WithCancel(ctx)
-	EnsureCleanup(t.T, cancel)
-
-	cfg.Tags = []string{fmt.Sprintf("queue=%s", t.PipelineName)}
-	cfg.Debug = true
-	go controller.Run(runCtx, t.Kubernetes, cfg)
-}
-
-func (t testcase) TriggerBuild(ctx context.Context, pipelineID string) api.Build {
-	t.Helper()
-
-	// trigger build
-	createBuild, err := api.BuildCreate(ctx, t.GraphQL, api.BuildCreateInput{
-		PipelineID: pipelineID,
-		Commit:     "HEAD",
-		Branch:     branch,
-	})
-	require.NoError(t, err)
-	EnsureCleanup(t.T, func() {
-		if _, err := api.BuildCancel(ctx, t.GraphQL, api.BuildCancelInput{
-			Id: createBuild.BuildCreate.Build.Id,
-		}); err != nil {
-			if ignorableError(err) {
-				return
-			}
-			t.Logf("failed to cancel build: %v", err)
-		}
-	})
-	build := createBuild.BuildCreate.Build
-	require.GreaterOrEqual(t, len(build.Jobs.Edges), 1)
-	node := build.Jobs.Edges[0].Node
-	_, ok := node.(*api.JobJobTypeCommand)
-	require.True(t, ok)
-
-	return build.Build
-}
-
-func (t testcase) AssertSuccess(ctx context.Context, build api.Build) {
-	t.Helper()
-	require.Equal(t, api.BuildStatesPassed, t.waitForBuild(ctx, build))
-}
-
-func (t testcase) AssertLogsContain(build api.Build, content string) {
-	t.Helper()
-	config, err := buildkite.NewTokenConfig(cfg.BuildkiteToken, false)
-	require.NoError(t, err)
-
-	client := buildkite.NewClient(config.Client())
-	job := build.Jobs.Edges[0].Node.(*api.JobJobTypeCommand)
-	logs, _, err := client.Jobs.GetJobLog(cfg.Org, t.PipelineName, strconv.Itoa(build.Number), job.Uuid)
-	require.NoError(t, err)
-	require.NotNil(t, logs.Content)
-	require.Contains(t, *logs.Content, content)
-}
-
-func (t testcase) AssertArtifactsContain(build api.Build, expected ...string) {
-	t.Helper()
-	config, err := buildkite.NewTokenConfig(cfg.BuildkiteToken, false)
-	require.NoError(t, err)
-	client := buildkite.NewClient(config.Client())
-
-	artifacts, _, err := client.Artifacts.ListByBuild(cfg.Org, t.PipelineName, strconv.Itoa(build.Number), nil)
-	require.NoError(t, err)
-	require.Len(t, artifacts, 2)
-	filenames := []string{*artifacts[0].Filename, *artifacts[1].Filename}
-	for _, filename := range expected {
-		require.Contains(t, filenames, filename)
-	}
-}
-
-func (t testcase) AssertFail(ctx context.Context, build api.Build) {
-	t.Helper()
-
-	require.Equal(t, api.BuildStatesFailed, t.waitForBuild(ctx, build))
-}
-
-func (t testcase) waitForBuild(ctx context.Context, build api.Build) api.BuildStates {
-	t.Helper()
-
-	for {
-		getBuild, err := api.GetBuild(ctx, t.GraphQL, build.Uuid)
-		require.NoError(t, err)
-		switch getBuild.Build.State {
-		case api.BuildStatesPassed, api.BuildStatesFailed, api.BuildStatesCanceled, api.BuildStatesCanceling:
-			return getBuild.Build.State
-		case api.BuildStatesScheduled, api.BuildStatesRunning:
-			t.Logger.Debug("sleeping", zap.Any("build state", getBuild.Build.State))
-			time.Sleep(time.Second)
-		default:
-			t.Errorf("unknown build state %q", getBuild.Build.State)
-			return getBuild.Build.State
-		}
-	}
-}
-
-func (t testcase) AssertMetadata(ctx context.Context, annotations, labelz map[string]string) {
-	t.Helper()
-
-	tagReq, err := labels.NewRequirement(api.TagLabel, selection.Equals, []string{fmt.Sprintf("queue_%s", t.PipelineName)})
-	require.NoError(t, err)
-	selector := labels.NewSelector().Add(*tagReq)
-
-	jobs, err := t.Kubernetes.BatchV1().Jobs(cfg.Namespace).List(ctx, v1.ListOptions{LabelSelector: selector.String()})
-	require.NoError(t, err)
-	require.Len(t, jobs.Items, 1)
-	for k, v := range annotations {
-		require.Equal(t, jobs.Items[0].ObjectMeta.Annotations[k], v)
-		require.Equal(t, jobs.Items[0].Spec.Template.Annotations[k], v)
-	}
-	for k, v := range labelz {
-		require.Equal(t, jobs.Items[0].ObjectMeta.Labels[k], v)
-		require.Equal(t, jobs.Items[0].Spec.Template.Labels[k], v)
-	}
-}
-
-func strPtr(p string) *string {
-	return &p
-}
-
-func ignorableError(err error) bool {
-	reasons := []string{
-		"already finished",
-		"already being canceled",
-		"already been canceled",
-		"No build found",
-	}
-	for _, reason := range reasons {
-		if strings.Contains(err.Error(), reason) {
-			return true
-		}
-	}
-	return false
-}
-
-func (t testcase) deletePipeline(ctx context.Context) {
-	t.Helper()
-
-	EnsureCleanup(t.T, func() {
-		err := roko.NewRetrier(
-			roko.WithMaxAttempts(10),
-			roko.WithStrategy(roko.Exponential(time.Second, 5*time.Second)),
-		).DoWithContext(ctx, func(r *roko.Retrier) error {
-			resp, err := t.Buildkite.Pipelines.Delete(cfg.Org, t.PipelineName)
-			if err != nil {
-				if resp.StatusCode == http.StatusNotFound {
-					return nil
-				}
-				t.Logf("waiting for build to be canceled on pipeline %s", t.PipelineName)
-				return err
-			}
-			return nil
-		})
-		if err != nil {
-			t.Logf("failed to cleanup pipeline %s: %v", t.PipelineName, err)
-			return
-		}
-		t.Logf("deleted pipeline! %s", t.PipelineName)
-	})
 }

--- a/internal/integration/testcase_test.go
+++ b/internal/integration/testcase_test.go
@@ -1,0 +1,248 @@
+package integration_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+	"text/template"
+	"time"
+
+	"github.com/Khan/genqlient/graphql"
+	"github.com/buildkite/agent-stack-k8s/v2/api"
+	"github.com/buildkite/agent-stack-k8s/v2/cmd/controller"
+	"github.com/buildkite/go-buildkite/v3/buildkite"
+	"github.com/buildkite/roko"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/client-go/kubernetes"
+	restconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
+)
+
+type testcase struct {
+	*testing.T
+	Logger       *zap.Logger
+	Fixture      string
+	Repo         string
+	GraphQL      graphql.Client
+	Kubernetes   kubernetes.Interface
+	Buildkite    *buildkite.Client
+	PipelineName string
+}
+
+func (t testcase) Init() testcase {
+	t.Helper()
+	t.Parallel()
+
+	t.PipelineName = fmt.Sprintf("agent-k8s-%s-%d", strings.ToLower(t.Name()), time.Now().UnixNano())
+	t.Logger = zaptest.NewLogger(t).Named(t.Name())
+
+	clientConfig, err := restconfig.GetConfig()
+	require.NoError(t, err)
+	clientset, err := kubernetes.NewForConfig(clientConfig)
+	require.NoError(t, err)
+	t.Kubernetes = clientset
+	config, err := buildkite.NewTokenConfig(cfg.BuildkiteToken, false)
+	require.NoError(t, err)
+
+	t.Buildkite = buildkite.NewClient(config.Client())
+
+	return t
+}
+
+func (t testcase) CreatePipeline(ctx context.Context) string {
+	t.Helper()
+
+	tpl, err := template.ParseFS(fixtures, fmt.Sprintf("fixtures/%s", t.Fixture))
+	require.NoError(t, err)
+
+	var steps bytes.Buffer
+	require.NoError(t, tpl.Execute(&steps, map[string]string{
+		"queue": t.PipelineName,
+	}))
+	pipeline, _, err := t.Buildkite.Pipelines.Create(cfg.Org, &buildkite.CreatePipeline{
+		Name:       t.PipelineName,
+		Repository: t.Repo,
+		ProviderSettings: &buildkite.GitHubSettings{
+			TriggerMode: strPtr("none"),
+		},
+		Configuration: steps.String(),
+	})
+	require.NoError(t, err)
+
+	if !preservePipelines {
+		t.deletePipeline(ctx)
+	}
+
+	return *pipeline.GraphQLID
+}
+
+func (t testcase) StartController(ctx context.Context, cfg api.Config) {
+	t.Helper()
+
+	runCtx, cancel := context.WithCancel(ctx)
+	EnsureCleanup(t.T, cancel)
+
+	cfg.Tags = []string{fmt.Sprintf("queue=%s", t.PipelineName)}
+	cfg.Debug = true
+	go controller.Run(runCtx, t.Kubernetes, cfg)
+}
+
+func (t testcase) TriggerBuild(ctx context.Context, pipelineID string) api.Build {
+	t.Helper()
+
+	// trigger build
+	createBuild, err := api.BuildCreate(ctx, t.GraphQL, api.BuildCreateInput{
+		PipelineID: pipelineID,
+		Commit:     "HEAD",
+		Branch:     branch,
+	})
+	require.NoError(t, err)
+	EnsureCleanup(t.T, func() {
+		if _, err := api.BuildCancel(ctx, t.GraphQL, api.BuildCancelInput{
+			Id: createBuild.BuildCreate.Build.Id,
+		}); err != nil {
+			if ignorableError(err) {
+				return
+			}
+			t.Logf("failed to cancel build: %v", err)
+		}
+	})
+	build := createBuild.BuildCreate.Build
+	require.GreaterOrEqual(t, len(build.Jobs.Edges), 1)
+	node := build.Jobs.Edges[0].Node
+	_, ok := node.(*api.JobJobTypeCommand)
+	require.True(t, ok)
+
+	return build.Build
+}
+
+func (t testcase) AssertSuccess(ctx context.Context, build api.Build) {
+	t.Helper()
+	require.Equal(t, api.BuildStatesPassed, t.waitForBuild(ctx, build))
+}
+
+func (t testcase) AssertLogsContain(build api.Build, content string) {
+	t.Helper()
+	config, err := buildkite.NewTokenConfig(cfg.BuildkiteToken, false)
+	require.NoError(t, err)
+
+	client := buildkite.NewClient(config.Client())
+	job := build.Jobs.Edges[0].Node.(*api.JobJobTypeCommand)
+	logs, _, err := client.Jobs.GetJobLog(cfg.Org, t.PipelineName, strconv.Itoa(build.Number), job.Uuid)
+	require.NoError(t, err)
+	require.NotNil(t, logs.Content)
+	require.Contains(t, *logs.Content, content)
+}
+
+func (t testcase) AssertArtifactsContain(build api.Build, expected ...string) {
+	t.Helper()
+	config, err := buildkite.NewTokenConfig(cfg.BuildkiteToken, false)
+	require.NoError(t, err)
+	client := buildkite.NewClient(config.Client())
+
+	artifacts, _, err := client.Artifacts.ListByBuild(cfg.Org, t.PipelineName, strconv.Itoa(build.Number), nil)
+	require.NoError(t, err)
+	require.Len(t, artifacts, 2)
+	filenames := []string{*artifacts[0].Filename, *artifacts[1].Filename}
+	for _, filename := range expected {
+		require.Contains(t, filenames, filename)
+	}
+}
+
+func (t testcase) AssertFail(ctx context.Context, build api.Build) {
+	t.Helper()
+
+	require.Equal(t, api.BuildStatesFailed, t.waitForBuild(ctx, build))
+}
+
+func (t testcase) waitForBuild(ctx context.Context, build api.Build) api.BuildStates {
+	t.Helper()
+
+	for {
+		getBuild, err := api.GetBuild(ctx, t.GraphQL, build.Uuid)
+		require.NoError(t, err)
+		switch getBuild.Build.State {
+		case api.BuildStatesPassed, api.BuildStatesFailed, api.BuildStatesCanceled, api.BuildStatesCanceling:
+			return getBuild.Build.State
+		case api.BuildStatesScheduled, api.BuildStatesRunning:
+			t.Logger.Debug("sleeping", zap.Any("build state", getBuild.Build.State))
+			time.Sleep(time.Second)
+		default:
+			t.Errorf("unknown build state %q", getBuild.Build.State)
+			return getBuild.Build.State
+		}
+	}
+}
+
+func (t testcase) AssertMetadata(ctx context.Context, annotations, labelz map[string]string) {
+	t.Helper()
+
+	tagReq, err := labels.NewRequirement(api.TagLabel, selection.Equals, []string{fmt.Sprintf("queue_%s", t.PipelineName)})
+	require.NoError(t, err)
+	selector := labels.NewSelector().Add(*tagReq)
+
+	jobs, err := t.Kubernetes.BatchV1().Jobs(cfg.Namespace).List(ctx, v1.ListOptions{LabelSelector: selector.String()})
+	require.NoError(t, err)
+	require.Len(t, jobs.Items, 1)
+	for k, v := range annotations {
+		require.Equal(t, jobs.Items[0].ObjectMeta.Annotations[k], v)
+		require.Equal(t, jobs.Items[0].Spec.Template.Annotations[k], v)
+	}
+	for k, v := range labelz {
+		require.Equal(t, jobs.Items[0].ObjectMeta.Labels[k], v)
+		require.Equal(t, jobs.Items[0].Spec.Template.Labels[k], v)
+	}
+}
+
+func strPtr(p string) *string {
+	return &p
+}
+
+func ignorableError(err error) bool {
+	reasons := []string{
+		"already finished",
+		"already being canceled",
+		"already been canceled",
+		"No build found",
+	}
+	for _, reason := range reasons {
+		if strings.Contains(err.Error(), reason) {
+			return true
+		}
+	}
+	return false
+}
+
+func (t testcase) deletePipeline(ctx context.Context) {
+	t.Helper()
+
+	EnsureCleanup(t.T, func() {
+		err := roko.NewRetrier(
+			roko.WithMaxAttempts(10),
+			roko.WithStrategy(roko.Exponential(time.Second, 5*time.Second)),
+		).DoWithContext(ctx, func(r *roko.Retrier) error {
+			resp, err := t.Buildkite.Pipelines.Delete(cfg.Org, t.PipelineName)
+			if err != nil {
+				if resp.StatusCode == http.StatusNotFound {
+					return nil
+				}
+				t.Logf("waiting for build to be canceled on pipeline %s", t.PipelineName)
+				return err
+			}
+			return nil
+		})
+		if err != nil {
+			t.Logf("failed to cleanup pipeline %s: %v", t.PipelineName, err)
+			return
+		}
+		t.Logf("deleted pipeline! %s", t.PipelineName)
+	})
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/buildkite/agent-stack-k8s/v2/api"
 	"github.com/buildkite/agent-stack-k8s/v2/internal/monitor"
+	"github.com/buildkite/agent-stack-k8s/v2/internal/version"
 	"github.com/buildkite/agent/v3/clicommand"
 	"go.uber.org/zap"
 	batchv1 "k8s.io/api/batch/v1"
@@ -320,6 +321,9 @@ func (w *jobWrapper) Build() (*batchv1.Job, error) {
 			}, {
 				Name:  "BUILDKITE_CONTAINER_COUNT",
 				Value: strconv.Itoa(containerCount),
+			}, {
+				Name:  "BUILDKITE_AGENT_TAGS",
+				Value: fmt.Sprintf("k8s-stack-version=%s", version.Version()),
 			},
 		},
 	}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -309,7 +309,7 @@ func (w *jobWrapper) Build() (*batchv1.Job, error) {
 
 	agentTags := []agentTag{
 		{
-			Name:  "bk-k8s:version",
+			Name:  "k8s:agent-stack-version",
 			Value: version.Version(),
 		},
 	}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -335,6 +335,30 @@ func (w *jobWrapper) Build() (*batchv1.Job, error) {
 				Name:  "BUILDKITE_AGENT_TAGS",
 				Value: createAgentTagString(agentTags),
 			},
+			{
+				Name: "BUILDKITE_K8S_NODE",
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{
+						FieldPath: "spec.nodeName",
+					},
+				},
+			},
+			{
+				Name: "BUILDKITE_K8S_NAMESPACE",
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{
+						FieldPath: "metadata.namespace",
+					},
+				},
+			},
+			{
+				Name: "BUILDKITE_K8S_SERVICE_ACCOUNT",
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{
+						FieldPath: "spec.serviceAccountName",
+					},
+				},
+			},
 		},
 	}
 	agentContainer.Env = append(agentContainer.Env, env...)

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -14,6 +14,7 @@ import (
 
 //go:generate mockgen -destination=mock_handler_test.go -source=scheduler.go -package scheduler_test
 func TestJobPluginConversion(t *testing.T) {
+	t.Parallel()
 	pluginConfig := KubernetesPlugin{
 		PodSpec: &corev1.PodSpec{
 			Containers: []corev1.Container{
@@ -87,6 +88,7 @@ func TestJobPluginConversion(t *testing.T) {
 }
 
 func TestJobWithNoKubernetesPlugin(t *testing.T) {
+	t.Parallel()
 	input := &monitor.Job{
 		CommandJob: api.CommandJob{
 			Uuid:    "abc",
@@ -107,6 +109,7 @@ func TestJobWithNoKubernetesPlugin(t *testing.T) {
 }
 
 func TestFailureJobs(t *testing.T) {
+	t.Parallel()
 	pluginsJSON, err := json.Marshal([]map[string]interface{}{
 		{
 			"github.com/buildkite-plugins/kubernetes-buildkite-plugin": `"some-invalid-json"`,

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -112,6 +112,7 @@ func TestFailureJobs(t *testing.T) {
 			"github.com/buildkite-plugins/kubernetes-buildkite-plugin": `"some-invalid-json"`,
 		},
 	})
+	require.NoError(t, err)
 
 	input := &monitor.Job{
 		CommandJob: api.CommandJob{
@@ -129,17 +130,20 @@ func TestFailureJobs(t *testing.T) {
 
 	commandContainer := findContainer(t, result.Spec.Template.Spec.Containers, "container-0")
 	commandEnv := findEnv(t, commandContainer.Env, "BUILDKITE_COMMAND")
-	require.Equal(t, `echo "failed parsing Kubernetes plugin: json: cannot unmarshal string into Go value of type scheduler.KubernetesPlugin" && exit 1`, commandEnv.Value)
-
+	require.Equal(t,
+		`echo "failed parsing Kubernetes plugin: json: cannot unmarshal string into Go value of type scheduler.KubernetesPlugin" && exit 1`,
+		commandEnv.Value,
+	)
 }
 
 func findContainer(t *testing.T, containers []corev1.Container, name string) corev1.Container {
+	t.Helper()
+
 	for _, container := range containers {
 		if container.Name == name {
 			return container
 		}
 	}
-	t.Helper()
 	require.FailNow(t, "container not found")
 
 	return corev1.Container{}
@@ -151,6 +155,5 @@ func findEnv(t *testing.T, envs []corev1.EnvVar, name string) *corev1.EnvVar {
 			return &env
 		}
 	}
-
 	return nil
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,7 @@
+package version
+
+var version = "devel"
+
+func Version() string {
+	return version
+}

--- a/justfile
+++ b/justfile
@@ -48,7 +48,11 @@ agent target os=("linux") arch=("amd64 arm64"):
   rm packaging/docker/alpine/buildkite-agent-*
 
 controller *FLAGS:
-  ko build -P {{FLAGS}}
+  #!/usr/bin/env bash
+  set -eufo pipefail
+
+  export VERSION=$(git describe)
+  ko build --preserve-import-paths {{FLAGS}}
 
 deploy *FLAGS:
   #!/usr/bin/env bash


### PR DESCRIPTION
This adds the agent-stack-k8s version, as well as the node name, namespace, and service account name of the pod.

The version is obtained through a variable set at compile time. It is passed directly as a tag to the `buildkite-agent start` command. The others are set as environment variables using the [downward api](https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/). The agent then has the responsibility to read these and added the appropriate tags. Support for this is added in the companion PR in the agent repo: https://github.com/buildkite/agent/pull/2003

## Screenshot
![2023-03-09T10:47:40,722595643+11:00](https://user-images.githubusercontent.com/11096602/223880234-44980406-23d5-4307-a53c-0ffb1889921c.png)

## Also

- Refactored the test code to break out the `testcase` objet
- Added an integration test that the agent token is interpolated
- Refactored the pipeline
- Changed the pipeline to push agent/controller/helm chart on branches, so we can test them out
	- we will re-visit this decision later, but I need it for now to do things like make the screenshot above
- made scheduler tests run in parallel
