### PR TITLE
Update README with instructions for clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ If you are using [Buildkite Cluster](https://buildkite.com/docs/agent/clusters) 
 config:
   cluster-uuid: beefcafe-abbe-baba-abba-deedcedecade
 ```
-The cluster's UUID may be obtained from the settings page for the cluster.
+The cluster's UUID may be obtained by navigating to the [clusters page](https://buildkite.com/organizations/-/clusters), clicking on the relevant cluster and then clicking on "Settings". It will be in a section titled "GraphQL API Integration".
 
 ### Sidecars
 

--- a/README.md
+++ b/README.md
@@ -51,16 +51,29 @@ Available versions and their digests can be found on [the releases page](https:/
 
 ```text
 $ agent-stack-k8s --help
-Usage of agent-stack-k8s:
+Usage:
+  agent-stack-k8s [flags]
+  agent-stack-k8s [command]
+
+Available Commands:
+  completion  Generate the autocompletion script for the specified shell
+  help        Help about any command
+  lint        A tool for linting Buildkite pipelines
+  version     Prints the version
+
+Flags:
       --agent-token-secret string   name of the Buildkite agent token secret (default "buildkite-agent-token")
       --buildkite-token string      Buildkite API token with GraphQL scopes
+      --cluster-uuid string         UUID of the Buildkite Cluster. The agent token must be for the Buildkite Cluster.
   -f, --config string               config file path
       --debug                       debug logs
+  -h, --help                        help for agent-stack-k8s
       --image string                The image to use for the Buildkite agent (default "ghcr.io/buildkite/agent-k8s:latest")
       --job-ttl duration            time to retain kubernetes jobs after completion (default 10m0s)
-      --max-in-flight int           max jobs in flight, 0 means no max (default 1)
+      --max-in-flight int           max jobs in flight, 0 means no max (default 25)
       --namespace string            kubernetes namespace to create resources in (default "default")
       --org string                  Buildkite organization name to watch
+      --profiler-address string     Bind address to expose the pprof profiler (e.g. localhost:6060)
       --tags strings                A comma-separated list of tags for the agent (for example, "linux" or "mac,xcode=8") (default [queue=kubernetes])
 ```
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,14 @@ The `podSpec` of the `kubernetes` plugin can support any field from the `PodSpec
 
 More samples can be found in the [integration test fixtures directory](internal/integration/fixtures).
 
+### Buildkite Clusters
+If you are using [Buildkite Cluster](https://buildkite.com/docs/agent/clusters) to isolate sets of pipelines from each other, you will need to specify the cluster's UUID in the configuration for the controller. This may be done using a flag on the `helm` command like so: `--set config.cluster-uuid=<your cluster's UUID>`, or a entry in a values file.
+```yaml
+# values.yaml
+config:
+  cluster-uuid: beefcafe-abbe-baba-abba-deedcedecade
+```
+
 ### Sidecars
 
 Sidecar containers can be added to your job by specifying them under the top-level `sidecars` key. See [this example](internal/integration/fixtures/sidecars.yaml) for a simple job that runs `nginx` as a sidecar, and accesses the nginx server from the main job.

--- a/README.md
+++ b/README.md
@@ -101,12 +101,13 @@ The `podSpec` of the `kubernetes` plugin can support any field from the `PodSpec
 More samples can be found in the [integration test fixtures directory](internal/integration/fixtures).
 
 ### Buildkite Clusters
-If you are using [Buildkite Cluster](https://buildkite.com/docs/agent/clusters) to isolate sets of pipelines from each other, you will need to specify the cluster's UUID in the configuration for the controller. This may be done using a flag on the `helm` command like so: `--set config.cluster-uuid=<your cluster's UUID>`, or a entry in a values file.
+If you are using [Buildkite Cluster](https://buildkite.com/docs/agent/clusters) to isolate sets of pipelines from each other, you will need to specify the cluster's UUID in the configuration for the controller. This may be done using a flag on the `helm` command like so: `--set config.cluster-uuid=<your cluster's UUID>`, or an entry in a values file.
 ```yaml
 # values.yaml
 config:
   cluster-uuid: beefcafe-abbe-baba-abba-deedcedecade
 ```
+The cluster's UUID may be obtained from the settings page for the cluster.
 
 ### Sidecars
 

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -44,7 +44,7 @@ func addFlags(cmd *cobra.Command) {
 	cmd.Flags().Int("max-in-flight", 25, "max jobs in flight, 0 means no max")
 	cmd.Flags().Duration("job-ttl", 10*time.Minute, "time to retain kubernetes jobs after completion")
 	cmd.Flags().String(
-		"cluster-uuid", "", "UUID of the Cluster. The agent token must be for the Cluster.",
+		"cluster-uuid", "", "UUID of the Buildkite Cluster. The agent token must be for the Buildkite Cluster.",
 	)
 	cmd.Flags().String("profiler-address", "", "Bind address to expose the pprof profiler (e.g. localhost:6060)")
 }

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -6,6 +6,9 @@ job-ttl: 5m
 max-in-flight: 100
 namespace: my-buildkite-ns
 org: my-buildkite-org
+# only set if the pipelines are in a cluster
+# the UUID may be found in the cluster settings
+cluster-uuid: beefcafe-abbe-baba-abba-deedcedecade
 tags:
 - queue=my-queue
 - priority=high


### PR DESCRIPTION
We improved cluster support in https://github.com/buildkite/agent-stack-k8s/pull/154. It changed the config you need to provide to use clusters, so let's document it.