### PR TITLE
Fix deploy script

### DIFF
--- a/.buildkite/steps/build_and_push.sh
+++ b/.buildkite/steps/build_and_push.sh
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/usr/bin/env ash
 
 set -eufo pipefail
 
@@ -16,9 +16,9 @@ skopeo copy --multi-arch=all "docker://${temp_agent_image}" "docker://${agent_im
 echo --- :helm: Packaging helm chart
 yq -i ".image = \"$controller_image\"" charts/agent-stack-k8s/values.yaml
 yq -i ".config.image = \"$agent_image\"" charts/agent-stack-k8s/values.yaml
-helm package ./charts/agent-stack-k8s --app-version "$version" -d dist --version "$version"
+helm package charts/agent-stack-k8s --app-version "$version" -d dist --version "$version"
 
 echo --- :helm: Pushing helm chart to ghcr.io
-helm push ./dist/agent-stack-k8s-*.tgz "$helm_repo"
+helm push "dist/agent-stack-k8s-${version}.tgz" "$helm_repo"
 
 buildkite-agent annotate "Version: $version of the helm chart has been pushed to $helm_repo/agent-stack-k8s:$version"

--- a/.buildkite/steps/build_and_push.sh
+++ b/.buildkite/steps/build_and_push.sh
@@ -5,7 +5,7 @@ set -eufo pipefail
 echo --- :hammer: Installing tools
 apk add --update-cache --no-progress helm yq skopeo git
 
-. .buildkite/steps/repo_info.sh
+source .buildkite/steps/repo_info.sh
 
 echo --- :docker: Logging into ghcr.io
 skopeo login ghcr.io -u "$REGISTRY_USERNAME" --password "$REGISTRY_PASSWORD" --authfile ~/.docker/config.json

--- a/.buildkite/steps/build_and_push.sh
+++ b/.buildkite/steps/build_and_push.sh
@@ -1,9 +1,9 @@
 #!/bin/ash
 
-set -euo pipefail
+set -eufo pipefail
 
 echo --- :hammer: Installing tools
-apk add helm yq skopeo git --quiet --no-progress
+apk add --update-cache --no-progress helm yq skopeo git
 
 . .buildkite/steps/repo_info.sh
 

--- a/.buildkite/steps/deploy.sh
+++ b/.buildkite/steps/deploy.sh
@@ -5,7 +5,7 @@ set -eufo pipefail
 echo --- :hammer: Installing tools
 apk add --update-cache --no-progress helm git
 
-. .buildkite/steps/repo_info.sh
+source .buildkite/steps/repo_info.sh
 
 echo --- :helm: Helm upgrade
 helm upgrade agent-stack-k8s "${helm_repo}/agent-stack-k8s" \

--- a/.buildkite/steps/deploy.sh
+++ b/.buildkite/steps/deploy.sh
@@ -3,7 +3,7 @@
 set -eufo pipefail
 
 echo --- :hammer: Installing tools
-apk add helm git --quiet --no-progress
+apk add --update-cache --no-progress helm git
 
 . .buildkite/steps/repo_info.sh
 

--- a/.buildkite/steps/deploy.sh
+++ b/.buildkite/steps/deploy.sh
@@ -8,7 +8,7 @@ apk add helm git --quiet --no-progress
 . .buildkite/steps/repo_info.sh
 
 echo --- :helm: Helm upgrade
-helm upgrade agent-stack-k8s "oci://${helm_repo}/agent-stack-k8s" \
+helm upgrade agent-stack-k8s "${helm_repo}/agent-stack-k8s" \
     --version "$version" \
     --namespace buildkite \
     --install \

--- a/.buildkite/steps/repo_info.sh
+++ b/.buildkite/steps/repo_info.sh
@@ -1,6 +1,8 @@
 # vim: ft=sh
 # shellcheck disable=SC2034  # this file will be sourced
 
+set -eufo pipefail
+
 docker_repo_prefix=ghcr.io/buildkite
 tag=$(git describe)
 version=${tag/v/}

--- a/.buildkite/steps/tests.sh
+++ b/.buildkite/steps/tests.sh
@@ -2,7 +2,7 @@
 
 set -eufo pipefail
 
-echo "+++ Installing gotestsum :golang::test_tube:"
+echo "--- Installing gotestsum :golang::test_tube:"
 go install gotest.tools/gotestsum
 
 echo '+++ Running integration tests :test_tube:'


### PR DESCRIPTION
There was an extra `oci://` somewhere.

I also refactored some log groups and log output and made apk (the package manager for alpine linux) update its cache of the repos before installing new packages. Finally, I made sure that only the current version of the chart is pushed. While it's unlikely that there will be multiple versions packaged in the same container. I think this is a good defence in case someone retrofits that script to run elsewhere.