### PR TITLE
Make deploy step depend on push step

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -95,7 +95,8 @@ steps:
                 - secretRef:
                     name: deploy-secrets
 
-  - label: ":helm::docker: push helm chart"
+  - label: ":helm::docker: push controller image and helm chart"
+    key: push
     depends_on:
     - agent
     - controller
@@ -119,8 +120,7 @@ steps:
   - label: ":shipit: deploy"
     if: "build.branch == pipeline.default_branch"
     depends_on:
-    - agent
-    - controller
+    - push
     - integration
     env:
       BUILDKITE_GIT_FETCH_FLAGS: "-v --tags"


### PR DESCRIPTION
Although the deployment does not depend on the helm chart being pushed to
the registry, it does depend on the controller image being in the registry,
so we need to make the deployment step depend on the push step.

I have seen this error a few time on the main branch:
https://buildkite.com/buildkite-kubernetes-stack/kubernetes-agent-stack/builds/735#0188e6bc-22f2-4d18-9f4f-75446fc00f85
https://buildkite.com/buildkite-kubernetes-stack/kubernetes-agent-stack/builds/736#0188ec5d-70d1-4a74-b170-d2a9a73a56cb