### PR TITLE
Publish latest images for agent, controller, and helm chart on main branch

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,9 @@
 agents:
   queue: kubernetes
+
 steps:
-  - name: ":go::broom: tidy"
+  - label: ":go::broom: tidy"
+    key: tidy
     plugins:
     - kubernetes:
         podSpec:
@@ -9,42 +11,38 @@ steps:
           - image: golang:1.20.2-alpine
             command: [.buildkite/steps/tidy.sh]
 
-  - name: ":go::lint-roller: lint"
+  - label: ":go::lint-roller: lint"
+    key: lint
     plugins:
     - kubernetes:
         podSpec:
           containers:
           - image: golangci/golangci-lint:v1.51.1
-            command:
-            - golangci-lint
-            args:
-            - run
-            - ./...
+            command: [golangci-lint, run, ./...]
             resources:
               requests:
                 cpu: 1000m
                 memory: 1Gi
 
-  - name: ":golang::robot_face: check code generation"
+  - label: ":golang::robot_face: check code generation"
     key: check-code-generation
     plugins:
-      - kubernetes:
-          podSpec:
-            containers:
-              - name: docker
-                image: golang:alpine
-                command: [.buildkite/steps/check-code-generation.sh]
-
+    - kubernetes:
+        podSpec:
+          containers:
+          - name: docker
+            image: golang:alpine
+            command: [.buildkite/steps/check-code-generation.sh]
 
   - label: ":docker::buildkite: choose agent image"
     key: agent
     plugins:
-      - kubernetes:
-          podSpec:
-            containers:
-              - name: docker
-                image: alpine:latest
-                command: [.buildkite/steps/agent.sh]
+    - kubernetes:
+        podSpec:
+          containers:
+          - name: docker
+            image: alpine:latest
+            command: [.buildkite/steps/agent.sh]
 
   - label: ":buildkite: integration tests"
     key: integration
@@ -79,21 +77,21 @@ steps:
                     cpu: 1000m
                     memory: 512Mi
       - test-collector:
-          files: "junit-*.xml"
-          format: "junit"
+          files: junit-*.xml
+          format: junit
 
   - label: ":docker: build controller"
     key: controller
     plugins:
-      - kubernetes:
-          podSpec:
-            containers:
-              - name: ko
-                image: golang:latest
-                command: [.buildkite/steps/controller.sh]
-                envFrom:
-                - secretRef:
-                    name: deploy-secrets
+    - kubernetes:
+        podSpec:
+          containers:
+          - name: ko
+            image: golang:latest
+            command: [.buildkite/steps/controller.sh]
+            envFrom:
+            - secretRef:
+                name: deploy-secrets
 
   - label: ":helm::docker: push controller image and helm chart"
     key: push
@@ -101,42 +99,42 @@ steps:
     - agent
     - controller
     env:
-      BUILDKITE_GIT_FETCH_FLAGS: "-v --tags"
+      BUILDKITE_GIT_FETCH_FLAGS: -v --tags
     plugins:
-      - kubernetes:
-          podSpec:
-            serviceAccountName: deploy
-            containers:
-              - name: deploy
-                image: alpine:latest
-                command: [.buildkite/steps/build_and_push.sh]
-                env:
-                - name: BUILDKITE_SHELL
-                  value: /bin/sh -ec
-                envFrom:
-                - secretRef:
-                    name: deploy-secrets
+    - kubernetes:
+        podSpec:
+          serviceAccountName: deploy
+          containers:
+          - name: deploy
+            image: alpine:latest
+            command: [.buildkite/steps/build-and-push.sh]
+            env:
+            - name: BUILDKITE_SHELL
+              value: /bin/sh -ec
+            envFrom:
+            - secretRef:
+                name: deploy-secrets
 
   - label: ":shipit: deploy"
-    if: "build.branch == pipeline.default_branch"
+    if: build.branch == pipeline.default_branch
     depends_on:
     - push
     - integration
     env:
-      BUILDKITE_GIT_FETCH_FLAGS: "-v --tags"
+      BUILDKITE_GIT_FETCH_FLAGS: -v --tags
     plugins:
-      - kubernetes:
-          podSpec:
-            serviceAccountName: deploy
-            containers:
-              - name: deploy
-                image: alpine:latest
-                command: [.buildkite/steps/deploy.sh]
-                env:
-                - name: BUILDKITE_SHELL
-                  value: /bin/sh -ec
-                envFrom:
-                - secretRef:
-                    name: deploy-secrets
-                - secretRef:
-                    name: agent-stack-k8s-secrets
+    - kubernetes:
+        podSpec:
+          serviceAccountName: deploy
+          containers:
+          - name: deploy
+            image: alpine:latest
+            command: [.buildkite/steps/deploy.sh]
+            env:
+            - name: BUILDKITE_SHELL
+              value: /bin/sh -ec
+            envFrom:
+            - secretRef:
+                name: deploy-secrets
+            - secretRef:
+                name: agent-stack-k8s-secrets

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -118,6 +118,25 @@ steps:
             - secretRef:
                 name: deploy-secrets
 
+  - label: ":docker::label: tag latest"
+    if: build.branch == pipeline.default_branch
+    depends_on:
+    - push
+    - integration
+    env:
+      BUILDKITE_GIT_FETCH_FLAGS: -v --tags
+    plugins:
+    - kubernetes:
+        podSpec:
+          serviceAccountName: deploy
+          containers:
+          - name: deploy
+            image: alpine:latest
+            command: [.buildkite/steps/tag-latest.sh]
+            envFrom:
+            - secretRef:
+                name: deploy-secrets
+
   - label: ":shipit: deploy"
     if: build.branch == pipeline.default_branch
     depends_on:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -96,6 +96,9 @@ steps:
   - label: ":helm::docker: push controller image and helm chart"
     key: push
     depends_on:
+    - tidy
+    - lint
+    - check-code-generation
     - agent
     - controller
     env:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -17,7 +17,7 @@ steps:
     - kubernetes:
         podSpec:
           containers:
-          - image: golangci/golangci-lint:v1.51.1
+          - image: golangci/golangci-lint:v1.53.3
             command: [golangci-lint, run, ./...]
             resources:
               requests:

--- a/.buildkite/steps/build-and-push.sh
+++ b/.buildkite/steps/build-and-push.sh
@@ -8,10 +8,16 @@ apk add --update-cache --no-progress helm yq skopeo git
 source .buildkite/steps/repo_info.sh
 
 echo --- :docker: Logging into ghcr.io
-skopeo login ghcr.io -u "$REGISTRY_USERNAME" --password "$REGISTRY_PASSWORD" --authfile ~/.docker/config.json
+skopeo login ghcr.io \
+  -u "$REGISTRY_USERNAME" \
+  --password "$REGISTRY_PASSWORD" \
+  --authfile ~/.docker/config.json
 
 echo --- :docker: Copying image to ghcr.io
-skopeo copy --multi-arch=all "docker://${temp_agent_image}" "docker://${agent_image}" --authfile ~/.docker/config.json
+skopeo copy \
+  --authfile ~/.docker/config.json \
+  --multi-arch=all \
+  "docker://${temp_agent_image}" "docker://${agent_image}"
 
 buildkite-agent annotate --style success --append <<EOF
 ### Agent

--- a/.buildkite/steps/build-and-push.sh
+++ b/.buildkite/steps/build-and-push.sh
@@ -41,6 +41,6 @@ buildkite-agent annotate --style success --append <<EOF
 --------------------------------------------------
 | Version  | Image                               |
 |----------|-------------------------------------|
-| $version | $helm_repo/agent-stack-k8s:$version |
+| $version | $helm_image                         |
 --------------------------------------------------
 EOF

--- a/.buildkite/steps/controller.sh
+++ b/.buildkite/steps/controller.sh
@@ -19,9 +19,9 @@ version=${tag#v}
 
 echo --- Building with ko
 controller_image=$(
-    VERSION="$tag" \
-    KO_DOCKER_REPO=ghcr.io/buildkite/agent-stack-k8s/controller \
-        ko build --bare --tags "$version" --platform linux/amd64,linux/arm64 \
+  VERSION="$tag" \
+  KO_DOCKER_REPO=ghcr.io/buildkite/agent-stack-k8s/controller \
+    ko build --bare --tags "$version" --platform linux/amd64,linux/arm64 \
 )
 
 buildkite-agent meta-data set controller-image "$controller_image"

--- a/.buildkite/steps/deploy.sh
+++ b/.buildkite/steps/deploy.sh
@@ -9,14 +9,14 @@ source .buildkite/steps/repo_info.sh
 
 echo --- :helm: Helm upgrade
 helm upgrade agent-stack-k8s "${helm_repo}/agent-stack-k8s" \
-    --version "$version" \
-    --namespace buildkite \
-    --install \
-    --create-namespace \
-    --wait \
-    --set config.org="$BUILDKITE_ORGANIZATION_SLUG" \
-    --set agentToken="$BUILDKITE_AGENT_TOKEN" \
-    --set graphqlToken="$BUILDKITE_TOKEN" \
-    --set config.image="$agent_image" \
-    --set config.debug=true \
-    --set config.profiler-address=localhost:6060
+  --version "$version" \
+  --namespace buildkite \
+  --install \
+  --create-namespace \
+  --wait \
+  --set config.org="$BUILDKITE_ORGANIZATION_SLUG" \
+  --set agentToken="$BUILDKITE_AGENT_TOKEN" \
+  --set graphqlToken="$BUILDKITE_TOKEN" \
+  --set config.image="$agent_image" \
+  --set config.debug=true \
+  --set config.profiler-address=localhost:6060

--- a/.buildkite/steps/repo_info.sh
+++ b/.buildkite/steps/repo_info.sh
@@ -10,3 +10,4 @@ temp_agent_image=$(buildkite-agent meta-data get agent-image)
 agent_image="${docker_repo_prefix}/agent-stack-k8s/agent:${version}"
 controller_image=$(buildkite-agent meta-data get controller-image)
 helm_repo="oci://${docker_repo_prefix}/helm"
+helm_image="$helm_repo/agent-stack-k8s:$version"

--- a/.buildkite/steps/tag-latest.sh
+++ b/.buildkite/steps/tag-latest.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env ash
+
+set -eufo pipefail
+
+source .buildkite/steps/repo_info.sh
+
+echo --- :hammer: Installing tools
+apk add --update-cache --no-progress crane
+
+echo --- :doker: Logging into ghcr.io
+crane auth login ghcr.io \
+  --username "$REGISTRY_USERNAME" \
+  --password "$REGISTRY_PASSWORD"
+
+echo --- :crane: tagging images latest on ghcr.io
+crane tag "$controller_image" latest
+crane tag "$agent_image" latest
+crane tag "$helm_image" latest

--- a/.buildkite/steps/tests.sh
+++ b/.buildkite/steps/tests.sh
@@ -6,14 +6,16 @@ echo "--- Installing gotestsum :golang::test_tube:"
 go install gotest.tools/gotestsum
 
 echo '+++ Running integration tests :test_tube:'
+package="github.com/buildkite/agent-stack-k8s/v2/internal/integration_test"
+branch="${BUILDKITE_BRANCH:-main}"
 IMAGE=$(buildkite-agent meta-data get "agent-image")
 export IMAGE
 
 gotestsum \
-    --junitfile "junit-${BUILDKITE_JOB_ID}.xml" \
-    -- \
-    -count=1 \
-    -failfast \
-    -ldflags="-X github.com/buildkite/agent-stack-k8s/v2/internal/integration_test.branch=${BUILDKITE_BRANCH:-main}" \
-    "$@" \
-    ./...
+  --junitfile "junit-${BUILDKITE_JOB_ID}.xml" \
+  -- \
+  -count=1 \
+  -failfast \
+  -ldflags="-X ${package}.branch=${branch}" \
+  "$@" \
+  ./...

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -3,8 +3,8 @@
 set -eufo pipefail
 
 if [[ ${#} -lt 1 ]]; then
-    echo "Usage: ${0} [version, ie 0.1.0]" >&2
-    exit 1
+  echo "Usage: ${0} [version, ie 0.1.0]" >&2
+  exit 1
 fi
 
 # ensure we remove leading `v`
@@ -17,10 +17,10 @@ build_tag=$(git describe --exclude "$tag")
 build_version=${build_tag#v}
 
 tag_image() {
-    if ! crane tag "$1" "$2"; then
-        echo "Failed to tag image $1 with $2, maybe the build has not completed yet?" >&2
-        return 1
-    fi
+  if ! crane tag "$1" "$2"; then
+    echo "Failed to tag image $1 with $2, maybe the build has not completed yet?" >&2
+    return 1
+  fi
 }
 
 # NB: these will fail if the commit hasn't gone through CI and produced release-candidate images yet
@@ -34,7 +34,8 @@ tag_image "ghcr.io/buildkite/agent-stack-k8s/agent:${build_version}" "$version"
 ((tag_failures+=$?))
 set -e
 if [[ $tag_failures != 0 ]]; then
-    exit 1
+  echo "Failed to tag images, aborting release" >&2
+  exit 1
 fi
 
 chart_digest=$(crane digest "ghcr.io/buildkite/helm/agent-stack-k8s:$version")


### PR DESCRIPTION
Latest will track the main branch.

There was a bit of freshening up in this PR, so I recommend reviewing commit by commit.

[5d852f5](https://github.com/buildkite/agent-stack-k8s/pull/177/commits/5d852f58fcbc5923ee86783a51a15a2e723140ca) does what the title claims.