### PR TITLE
Fix helm template with default value for the label

### DIFF
--- a/charts/agent-stack-k8s/templates/_helper.tpl
+++ b/charts/agent-stack-k8s/templates/_helper.tpl
@@ -1,5 +1,8 @@
 {{/* Generate basic labels */}}
-{{- define "agent-stack-k8s.labels" }} 
-{{- toYaml $.Values.labels }}
+{{- define "agent-stack-k8s.mandatoryLabels" }}
 app: {{ .Release.Name }}
+{{- end }}
+
+{{- define "agent-stack-k8s.labels" }}
+{{- toYaml (mustMerge (fromYaml (include "agent-stack-k8s.mandatoryLabels" .)) .Values.labels) }}
 {{- end }}

--- a/charts/agent-stack-k8s/templates/deployment.yaml.tpl
+++ b/charts/agent-stack-k8s/templates/deployment.yaml.tpl
@@ -10,7 +10,7 @@ spec:
   template:
     metadata:
       labels:
-{{- include "agent-stack-k8s.labels" . | nindent 8 }}
+        {{- include "agent-stack-k8s.labels" . | nindent 8 }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/config.yaml.tpl") . | sha256sum }}
         checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml.tpl") . | sha256sum }}

--- a/charts/agent-stack-k8s/templates/deployment.yaml.tpl
+++ b/charts/agent-stack-k8s/templates/deployment.yaml.tpl
@@ -6,7 +6,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: {{ .Release.Name }}
+      {{- include "agent-stack-k8s.mandatoryLabels" . | nindent 8 }}
   template:
     metadata:
       labels:

--- a/charts/agent-stack-k8s/templates/deployment.yaml.tpl
+++ b/charts/agent-stack-k8s/templates/deployment.yaml.tpl
@@ -17,7 +17,7 @@ spec:
     spec:
       serviceAccountName: {{ .Release.Name }}-controller
       nodeSelector:
-{{ toYaml $.Values.nodeSelector | indent 8 }}
+        {{- toYaml $.Values.nodeSelector | nindent 8 }}
       containers:
       - name: controller
         terminationMessagePolicy: FallbackToLogsOnError
@@ -34,7 +34,6 @@ spec:
             subPath: config.yaml
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
-
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true

--- a/charts/agent-stack-k8s/values.yaml
+++ b/charts/agent-stack-k8s/values.yaml
@@ -12,4 +12,3 @@ resources:
     memory: 100Mi
 
 labels: {}
-  


### PR DESCRIPTION
The default value for `.Values.label` is `{}`, but is always another key, `app`, so the template renders as
```yaml
labels:
   {}
   app: foo
```
which is not valid yaml.

In this PR we merge the object provided by the user as `.Values.label` with an object of mandatory label, which the user cannot modify.

These mandatory labels are used as selectors for the deployment, so the user should not have too much control over them.