### PR TITLE
Change the ClusterRole to a Role

### DIFF
--- a/charts/agent-stack-k8s/templates/deployment.yaml.tpl
+++ b/charts/agent-stack-k8s/templates/deployment.yaml.tpl
@@ -15,7 +15,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/config.yaml.tpl") . | sha256sum }}
         checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml.tpl") . | sha256sum }}
     spec:
-      serviceAccountName: {{ .Release.Name }}
+      serviceAccountName: {{ .Release.Name }}-controller
       nodeSelector:
 {{ toYaml $.Values.nodeSelector | indent 8 }}
       containers:

--- a/charts/agent-stack-k8s/templates/rbac.yaml.tpl
+++ b/charts/agent-stack-k8s/templates/rbac.yaml.tpl
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ .Release.Name }}-controller
   namespace: {{ .Release.Namespace }}
 rules:
   - apiGroups:
@@ -30,14 +30,14 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ .Release.Name }}
+  name: {{ .Release.Name }}-controller
 subjects:
   - kind: ServiceAccount
-    name: {{ .Release.Name }}
+    name: {{ .Release.Name }}-controller
     namespace: {{ .Release.Namespace }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ .Release.Name }}-controller
   namespace: {{ .Release.Namespace }}

--- a/charts/agent-stack-k8s/templates/rbac.yaml.tpl
+++ b/charts/agent-stack-k8s/templates/rbac.yaml.tpl
@@ -1,7 +1,8 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
 rules:
   - apiGroups:
       - batch
@@ -23,12 +24,12 @@ rules:
     - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: {{ .Release.Name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: {{ .Release.Name }}
 subjects:
   - kind: ServiceAccount

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -49,7 +49,7 @@ func Run(
 	})
 	limiter := scheduler.NewLimiter(logger.Named("limiter"), sched, cfg.MaxInFlight)
 
-	informerFactory, err := scheduler.NewInformerFactory(k8sClient, cfg.Tags)
+	informerFactory, err := scheduler.NewInformerFactory(k8sClient, cfg.Namespace, cfg.Tags)
 	if err != nil {
 		logger.Fatal("failed to create informer", zap.Error(err))
 	}

--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -18,9 +18,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/selection"
-	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/pointer"
 )
@@ -43,31 +40,6 @@ func New(logger *zap.Logger, client kubernetes.Interface, cfg Config) *worker {
 		client: client,
 		logger: logger.Named("worker"),
 	}
-}
-
-// returns an informer factory configured to watch resources (pods, jobs) created by the scheduler
-func NewInformerFactory(
-	k8s kubernetes.Interface,
-	namespace string,
-	tags []string,
-) (informers.SharedInformerFactory, error) {
-	hasTag, err := labels.NewRequirement(config.TagLabel, selection.In, config.TagsToLabels(tags))
-	if err != nil {
-		return nil, fmt.Errorf("failed to build tag label selector for job manager: %w", err)
-	}
-	hasUUID, err := labels.NewRequirement(config.UUIDLabel, selection.Exists, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to build uuid label selector for job manager: %w", err)
-	}
-	factory := informers.NewSharedInformerFactoryWithOptions(
-		k8s,
-		0,
-		informers.WithNamespace(namespace),
-		informers.WithTweakListOptions(func(opt *metav1.ListOptions) {
-			opt.LabelSelector = labels.NewSelector().Add(*hasTag, *hasUUID).String()
-		}),
-	)
-	return factory, nil
 }
 
 type KubernetesPlugin struct {

--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -48,6 +48,7 @@ func New(logger *zap.Logger, client kubernetes.Interface, cfg Config) *worker {
 // returns an informer factory configured to watch resources (pods, jobs) created by the scheduler
 func NewInformerFactory(
 	k8s kubernetes.Interface,
+	namespace string,
 	tags []string,
 ) (informers.SharedInformerFactory, error) {
 	hasTag, err := labels.NewRequirement(config.TagLabel, selection.In, config.TagsToLabels(tags))
@@ -61,6 +62,7 @@ func NewInformerFactory(
 	factory := informers.NewSharedInformerFactoryWithOptions(
 		k8s,
 		0,
+		informers.WithNamespace(namespace),
 		informers.WithTweakListOptions(func(opt *metav1.ListOptions) {
 			opt.LabelSelector = labels.NewSelector().Add(*hasTag, *hasUUID).String()
 		}),


### PR DESCRIPTION
Previously, the controller was given permission to crud jobs in any namespace in the cluster. This is too broad, so this PR isolates this into one namespace.

I also moved the creation of the informer factory to the `controller` package as it is called from there.