### PR TITLE
Remove agent submodule

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -25,15 +25,14 @@ steps:
                 cpu: 1000m
                 memory: 1Gi
 
-  - label: ":docker: build agent"
+  - label: ":docker: choose agent"
     key: agent
     plugins:
       - kubernetes:
           podSpec:
-            serviceAccountName: docker
             containers:
               - name: docker
-                image: golang:latest
+                image: alpine:latest
                 command: [.buildkite/steps/agent.sh]
 
   - label: ":buildkite: integration tests"

--- a/.buildkite/steps/agent.sh
+++ b/.buildkite/steps/agent.sh
@@ -1,27 +1,14 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-set -eufo pipefail
+set -eu
 
 echo --- Installing packages
-apt update && apt install -y --no-install-recommends ca-certificates curl gnupg lsb-release jq
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-echo \
-    "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
-  $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list >/dev/null
-apt update && apt install -y docker-ce-cli
+apk add --update-cache --no-progress skopeo
 
-docker buildx create --driver kubernetes --use
-function cleanup {
-    docker buildx rm
-}
-trap cleanup EXIT
+repo="docker.io/buildkite/agent"
 
-echo --- Installing just
-curl --proto '=https' --tlsv1.3 -sSf https://just.systems/install.sh | bash -s -- --to /bin
+echo --- :docker: Inspecting agent docker image manifest
+digest=$(skopeo inspect "docker://${repo}:stable" --format {{.Digest}})
 
-echo --- Building agent docker image
-just agent ttl.sh/buildkite-agent:1h
-
-image=$(jq -r '"ttl.sh/buildkite-agent@\(."containerimage.digest")"' dist/metadata.json)
-buildkite-agent meta-data set agent-image "$image"
+echo Choosing image "${repo}@${digest}"
+buildkite-agent meta-data set agent-image "${repo}@${digest}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 Brewfile.lock.json
 
+.DS_Store
 .vscode
 
 dist/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "agent"]
-path = agent
-url = https://github.com/buildkite/agent.git
-branch = "kubernetes-job-runner"

--- a/.helmignore
+++ b/.helmignore
@@ -21,5 +21,3 @@
 .idea/
 *.tmproj
 .vscode/
-
-agent/

--- a/justfile
+++ b/justfile
@@ -30,24 +30,6 @@ gomod:
   go mod tidy
   git diff -G. --no-ext-diff --exit-code go.mod go.sum
 
-agent target os=("linux") arch=("amd64 arm64"):
-  #!/usr/bin/env bash
-  set -euxo pipefail
-  pushd agent
-  version=$(git describe --tags)
-  platforms=()
-  for os in {{os}}; do
-    for arch in {{arch}}; do
-      platforms+=("${os}/${arch}")
-      ./scripts/build-binary.sh $os $arch $version
-    done
-  done
-  commaified=$(IFS=, ; echo "${platforms[*]}")
-  mkdir -p {{justfile_directory()}}/dist
-  mv pkg/buildkite-agent-* packaging/docker/alpine/
-  docker buildx build --tag {{target}} --platform "$commaified" --push --metadata-file {{justfile_directory()}}/dist/metadata.json packaging/docker/alpine
-  rm packaging/docker/alpine/buildkite-agent-*
-
 controller *FLAGS:
   #!/usr/bin/env bash
   set -eufo pipefail


### PR DESCRIPTION
Use the current stable agent image instead. The agent image digest is pinned to avoid testing with one image and bundling another.