### PR TITLE
adding tolerations parameters to the helm chart

### DIFF
--- a/charts/agent-stack-k8s/templates/deployment.yaml.tpl
+++ b/charts/agent-stack-k8s/templates/deployment.yaml.tpl
@@ -18,6 +18,8 @@ spec:
       serviceAccountName: {{ .Release.Name }}-controller
       nodeSelector:
         {{- toYaml $.Values.nodeSelector | nindent 8 }}
+      tolerations:
+        {{- toYaml $.Values.tolerations | nindent 8 }}
       containers:
       - name: controller
         terminationMessagePolicy: FallbackToLogsOnError

--- a/charts/agent-stack-k8s/values.schema.json
+++ b/charts/agent-stack-k8s/values.schema.json
@@ -43,6 +43,19 @@
         }
       ]
     },
+    "tolerations": {
+      "type": "array",
+      "default": [],
+      "title": "The tolerations Schema",
+      "examples": [
+        {
+          "key": "buildkite",
+          "operator": "Equal",
+          "value": "true",
+          "effect": "NoSchedule"
+        }
+      ]
+    },
     "labels": {
       "type": "object",
       "default": {},

--- a/charts/agent-stack-k8s/values.yaml
+++ b/charts/agent-stack-k8s/values.yaml
@@ -2,6 +2,7 @@ agentToken: ""
 graphqlToken: ""
 
 nodeSelector: {}
+tolerations: []
 
 config:
   org: ""


### PR DESCRIPTION
same as `nodeSelector` parameter, we need a parameter to specify `tolerations` when deploying the agent-stack-k8s pods.
this can be required if we want to dedicate specific k8s nodes to run buildkite agent controller