### PR TITLE
Fix nullifying annotations when there are no labels

### DIFF
--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -170,10 +170,15 @@ func (w *jobWrapper) Build() (*batchv1.Job, error) {
 			},
 		}
 	}
+
 	if w.k8sPlugin.Metadata.Labels == nil {
 		w.k8sPlugin.Metadata.Labels = map[string]string{}
+	}
+
+	if w.k8sPlugin.Metadata.Annotations == nil {
 		w.k8sPlugin.Metadata.Annotations = map[string]string{}
 	}
+
 	w.k8sPlugin.Metadata.Labels[api.UUIDLabel] = w.job.Uuid
 	w.k8sPlugin.Metadata.Labels[api.TagLabel] = api.TagToLabel(w.job.Tag)
 	w.k8sPlugin.Metadata.Annotations[api.BuildURLAnnotation] = w.envMap["BUILDKITE_BUILD_URL"]


### PR DESCRIPTION
Fixes #155 

Currently if there are no labels described in the configuration, annotations also get set to an empty map, nuking any annotations set in the configuration. 

https://github.com/buildkite/agent-stack-k8s/blob/b5811c8fbb21b4ab4c7869a775cc08454696cc2a/internal/scheduler/scheduler.go#L173-L176

This splits them up so that annotations are only set to an empty map if no annotations are described.


