### PR TITLE
Add flag to preserve test pipelines

### DIFF
--- a/.buildkite/steps/tests.sh
+++ b/.buildkite/steps/tests.sh
@@ -11,11 +11,18 @@ branch="${BUILDKITE_BRANCH:-main}"
 IMAGE=$(buildkite-agent meta-data get "agent-image")
 export IMAGE
 
-gotestsum \
-  --junitfile "junit-${BUILDKITE_JOB_ID}.xml" \
+args=(
+  --junitfile "junit-${BUILDKITE_JOB_ID}.xml"
   -- \
   -count=1 \
   -failfast \
   -ldflags="-X ${package}.branch=${branch}" \
-  "$@" \
   ./...
+)
+
+if [[ "${TEST_PRESERVE_PIPELINES:-false}" == "true" ]]; then
+  echo Preserving pipelines for debugging
+  args+=(--preserve-pipelines)
+fi
+
+gotestsum "${args[@]}"


### PR DESCRIPTION
Each integration test creates a new pipeline in the `buildkite-kubernetes-stack` organization. But these are deleted when the tests finish. It would be useful to debug failing integration tests if there were an option to not do this.

In this PR we do this if the environment has `TEST_PRESERVE_PIPELINE=true`