### PR TITLE
allow annotations in secrets and service account metadata

### DIFF
--- a/charts/agent-stack-k8s/templates/_helper.tpl
+++ b/charts/agent-stack-k8s/templates/_helper.tpl
@@ -7,7 +7,6 @@ app: {{ .Release.Name }}
 {{- toYaml (mustMerge (fromYaml (include "agent-stack-k8s.mandatoryLabels" .)) .Values.labels) }}
 {{- end }}
 
-
 {{/* Generate basic secrets metadata */}}
 {{- define "agent-stack-k8s.mandatorySecretsmetadata" }}
 name: {{ .Release.Name }}-secrets

--- a/charts/agent-stack-k8s/templates/_helper.tpl
+++ b/charts/agent-stack-k8s/templates/_helper.tpl
@@ -8,21 +8,21 @@ app: {{ .Release.Name }}
 {{- end }}
 
 {{/* Generate basic secrets metadata */}}
-{{- define "agent-stack-k8s.mandatorySecretsmetadata" }}
+{{- define "agent-stack-k8s.mandatorySecretsMetadata" }}
 name: {{ .Release.Name }}-secrets
 namespace: {{ .Release.Namespace }}
 {{- end }}
 
-{{- define "agent-stack-k8s.secretsmetadata" }}
-{{- toYaml (mustMerge (fromYaml (include "agent-stack-k8s.mandatorySecretsmetadata" .)) .Values.secretsmetadata) }}
+{{- define "agent-stack-k8s.secretsMetadata" }}
+{{- toYaml (mustMerge (fromYaml (include "agent-stack-k8s.mandatorySecretsMetadata" .)) .Values.secretsMetadata) }}
 {{- end }}
 
 {{/* Generate basic serviceaccount metadata */}}
-{{- define "agent-stack-k8s.mandatoryServiceaccountmetadata" }}
+{{- define "agent-stack-k8s.mandatoryServiceAccountMetadata" }}
 name: {{ .Release.Name }}-controller
 namespace: {{ .Release.Namespace }}
 {{- end }}
 
-{{- define "agent-stack-k8s.serviceaccountmetadata" }}
-{{- toYaml (mustMerge (fromYaml (include "agent-stack-k8s.mandatoryServiceaccountmetadata" .)) .Values.serviceaccountmetadata) }}
+{{- define "agent-stack-k8s.serviceAccountMetadata" }}
+{{- toYaml (mustMerge (fromYaml (include "agent-stack-k8s.mandatoryServiceAccountMetadata" .)) .Values.serviceAccountMetadata) }}
 {{- end }}

--- a/charts/agent-stack-k8s/templates/_helper.tpl
+++ b/charts/agent-stack-k8s/templates/_helper.tpl
@@ -6,3 +6,24 @@ app: {{ .Release.Name }}
 {{- define "agent-stack-k8s.labels" }}
 {{- toYaml (mustMerge (fromYaml (include "agent-stack-k8s.mandatoryLabels" .)) .Values.labels) }}
 {{- end }}
+
+
+{{/* Generate basic secrets metadata */}}
+{{- define "agent-stack-k8s.mandatorySecretsmetadata" }}
+name: {{ .Release.Name }}-secrets
+namespace: {{ .Release.Namespace }}
+{{- end }}
+
+{{- define "agent-stack-k8s.secretsmetadata" }}
+{{- toYaml (mustMerge (fromYaml (include "agent-stack-k8s.mandatorySecretsmetadata" .)) .Values.secretsmetadata) }}
+{{- end }}
+
+{{/* Generate basic serviceaccount metadata */}}
+{{- define "agent-stack-k8s.mandatoryServiceaccountmetadata" }}
+name: {{ .Release.Name }}-controller
+namespace: {{ .Release.Namespace }}
+{{- end }}
+
+{{- define "agent-stack-k8s.serviceaccountmetadata" }}
+{{- toYaml (mustMerge (fromYaml (include "agent-stack-k8s.mandatoryServiceaccountmetadata" .)) .Values.serviceaccountmetadata) }}
+{{- end }}

--- a/charts/agent-stack-k8s/templates/rbac.yaml.tpl
+++ b/charts/agent-stack-k8s/templates/rbac.yaml.tpl
@@ -1,8 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ .Release.Name }}-controller
-  namespace: {{ .Release.Namespace }}
+  {{- include "agent-stack-k8s.serviceaccountmetadata" . | nindent 2 }}
 rules:
   - apiGroups:
       - batch
@@ -33,11 +32,9 @@ roleRef:
   name: {{ .Release.Name }}-controller
 subjects:
   - kind: ServiceAccount
-    name: {{ .Release.Name }}-controller
-    namespace: {{ .Release.Namespace }}
+    {{- include "agent-stack-k8s.serviceaccountmetadata" . | nindent 4 }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Release.Name }}-controller
-  namespace: {{ .Release.Namespace }}
+  {{- include "agent-stack-k8s.serviceaccountmetadata" . | nindent 2 }}

--- a/charts/agent-stack-k8s/templates/rbac.yaml.tpl
+++ b/charts/agent-stack-k8s/templates/rbac.yaml.tpl
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  {{- include "agent-stack-k8s.serviceaccountmetadata" . | nindent 2 }}
+  {{- include "agent-stack-k8s.serviceAccountMetadata" . | nindent 2 }}
 rules:
   - apiGroups:
       - batch
@@ -32,9 +32,9 @@ roleRef:
   name: {{ .Release.Name }}-controller
 subjects:
   - kind: ServiceAccount
-    {{- include "agent-stack-k8s.serviceaccountmetadata" . | nindent 4 }}
+    {{- include "agent-stack-k8s.serviceAccountMetadata" . | nindent 4 }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  {{- include "agent-stack-k8s.serviceaccountmetadata" . | nindent 2 }}
+  {{- include "agent-stack-k8s.serviceAccountMetadata" . | nindent 2 }}

--- a/charts/agent-stack-k8s/templates/secrets.yaml.tpl
+++ b/charts/agent-stack-k8s/templates/secrets.yaml.tpl
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  {{- include "agent-stack-k8s.secretsmetadata" . | nindent 2 }}
+  {{- include "agent-stack-k8s.secretsMetadata" . | nindent 2 }}
 data:
   BUILDKITE_AGENT_TOKEN: {{ required "agentToken must be set" .Values.agentToken | b64enc | quote }}
   BUILDKITE_TOKEN: {{ required "graphqlToken must be set" .Values.graphqlToken | b64enc | quote }}

--- a/charts/agent-stack-k8s/templates/secrets.yaml.tpl
+++ b/charts/agent-stack-k8s/templates/secrets.yaml.tpl
@@ -3,8 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Release.Name }}-secrets
-  namespace: {{ .Release.Namespace }}
+  {{- include "agent-stack-k8s.secretsmetadata" . | nindent 2 }}
 data:
   BUILDKITE_AGENT_TOKEN: {{ required "agentToken must be set" .Values.agentToken | b64enc | quote }}
   BUILDKITE_TOKEN: {{ required "graphqlToken must be set" .Values.graphqlToken | b64enc | quote }}

--- a/charts/agent-stack-k8s/values.schema.json
+++ b/charts/agent-stack-k8s/values.schema.json
@@ -73,6 +73,42 @@
         }
       ]
     },
+    "secretsmetadata": {
+      "type": "object",
+      "default": {},
+      "title": "The secretsmetadata Schema",
+      "description": "secret name and namespace are reserved, user input secret name and namespace are not allowed",
+      "not": { "required": ["name", "namespace"] },
+      "additionalProperties": {
+        "type": "object",
+        "default": {}
+      },
+      "example": [
+        {
+          "annotations": {
+            "strategy.spinnaker.io/versioned": ""
+          }
+        }
+      ]
+    },
+    "serviceaccountmetadata": {
+      "type": "object",
+      "default": {},
+      "title": "The serviceaccountmetadata Schema",
+      "description": "serviceaccount name and namespace are reserved, user input serviceaccount name and namespace are not allowed",
+      "not": { "required": ["name", "namespace"] },
+      "additionalProperties": {
+        "type": "object",
+        "default": {}
+      },
+      "example": [
+        {
+          "annotations": {
+            "eks.amazonaws.com/role-arn": "my-service-role"
+          }
+        }
+      ]
+    },
     "resources": {
       "type": "object",
       "default": {},

--- a/charts/agent-stack-k8s/values.schema.json
+++ b/charts/agent-stack-k8s/values.schema.json
@@ -73,7 +73,7 @@
         }
       ]
     },
-    "secretsmetadata": {
+    "secretsMetadata": {
       "type": "object",
       "default": {},
       "title": "The secretsmetadata Schema",
@@ -91,7 +91,7 @@
         }
       ]
     },
-    "serviceaccountmetadata": {
+    "serviceAccountMetadata": {
       "type": "object",
       "default": {},
       "title": "The serviceaccountmetadata Schema",

--- a/charts/agent-stack-k8s/values.yaml
+++ b/charts/agent-stack-k8s/values.yaml
@@ -13,3 +13,7 @@ resources:
     memory: 100Mi
 
 labels: {}
+
+secretsmetadata: {}
+
+serviceaccountmetadata: {}

--- a/charts/agent-stack-k8s/values.yaml
+++ b/charts/agent-stack-k8s/values.yaml
@@ -14,6 +14,6 @@ resources:
 
 labels: {}
 
-secretsmetadata: {}
+secretsMetadata: {}
 
-serviceaccountmetadata: {}
+serviceAccountMetadata: {}


### PR DESCRIPTION
Customers would like to add annotations to secrets and service account to accommodate more user cases, such as add 
```
annotations:
    strategy.spinnaker.io/versioned: ""
```
for spinnaker user case. And adding their own IAM role for aws eks with annotations in service account metadata. 