### PR TITLE
Add nodeSelector to values.yaml schema

### DIFF
--- a/charts/agent-stack-k8s/templates/deployment.yaml.tpl
+++ b/charts/agent-stack-k8s/templates/deployment.yaml.tpl
@@ -16,6 +16,8 @@ spec:
         checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml.tpl") . | sha256sum }}
     spec:
       serviceAccountName: {{ .Release.Name }}
+      nodeSelector:
+{{ toYaml $.Values.nodeSelector | indent 8 }}
       containers:
       - name: controller
         terminationMessagePolicy: FallbackToLogsOnError

--- a/charts/agent-stack-k8s/values.schema.json
+++ b/charts/agent-stack-k8s/values.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "http://example.com/example.json",
   "type": "object",
   "default": {},
@@ -25,6 +25,16 @@
       "default": "",
       "title": "The image Schema",
       "examples": ["ghcr.io/buildkite/agent-stack-k8s:latest"]
+    },
+    "nodeSelector": {
+      "type": "object",
+      "default": {},
+      "title": "The nodeSelector Schema",
+      "examples": [
+        {
+          "kubernetes.io/arch": "amd64"
+        }
+      ]
     },
     "config": {
       "type": "object",
@@ -90,6 +100,7 @@
       "agentToken": "",
       "graphqlToken": "",
       "image": "ghcr.io/buildkite/agent-stack-k8s:latest",
+      "nodeSelector": {},
       "config": {
         "agentImage": "",
         "debug": false,

--- a/charts/agent-stack-k8s/values.yaml
+++ b/charts/agent-stack-k8s/values.yaml
@@ -1,5 +1,7 @@
 agentToken: ""
 graphqlToken: ""
 
+nodeSelector: {}
+
 config:
   org: ""


### PR DESCRIPTION
This will allow setting the nodeSelector on the pod for the controller. This is a pretty standard
option in helm charts as it's part of the values.yaml created by the `helm create` command.