### PR TITLE
Revert "add optional labels"

### DIFF
--- a/charts/agent-stack-k8s/templates/deployment.yaml.tpl
+++ b/charts/agent-stack-k8s/templates/deployment.yaml.tpl
@@ -10,7 +10,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- toYaml $.Values.labels | nindent 8 }}
+        app: {{ .Release.Name }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/config.yaml.tpl") . | sha256sum }}
         checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml.tpl") . | sha256sum }}

--- a/charts/agent-stack-k8s/values.schema.json
+++ b/charts/agent-stack-k8s/values.schema.json
@@ -4,7 +4,7 @@
   "type": "object",
   "default": {},
   "title": "Root Schema",
-  "required": ["agentToken", "graphqlToken", "image","labels", "config"],
+  "required": ["agentToken", "graphqlToken", "image", "config"],
   "properties": {
     "agentToken": {
       "type": "string",
@@ -33,32 +33,6 @@
       "examples": [
         {
           "kubernetes.io/arch": "amd64"
-        }
-      ]
-    },
-    "labels": {
-      "type": "object",
-      "default": {},
-      "title": "The labels Schema",
-      "required": ["app"],
-      "properties": {
-        "app":{
-          "type": ["string", "number"]
-        }
-      },
-      "additionalProperties": {
-        "type": "object",
-        "default": {}
-      },
-      "example": [
-        { 
-          "app": "my-app1",
-          "user": {
-            "user": "name"
-          },
-          "project": {
-            "project": "project"
-          }
         }
       ]
     },
@@ -177,9 +151,6 @@
       "graphqlToken": "",
       "image": "ghcr.io/buildkite/agent-stack-k8s:latest",
       "nodeSelector": {},
-      "labels": {
-        "app": ""
-      },
       "config": {
         "agentImage": "",
         "debug": false,

--- a/charts/agent-stack-k8s/values.yaml
+++ b/charts/agent-stack-k8s/values.yaml
@@ -6,9 +6,6 @@ nodeSelector: {}
 config:
   org: ""
 
-labels:
-  app: ""
-
 resources:
   requests:
     cpu: 100m


### PR DESCRIPTION
Reverts buildkite/agent-stack-k8s#172

This failed to upgrade an existing helm release of agent-stack-k8s with the following error:
```
Error: UPGRADE FAILED: cannot patch "agent-stack-k8s" with kind Deployment: Deployment.apps "agent-stack-k8s" is invalid: spec.template.metadata.labels: Invalid value: map[string]string{"app":""}: `selector` does not match template `labels`
```

It seems we need the deployment's `spec.selector.matchLabels` object to be a sub-object of `template.metadata.labels`. The chart used to guarantee this (it hard coded that they were the same), but that's not the case with this PR, so I'm reverting it.

Also, I think we should preserve the label `app: {{ .Release.Name }}`. So, for resubmission, I think we should merge the labels specified in `.Values.labels` with the object `app: {{ .Release.Name }}`.

@jiaquan1 we'll be happy to accept another PR that does this.