### PR TITLE
Fix release

### DIFF
--- a/.buildkite/steps/release.sh
+++ b/.buildkite/steps/release.sh
@@ -42,31 +42,13 @@ tag_image() {
 }
 
 echo --- :docker: Tagging images
-# NB: these will fail if the commit hasn't gone through CI and produced release-candidate images yet
-tag_failures=0
-set +e
 tag_image "ghcr.io/buildkite/helm/agent-stack-k8s:${build_version}" "$version"
-((tag_failures+=$?))
 tag_image "ghcr.io/buildkite/agent-stack-k8s/controller:${build_version}" "$version"
-((tag_failures+=$?))
 tag_image "ghcr.io/buildkite/agent-stack-k8s/agent:${build_version}" "$version"
-((tag_failures+=$?))
 
 tag_image "ghcr.io/buildkite/helm/agent-stack-k8s:${build_version}" latest
-((tag_failures+=$?))
 tag_image "ghcr.io/buildkite/agent-stack-k8s/controller:${build_version}" latest
-((tag_failures+=$?))
 tag_image "ghcr.io/buildkite/agent-stack-k8s/agent:${build_version}" latest
-((tag_failures+=$?))
-set -e
-
-if [[ $tag_failures != 0 ]]; then
-  echo "^^^ +++"
-  echo "Failed to tag images. The build on the default branch needs to" >&2
-  echo "push images to the container image registry first." >&2
-  echo "Aborting release." >&2
-  exit 1
-fi
 
 echo --- :golang: Creating draft release with goreleaser
 chart_digest=$(crane digest "ghcr.io/buildkite/helm/agent-stack-k8s:$version")

--- a/.buildkite/steps/release.sh
+++ b/.buildkite/steps/release.sh
@@ -11,14 +11,15 @@ fi
 ARCH=$(uname -m)
 GORELEASER_VERSION=1.19.2
 GORELEASER_URL=https://github.com/goreleaser/goreleaser/releases/download
-GORELEASER_PATH="goreleaser_${GORELEASER_VERSION}_${ARCH}.apk"
+GORELEASER_FILE="goreleaser_${GORELEASER_VERSION}_${ARCH}.apk"
 GHCH_VERSION=0.11.0
 GHCH_URL="https://github.com/buildkite/ghch/releases/download/v${GHCH_VERSION}/ghch-$(go env GOARCH)"
 
 echo --- :hammer: Installing packages
-apk add --no-progress crane git github-cli
-wget -q "${GORELEASER_URL}/v${GORELEASER_VERSION}/${GORELEASER_PATH}"
-apk add --no-progress --allow-untrusted "$GORELEASER_PATH"
+apk add --no-progress crane git
+wget -q "${GORELEASER_URL}/v${GORELEASER_VERSION}/${GORELEASER_FILE}"
+apk add --no-progress --allow-untrusted "$GORELEASER_FILE"
+rm "$GORELEASER_FILE"
 wget -qO- "$GHCH_URL" > /usr/bin/ghch
 chmod +x /usr/bin/ghch
 
@@ -71,6 +72,8 @@ echo --- :golang: Creating draft release with goreleaser
 chart_digest=$(crane digest "ghcr.io/buildkite/helm/agent-stack-k8s:$version")
 controller_digest=$(crane digest "ghcr.io/buildkite/agent-stack-k8s/controller:$version")
 agent_digest=$(crane digest "ghcr.io/buildkite/agent-stack-k8s/agent:$version")
+
+git stash -uk
 
 goreleaser release \
   --rm-dist \


### PR DESCRIPTION
The main fix is that goreleaser does not work with a dirty working tree. This is a side effect of the workspace being made world writable.