### PR TITLE
Fix deploy step did not have a key

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -137,9 +137,9 @@ steps:
 
   - if: build.branch == pipeline.default_branch || build.tag =~ /^.+\$/
     label: ":shipit: deploy"
+    key: deploy
     depends_on:
     - push-main-or-tag
-    - integration
     env:
       BUILDKITE_GIT_FETCH_FLAGS: -v --tags
     plugins:
@@ -158,8 +158,9 @@ steps:
 
   - if: build.tag =~ /^.+\$/
     label: ":rocket: release"
+    key: release
     depends_on:
-    - deploy-main-or-tag
+    - deploy
     env:
       BUILDKITE_GIT_FETCH_FLAGS: -v --tags
     plugins:


### PR DESCRIPTION
Also, the release step did not have a key, but that don't matter as
noting depended on it. The deploy step no longer needs an explicit
dependence on the integration tests as it depends on them transitively
through `push-main-or-tag`.