### PR TITLE
Use sh as default shell

### DIFF
--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -250,6 +250,9 @@ func (w *jobWrapper) Build() (*batchv1.Job, error) {
 		}, corev1.EnvVar{
 			Name:  clicommand.RedactedVars.EnvVar,
 			Value: strings.Join(clicommand.RedactedVars.Value.Value(), ","),
+		}, corev1.EnvVar{
+			Name:  "BUILDKITE_SHELL",
+			Value: "/bin/sh -ec",
 		})
 		if c.Name == "" {
 			c.Name = fmt.Sprintf("%s-%d", "container", i)


### PR DESCRIPTION
Now that https://github.com/buildkite/agent/pull/1995 has merged, this should allow us to run
buildkite jobs where all the hooks set the hashbang to /bin/sh to run in a container without bash installed.