### PR TITLE
Adding extraVolumeMounts option

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,13 @@ Sidecar containers can be added to your job by specifying them under the top-lev
 
 There is no guarantee that your sidecars will have started before your job, so using retries or a tool like [wait-for-it](https://github.com/vishnubob/wait-for-it) is a good idea to avoid flaky tests.
 
+### Extra volume mounts
+
+In some situations, for example if you want to use [git mirrors](https://buildkite.com/docs/agent/v3#promoted-experiments-git-mirrors) you may want to attach extra volume mounts (in addition to the `/workspace` one) in all the pod containers.
+
+See [this example](internal/integration/fixtures/extra-volumes.yaml), that will declare a new volume in the `podSpec` and mount it in all the containers. The benefit, is to have the same mounted path in all containers, including the `checkout` container.
+
+
 ### Validating your pipeline
 
 With the unstructured nature of Buildkite plugin specs, it can be frustratingly

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ There is no guarantee that your sidecars will have started before your job, so u
 
 In some situations, for example if you want to use [git mirrors](https://buildkite.com/docs/agent/v3#promoted-experiments-git-mirrors) you may want to attach extra volume mounts (in addition to the `/workspace` one) in all the pod containers.
 
-See [this example](internal/integration/fixtures/extra-volumes.yaml), that will declare a new volume in the `podSpec` and mount it in all the containers. The benefit, is to have the same mounted path in all containers, including the `checkout` container.
+See [this example](internal/integration/fixtures/extra-volume-mounts.yaml), that will declare a new volume in the `podSpec` and mount it in all the containers. The benefit, is to have the same mounted path in all containers, including the `checkout` container.
 
 
 ### Validating your pipeline

--- a/cmd/linter/schema.json
+++ b/cmd/linter/schema.json
@@ -19,6 +19,12 @@
             "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.Container"
           }
         },
+        "extraVolumeMounts": {
+          "type": "array",
+          "items": {
+            "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.VolumeMount"
+          }
+        },
         "metadata": {
           "type": "object",
           "properties": {

--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -44,10 +44,11 @@ func New(logger *zap.Logger, client kubernetes.Interface, cfg Config) *worker {
 }
 
 type KubernetesPlugin struct {
-	PodSpec    *corev1.PodSpec
-	GitEnvFrom []corev1.EnvFromSource
-	Sidecars   []corev1.Container `json:"sidecars,omitempty"`
-	Metadata   Metadata
+	PodSpec           *corev1.PodSpec
+	GitEnvFrom        []corev1.EnvFromSource
+	Sidecars          []corev1.Container `json:"sidecars,omitempty"`
+	Metadata          Metadata
+	ExtraVolumeMounts []corev1.VolumeMount
 }
 
 type Metadata struct {
@@ -218,7 +219,10 @@ func (w *jobWrapper) Build() (*batchv1.Job, error) {
 			env = append(env, corev1.EnvVar{Name: k, Value: v})
 		}
 	}
+
 	volumeMounts := []corev1.VolumeMount{{Name: "workspace", MountPath: "/workspace"}}
+	volumeMounts = append(volumeMounts, w.k8sPlugin.ExtraVolumeMounts...)
+
 	const systemContainers = 1
 	ttl := int32(w.cfg.JobTTL.Seconds())
 	kjob.Spec.TTLSecondsAfterFinished = &ttl

--- a/internal/integration/fixtures/extra-volume-mounts.yaml
+++ b/internal/integration/fixtures/extra-volume-mounts.yaml
@@ -13,12 +13,12 @@ steps:
                 command: [ash]
                 args:
                   -  -c
-                  - "echo 'volume mounted' > /tmp/buildkite-git-mirrors/foo.txt"
+                  - '"echo volume mounted > /tmp/buildkite-git-mirrors/foo.txt"'
               - image: alpine:latest
                 command: [ash]
                 args:
                   - -c
-                  - "sleep 2; cat /tmp/buildkite-git-mirrors/foo.txt"
+                  - '"sleep 2; cat /tmp/buildkite-git-mirrors/foo.txt"'
             volumes:
               - name: host-volume
                 hostPath:

--- a/internal/integration/fixtures/extra-volume-mounts.yaml
+++ b/internal/integration/fixtures/extra-volume-mounts.yaml
@@ -3,7 +3,6 @@ steps:
     agents:
       queue: {{.queue}}
     env:
-      BUILDKITE_SHELL: /bin/sh -e -c
       BUILDKITE_GIT_CLONE_MIRROR_FLAGS: --mirror
       BUILDKITE_GIT_MIRRORS_PATH: /tmp/buildkite-git-mirrors
     plugins:
@@ -11,11 +10,15 @@ steps:
           podSpec:
             containers:
               - image: alpine:latest
-                command: [bash]
-                args: [-c "echo 'volume mounted' > /tmp/buildkite-git-mirrors/foo.txt"]
+                command: [ash]
+                args:
+                  -  -c
+                  - "echo 'volume mounted' > /tmp/buildkite-git-mirrors/foo.txt"
               - image: alpine:latest
-                command: [bash]
-                args: ["sleep 2; cat /tmp/buildkite-git-mirrors/foo.txt"]
+                command: [ash]
+                args:
+                  - -c
+                  - "sleep 2; cat /tmp/buildkite-git-mirrors/foo.txt"
             volumes:
               - name: host-volume
                 hostPath:

--- a/internal/integration/fixtures/extra-volume-mounts.yaml
+++ b/internal/integration/fixtures/extra-volume-mounts.yaml
@@ -11,11 +11,15 @@ steps:
           podSpec:
             containers:
               - image: alpine:latest
-                command: [touch]
-                args: [/tmp/buildkite-git-mirrors/somefile.txt]
+                command: [bash]
+                args: [-c "echo 'volume mounted' > /tmp/buildkite-git-mirrors/foo.txt"]
+              - image: alpine:latest
+                command: [bash]
+                args: ["sleep 2; cat /tmp/buildkite-git-mirrors/foo.txt"]
+            volumes:
               - name: host-volume
                 hostPath:
-                  path: /host/shared/folder
+                  path: /tmp
                   type: ''
           extraVolumeMounts:
               - name: host-volume

--- a/internal/integration/fixtures/extra-volumes.yaml
+++ b/internal/integration/fixtures/extra-volumes.yaml
@@ -1,0 +1,23 @@
+steps:
+  - label: ":wave:"
+    agents:
+      queue: {{.queue}}
+    env:
+      BUILDKITE_SHELL: /bin/sh -e -c
+      BUILDKITE_GIT_CLONE_MIRROR_FLAGS: --mirror
+      BUILDKITE_GIT_MIRRORS_PATH: /tmp/buildkite-git-mirrors
+    plugins:
+      - kubernetes:
+          podSpec:
+            containers:
+              - image: alpine:latest
+                command: [touch]
+                args: [/tmp/buildkite-git-mirrors/somefile.txt]
+              - name: host-volume
+                hostPath:
+                  path: /host/shared/folder
+                  type: ''
+          extraVolumeMounts:
+              - name: host-volume
+                mountPath: /tmp/buildkite-git-mirrors
+                subPath: buildkite-git-mirrors

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -166,6 +166,21 @@ func TestSidecars(t *testing.T) {
 	tc.AssertLogsContain(build, "Welcome to nginx!")
 }
 
+func TestExtraVolumeMounts(t *testing.T) {
+	tc := testcase{
+		T:       t,
+		Fixture: "extra-volume-mounts.yaml",
+		Repo:    repoHTTP,
+		GraphQL: api.NewClient(cfg.BuildkiteToken),
+	}.Init()
+	ctx := context.Background()
+	pipelineID := tc.CreatePipeline(ctx)
+	tc.StartController(ctx, cfg)
+	build := tc.TriggerBuild(ctx, pipelineID)
+	tc.AssertSuccess(ctx, build)
+	tc.AssertLogsContain(build, "volume mounted")
+}
+
 func TestInvalidPodSpec(t *testing.T) {
 	tc := testcase{
 		T:       t,


### PR DESCRIPTION
This PR adds the possibility to add extra `volumeMounts` to all the containers of the agent Pod. including `checkout` container (or other system containers).
This is needed for a specific use case: having a shared folder between all `checkout` containers, in order to use [git mirrors](https://buildkite.com/docs/agent/v3#promoted-experiments-git-mirrors)  feature.
The idea is to have a shared folder (per host), and to have all `checkout` containers source the git code from, using git mirrors. This is critical for situations where the `git clone` takes several minutes.


**Note**: I've added an integration test, but I don't see clearly how the integration tests can be executed (step by step).
