### PR TITLE
Fix extraVolumeMounts integration test

### DIFF
--- a/internal/integration/fixtures/extra-volume-mounts.yaml
+++ b/internal/integration/fixtures/extra-volume-mounts.yaml
@@ -1,30 +1,29 @@
 steps:
-  - label: ":wave:"
-    agents:
-      queue: {{.queue}}
-    env:
-      BUILDKITE_GIT_CLONE_MIRROR_FLAGS: --mirror
-      BUILDKITE_GIT_MIRRORS_PATH: /tmp/buildkite-git-mirrors
-    plugins:
-      - kubernetes:
-          podSpec:
-            containers:
-              - image: alpine:latest
-                command: [ash]
-                args:
-                  -  -c
-                  - '"echo volume mounted > /tmp/buildkite-git-mirrors/foo.txt"'
-              - image: alpine:latest
-                command: [ash]
-                args:
-                  - -c
-                  - '"sleep 2; cat /tmp/buildkite-git-mirrors/foo.txt"'
-            volumes:
-              - name: host-volume
-                hostPath:
-                  path: /tmp
-                  type: ''
-          extraVolumeMounts:
-              - name: host-volume
-                mountPath: /tmp/buildkite-git-mirrors
-                subPath: buildkite-git-mirrors
+- label: ":wave:"
+  agents:
+    queue: {{.queue}}
+  env:
+    BUILDKITE_GIT_MIRRORS_PATH: /tmp/buildkite-git-mirrors
+  plugins:
+  - kubernetes:
+      podSpec:
+        containers:
+        - image: alpine:latest
+          command: [ash]
+          args:
+          -  -c
+          - '"echo volume mounted > /tmp/buildkite-git-mirrors/foo.txt"'
+        - image: alpine:latest
+          command: [ash]
+          args:
+          - -c
+          - '"sleep 2; cat /tmp/buildkite-git-mirrors/foo.txt"'
+        volumes:
+        - name: host-volume
+          hostPath:
+            path: /tmp/volumes/{{.queue}}
+            type: ''
+      extraVolumeMounts:
+      - name: host-volume
+        mountPath: /tmp/buildkite-git-mirrors
+        subPath: buildkite-git-mirrors

--- a/internal/integration/fixtures/extra-volume-mounts.yaml
+++ b/internal/integration/fixtures/extra-volume-mounts.yaml
@@ -1,9 +1,10 @@
+agents:
+  queue: {{.queue}}
+env:
+  BUILDKITE_GIT_MIRRORS_PATH: /tmp/buildkite-git-mirrors
 steps:
-- label: ":wave:"
-  agents:
-    queue: {{.queue}}
-  env:
-    BUILDKITE_GIT_MIRRORS_PATH: /tmp/buildkite-git-mirrors
+- label: ":git: Write File to Git Mirror Dir"
+  key: write-file-to-git-mirror-dir
   plugins:
   - kubernetes:
       podSpec:
@@ -11,13 +12,30 @@ steps:
         - image: alpine:latest
           command: [ash]
           args:
-          -  -c
-          - '"echo volume mounted > /tmp/buildkite-git-mirrors/foo.txt"'
+          - -c
+          - '"echo volume_mounted > /tmp/buildkite-git-mirrors/foo.txt"'
+        volumes:
+        - name: host-volume
+          hostPath:
+            path: /tmp/volumes/{{.queue}}
+            type: DirectoryOrCreate
+      extraVolumeMounts:
+      - name: host-volume
+        mountPath: /tmp/buildkite-git-mirrors
+        subPath: buildkite-git-mirrors
+- label: ":git: Check File in Git Mirror Dir"
+  key: check-file-in-git-mirror-dir
+  depends_on:
+  - write-file-to-git-mirror-dir
+  plugins:
+  - kubernetes:
+      podSpec:
+        containers:
         - image: alpine:latest
           command: [ash]
           args:
           - -c
-          - '"sleep 2; cat /tmp/buildkite-git-mirrors/foo.txt"'
+          - '"grep -Fx volume_mounted /tmp/buildkite-git-mirrors/foo.txt"'
         volumes:
         - name: host-volume
           hostPath:

--- a/internal/integration/fixtures/extra-volume-mounts.yaml
+++ b/internal/integration/fixtures/extra-volume-mounts.yaml
@@ -22,7 +22,7 @@ steps:
         - name: host-volume
           hostPath:
             path: /tmp/volumes/{{.queue}}
-            type: ''
+            type: DirectoryOrCreate
       extraVolumeMounts:
       - name: host-volume
         mountPath: /tmp/buildkite-git-mirrors

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -20,7 +20,7 @@ func TestWalkingSkeleton(t *testing.T) {
 	}.Init()
 	ctx := context.Background()
 	pipelineID, cleanup := tc.CreatePipeline(ctx)
-	defer cleanup()
+	t.Cleanup(cleanup)
 	tc.StartController(ctx, cfg)
 	build := tc.TriggerBuild(ctx, pipelineID)
 	tc.AssertSuccess(ctx, build)
@@ -48,7 +48,7 @@ func TestSSHRepoClone(t *testing.T) {
 	require.NoError(t, err, "agent-stack-k8s secret must exist")
 
 	pipelineID, cleanup := tc.CreatePipeline(ctx)
-	defer cleanup()
+	t.Cleanup(cleanup)
 	tc.StartController(ctx, cfg)
 	build := tc.TriggerBuild(ctx, pipelineID)
 	tc.AssertSuccess(ctx, build)
@@ -65,7 +65,7 @@ func TestPluginCloneFailsTests(t *testing.T) {
 	ctx := context.Background()
 
 	pipelineID, cleanup := tc.CreatePipeline(ctx)
-	defer cleanup()
+	t.Cleanup(cleanup)
 	tc.StartController(ctx, cfg)
 	build := tc.TriggerBuild(ctx, pipelineID)
 	tc.AssertFail(ctx, build)
@@ -82,7 +82,7 @@ func TestMaxInFlightLimited(t *testing.T) {
 	ctx := context.Background()
 
 	pipelineID, cleanup := tc.CreatePipeline(ctx)
-	defer cleanup()
+	t.Cleanup(cleanup)
 	cfg := cfg
 	cfg.MaxInFlight = 1
 	tc.StartController(ctx, cfg)
@@ -121,7 +121,7 @@ func TestMaxInFlightUnlimited(t *testing.T) {
 	ctx := context.Background()
 
 	pipelineID, cleanup := tc.CreatePipeline(ctx)
-	defer cleanup()
+	t.Cleanup(cleanup)
 	cfg := cfg
 	cfg.MaxInFlight = 0
 	tc.StartController(ctx, cfg)
@@ -165,7 +165,7 @@ func TestSidecars(t *testing.T) {
 	}.Init()
 	ctx := context.Background()
 	pipelineID, cleanup := tc.CreatePipeline(ctx)
-	defer cleanup()
+	t.Cleanup(cleanup)
 	tc.StartController(ctx, cfg)
 	build := tc.TriggerBuild(ctx, pipelineID)
 	tc.AssertSuccess(ctx, build)
@@ -181,7 +181,7 @@ func TestExtraVolumeMounts(t *testing.T) {
 	}.Init()
 	ctx := context.Background()
 	pipelineID, cleanup := tc.CreatePipeline(ctx)
-	defer cleanup()
+	t.Cleanup(cleanup)
 	tc.StartController(ctx, cfg)
 	build := tc.TriggerBuild(ctx, pipelineID)
 	tc.AssertSuccess(ctx, build)
@@ -197,7 +197,7 @@ func TestInvalidPodSpec(t *testing.T) {
 	}.Init()
 	ctx := context.Background()
 	pipelineID, cleanup := tc.CreatePipeline(ctx)
-	defer cleanup()
+	t.Cleanup(cleanup)
 	tc.StartController(ctx, cfg)
 	build := tc.TriggerBuild(ctx, pipelineID)
 	tc.AssertFail(ctx, build)
@@ -216,7 +216,7 @@ func TestInvalidPodJSON(t *testing.T) {
 	}.Init()
 	ctx := context.Background()
 	pipelineID, cleanup := tc.CreatePipeline(ctx)
-	defer cleanup()
+	t.Cleanup(cleanup)
 	tc.StartController(ctx, cfg)
 	build := tc.TriggerBuild(ctx, pipelineID)
 	tc.AssertFail(ctx, build)
@@ -242,7 +242,7 @@ func TestEnvVariables(t *testing.T) {
 	}.Init()
 	ctx := context.Background()
 	pipelineID, cleanup := tc.CreatePipeline(ctx)
-	defer cleanup()
+	t.Cleanup(cleanup)
 	tc.StartController(ctx, cfg)
 	build := tc.TriggerBuild(ctx, pipelineID)
 	tc.AssertSuccess(ctx, build)
@@ -258,7 +258,7 @@ func TestImagePullBackOffCancelled(t *testing.T) {
 	}.Init()
 	ctx := context.Background()
 	pipelineID, cleanup := tc.CreatePipeline(ctx)
-	defer cleanup()
+	t.Cleanup(cleanup)
 	tc.StartController(ctx, cfg)
 	build := tc.TriggerBuild(ctx, pipelineID)
 	tc.AssertFail(ctx, build)

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -19,7 +19,8 @@ func TestWalkingSkeleton(t *testing.T) {
 		GraphQL: api.NewClient(cfg.BuildkiteToken),
 	}.Init()
 	ctx := context.Background()
-	pipelineID := tc.CreatePipeline(ctx)
+	pipelineID, cleanup := tc.CreatePipeline(ctx)
+	defer cleanup()
 	tc.StartController(ctx, cfg)
 	build := tc.TriggerBuild(ctx, pipelineID)
 	tc.AssertSuccess(ctx, build)
@@ -46,7 +47,8 @@ func TestSSHRepoClone(t *testing.T) {
 		Get(ctx, "agent-stack-k8s", v1.GetOptions{})
 	require.NoError(t, err, "agent-stack-k8s secret must exist")
 
-	pipelineID := tc.CreatePipeline(ctx)
+	pipelineID, cleanup := tc.CreatePipeline(ctx)
+	defer cleanup()
 	tc.StartController(ctx, cfg)
 	build := tc.TriggerBuild(ctx, pipelineID)
 	tc.AssertSuccess(ctx, build)
@@ -62,7 +64,8 @@ func TestPluginCloneFailsTests(t *testing.T) {
 
 	ctx := context.Background()
 
-	pipelineID := tc.CreatePipeline(ctx)
+	pipelineID, cleanup := tc.CreatePipeline(ctx)
+	defer cleanup()
 	tc.StartController(ctx, cfg)
 	build := tc.TriggerBuild(ctx, pipelineID)
 	tc.AssertFail(ctx, build)
@@ -78,7 +81,8 @@ func TestMaxInFlightLimited(t *testing.T) {
 
 	ctx := context.Background()
 
-	pipelineID := tc.CreatePipeline(ctx)
+	pipelineID, cleanup := tc.CreatePipeline(ctx)
+	defer cleanup()
 	cfg := cfg
 	cfg.MaxInFlight = 1
 	tc.StartController(ctx, cfg)
@@ -116,7 +120,8 @@ func TestMaxInFlightUnlimited(t *testing.T) {
 
 	ctx := context.Background()
 
-	pipelineID := tc.CreatePipeline(ctx)
+	pipelineID, cleanup := tc.CreatePipeline(ctx)
+	defer cleanup()
 	cfg := cfg
 	cfg.MaxInFlight = 0
 	tc.StartController(ctx, cfg)
@@ -159,7 +164,8 @@ func TestSidecars(t *testing.T) {
 		GraphQL: api.NewClient(cfg.BuildkiteToken),
 	}.Init()
 	ctx := context.Background()
-	pipelineID := tc.CreatePipeline(ctx)
+	pipelineID, cleanup := tc.CreatePipeline(ctx)
+	defer cleanup()
 	tc.StartController(ctx, cfg)
 	build := tc.TriggerBuild(ctx, pipelineID)
 	tc.AssertSuccess(ctx, build)
@@ -174,7 +180,8 @@ func TestExtraVolumeMounts(t *testing.T) {
 		GraphQL: api.NewClient(cfg.BuildkiteToken),
 	}.Init()
 	ctx := context.Background()
-	pipelineID := tc.CreatePipeline(ctx)
+	pipelineID, cleanup := tc.CreatePipeline(ctx)
+	defer cleanup()
 	tc.StartController(ctx, cfg)
 	build := tc.TriggerBuild(ctx, pipelineID)
 	tc.AssertSuccess(ctx, build)
@@ -189,7 +196,8 @@ func TestInvalidPodSpec(t *testing.T) {
 		GraphQL: api.NewClient(cfg.BuildkiteToken),
 	}.Init()
 	ctx := context.Background()
-	pipelineID := tc.CreatePipeline(ctx)
+	pipelineID, cleanup := tc.CreatePipeline(ctx)
+	defer cleanup()
 	tc.StartController(ctx, cfg)
 	build := tc.TriggerBuild(ctx, pipelineID)
 	tc.AssertFail(ctx, build)
@@ -207,7 +215,8 @@ func TestInvalidPodJSON(t *testing.T) {
 		GraphQL: api.NewClient(cfg.BuildkiteToken),
 	}.Init()
 	ctx := context.Background()
-	pipelineID := tc.CreatePipeline(ctx)
+	pipelineID, cleanup := tc.CreatePipeline(ctx)
+	defer cleanup()
 	tc.StartController(ctx, cfg)
 	build := tc.TriggerBuild(ctx, pipelineID)
 	tc.AssertFail(ctx, build)
@@ -232,7 +241,8 @@ func TestEnvVariables(t *testing.T) {
 		GraphQL: api.NewClient(cfg.BuildkiteToken),
 	}.Init()
 	ctx := context.Background()
-	pipelineID := tc.CreatePipeline(ctx)
+	pipelineID, cleanup := tc.CreatePipeline(ctx)
+	defer cleanup()
 	tc.StartController(ctx, cfg)
 	build := tc.TriggerBuild(ctx, pipelineID)
 	tc.AssertSuccess(ctx, build)
@@ -247,7 +257,8 @@ func TestImagePullBackOffCancelled(t *testing.T) {
 		GraphQL: api.NewClient(cfg.BuildkiteToken),
 	}.Init()
 	ctx := context.Background()
-	pipelineID := tc.CreatePipeline(ctx)
+	pipelineID, cleanup := tc.CreatePipeline(ctx)
+	defer cleanup()
 	tc.StartController(ctx, cfg)
 	build := tc.TriggerBuild(ctx, pipelineID)
 	tc.AssertFail(ctx, build)

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -185,7 +185,7 @@ func TestExtraVolumeMounts(t *testing.T) {
 	tc.StartController(ctx, cfg)
 	build := tc.TriggerBuild(ctx, pipelineID)
 	tc.AssertSuccess(ctx, build)
-	tc.AssertLogsContain(build, "volume mounted")
+	tc.AssertLogsContain(build, "volume_mounted")
 }
 
 func TestInvalidPodSpec(t *testing.T) {

--- a/internal/integration/testcase_test.go
+++ b/internal/integration/testcase_test.go
@@ -116,6 +116,7 @@ func (t testcase) TriggerBuild(ctx context.Context, pipelineID string) api.Build
 		PipelineID: pipelineID,
 		Commit:     "HEAD",
 		Branch:     branch,
+		Message:    t.Name(),
 	})
 	require.NoError(t, err)
 	EnsureCleanup(t.T, func() {

--- a/internal/integration/testcase_test.go
+++ b/internal/integration/testcase_test.go
@@ -69,7 +69,7 @@ func (t testcase) Init() testcase {
 	return t
 }
 
-func (t testcase) CreatePipeline(ctx context.Context) string {
+func (t testcase) CreatePipeline(ctx context.Context) (string, func()) {
 	t.Helper()
 
 	tpl, err := template.ParseFS(fixtures, fmt.Sprintf("fixtures/%s", t.Fixture))
@@ -89,11 +89,11 @@ func (t testcase) CreatePipeline(ctx context.Context) string {
 	})
 	require.NoError(t, err)
 
-	if !preservePipelines {
-		t.deletePipeline(ctx)
+	return *pipeline.GraphQLID, func() {
+		if !preservePipelines {
+			t.deletePipeline(ctx)
+		}
 	}
-
-	return *pipeline.GraphQLID
 }
 
 func (t testcase) StartController(ctx context.Context, cfg config.Config) {


### PR DESCRIPTION
This was failing because the checkout was failing. It used git mirrors on a volume mount, and I suspect some checkout in a previous build corrupted the mirror directory. The corruption indicates a bug with how the agent uses git mirrors. As we have plans to fix that in the agent repo, I'm not going to investigate that here.

In any case, agent-stack-k8s can protect itself from such bugs in the agent by not using the same volume across builds. Instead, I've checked that the volume is shared between steps (and therefore pods) in the same build.

I've also used a `defer` in the integration tests to clean up the pipelines that are created. It seems to me that the tests attempted to delete the pipeline as soon as it was created with back off. Seems a bit racy to me, so I moved the cleanup into a `defer`.

Also, I've made the build message in an integration test have the name of the test. I considered making it the pipeline name too, but the pipeline name needs to be unique. It already has a random component, and the name is constrained, so I don't think putting the test name in there will work.