### PR TITLE
Enable secrets to be referenced in the install namespace so this can be installed with tools like argo

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,18 @@ helm upgrade --install agent-stack-k8s oci://ghcr.io/buildkite/helm/agent-stack-
 We're using Helm's support for [OCI-based registries](https://helm.sh/docs/topics/registries/),
 which means you'll need Helm version 3.8.0 or newer.
 
+#### Externalize Secrets
+
+You can also have an external provider create a secret for you in the namespace before deploying the chart with helm. If the secret is pre-provisioned, replace the `agentToken` and `graphqlToken` arguments with:
+
+```bash
+--set agentStackSecret=<secret-name>
+```
+
+The format of the required secret can be found in [this file](./charts/agent-stack-k8s/templates/secrets.yaml.tpl).
+
+#### Other Installation Methods
+
 You can also use this chart as a dependency:
 
 ```yaml

--- a/charts/agent-stack-k8s/templates/deployment.yaml.tpl
+++ b/charts/agent-stack-k8s/templates/deployment.yaml.tpl
@@ -27,7 +27,7 @@ spec:
           value: /etc/config.yaml
         envFrom:
           - secretRef:
-              name: {{ .Release.Name }}-secrets
+              name: {{ if .Values.agentStackSecret }}{{.Values.agentStackSecret}}{{ else }}{{ .Release.Name }}-secrets{{ end }}
         volumeMounts:
           - name: config
             mountPath: /etc/config.yaml

--- a/charts/agent-stack-k8s/templates/secrets.yaml.tpl
+++ b/charts/agent-stack-k8s/templates/secrets.yaml.tpl
@@ -1,3 +1,4 @@
+{{- if not .Values.agentStackSecret -}}
 # A sample agent token and graphql token secret
 apiVersion: v1
 kind: Secret
@@ -7,3 +8,4 @@ metadata:
 data:
   BUILDKITE_AGENT_TOKEN: {{ required "agentToken must be set" .Values.agentToken | b64enc | quote }}
   BUILDKITE_TOKEN: {{ required "graphqlToken must be set" .Values.graphqlToken | b64enc | quote }}
+{{- end -}}

--- a/charts/agent-stack-k8s/values.schema.json
+++ b/charts/agent-stack-k8s/values.schema.json
@@ -9,20 +9,27 @@
     "agentToken": {
       "type": "string",
       "default": "",
-      "minLength": 1,
+      "minLength": 0,
       "title": "The agentToken Schema",
       "examples": [""]
     },
     "graphqlToken": {
       "type": "string",
       "default": "",
-      "minLength": 1,
+      "minLength": 0,
       "title": "The graphqlToken Schema",
       "examples": [""]
     },
-    "image": {
+    "agentStackSecret": {
       "type": "string",
       "default": "",
+      "minLength": 0,
+      "title": "If an external secret is provided for the agent stack, set its name here",
+      "examples": ["agent-stack-secret"]
+    },
+    "image": {
+      "type": "string",
+      "default": "ghcr.io/buildkite/agent-stack-k8s:latest",
       "title": "The image Schema",
       "examples": ["ghcr.io/buildkite/agent-stack-k8s:latest"]
     },


### PR DESCRIPTION
This came up in a conversation with a team using Buildkite right now and felt like a good pattern to support.

If this is installed via argo, you would likely have another mechanism that would install the secret in the namespace, such as external secrets operator. We should enable this secret to be pre-provisioned and referenced in the `envFrom` block by name.