### PR TITLE
fix: upload artifacts on failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Brewfile.lock.json
 .vscode
 
 dist/
+config.yaml

--- a/internal/controller/scheduler/completions.go
+++ b/internal/controller/scheduler/completions.go
@@ -65,7 +65,7 @@ func (w *completionsWatcher) cleanupSidecars(pod *v1.Pod) {
 			if err != nil {
 				return err
 			} else {
-				job.Spec.ActiveDeadlineSeconds = pointer.Int64(1)
+				job.Spec.ActiveDeadlineSeconds = pointer.Int64(60)
 				_, err = w.k8s.BatchV1().Jobs(pod.Namespace).Update(context.TODO(), job, metav1.UpdateOptions{})
 				return err
 			}

--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -220,6 +220,9 @@ func (w *jobWrapper) Build() (*batchv1.Job, error) {
 		}, {
 			Name:  "BUILDKITE_AGENT_ACQUIRE_JOB",
 			Value: w.job.Uuid,
+		}, {
+			Name:  "BUILDKITE_AGENT_ID",
+			Value: w.job.Uuid,
 		},
 	}
 	if w.otherPlugins != nil {


### PR DESCRIPTION
Referring to #203

Changes
- if there are artifacts to be uploaded, a script is added to each user provided container,
  - will create (or upsert to, if it already exists) a pre-exit job hook 
  - the hook will upload artifacts at the completion of the step, regardless of failure
- added a pod failure strategy
  - will continue executing containers until completion/failure even if one container fails
  - no longer will tear down job on step failure
  - this is not exactly useful, given that Buildkite will still stop the job & stop the running agent if one container fails prior to additionally defined containers
- removed artifact upload container (this is just a normal command step, by the way, not hooking into the official upload artifact hook, which is a hook that we cannot override)
  - removed since it will never execute on step failure, given that Buildkite stops the agent if any previous commands fail


Admittedly not the cleanest solution, but it is a solution. 
The best solution would be to use an agent hook, rather than a job hook, and to provide that hook script directly into the agent container. Unfortunately, through my testing, I found that any hooks provided in the agent container will not run, unless they are the `agent-shutdown` or `agent-startup` hooks.

CC @triarius 