### PR TITLE
More release tweaks

### DIFF
--- a/.buildkite/steps/release.sh
+++ b/.buildkite/steps/release.sh
@@ -48,6 +48,7 @@ chart_digest=$(crane digest "ghcr.io/buildkite/helm/agent-stack-k8s:$version")
 controller_digest=$(crane digest "ghcr.io/buildkite/agent-stack-k8s/controller:$version")
 agent_digest=$(crane digest "ghcr.io/buildkite/agent-stack-k8s/agent:$version")
 
+# TODO: remove once world write issues is fixed
 git stash -uk
 
 goreleaser release \

--- a/.buildkite/steps/release.sh
+++ b/.buildkite/steps/release.sh
@@ -52,7 +52,7 @@ agent_digest=$(crane digest "ghcr.io/buildkite/agent-stack-k8s/agent:$version")
 git stash -uk
 
 goreleaser release \
-  --rm-dist \
+  --clean \
   --release-notes <(ghch --format=markdown --from="$previous_tag" --next-version="$tag") \
   --release-footer <(cat <<EOF
 ## Images

--- a/.buildkite/steps/release.sh
+++ b/.buildkite/steps/release.sh
@@ -29,6 +29,9 @@ version="${BUILDKITE_TAG#v}"
 # put it back
 tag="v$version"
 previous_tag=$(git describe --abbrev=0 --exclude "$tag")
+echo "Version: $version"
+echo "Tag: $tag"
+echo "Previous tag: $previous_tag"
 
 echo --- :docker: Logging into ghcr.io
 crane auth login ghcr.io \


### PR DESCRIPTION
The main one is that `goreleaser` has deprecated `--rm-dist`.