### PR TITLE
revert the metadata change in rbac subjects

### DIFF
--- a/charts/agent-stack-k8s/templates/rbac.yaml.tpl
+++ b/charts/agent-stack-k8s/templates/rbac.yaml.tpl
@@ -32,7 +32,8 @@ roleRef:
   name: {{ .Release.Name }}-controller
 subjects:
   - kind: ServiceAccount
-    {{- include "agent-stack-k8s.serviceAccountMetadata" . | nindent 4 }}
+    name: {{ .Release.Name }}-controller
+    namespace: {{ .Release.Namespace }}
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
This is to revert the changes in the rbac subjects. Customized additional properties in metadata is not always allowed in rbac subjects, such as `annotations`, so revert the changes in the rbac subjects. Got the following error when helm install: 
```
error validating data: ValidationError(RoleBinding.subjects[0]): unknown field "annotations" in io.k8s.api.rbac.v1.Subject
```
Tested it works after revert the subject. 