### PR TITLE
PS-13 update readme to include default behaviour if no podspec is specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,12 @@ steps:
 
 The `podSpec` of the `kubernetes` plugin can support any field from the `PodSpec` resource [in the Kubernetes API documentation](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#podspec-v1-core).
 
+If however no `podSpec` is specified then behaviour will default to the command step.
+```yaml
+steps:
+  - command: "blah.sh"
+```
+
 More samples can be found in the [integration test fixtures directory](internal/integration/fixtures).
 
 ### Buildkite Clusters


### PR DESCRIPTION
A support ticket requested clarification in our doco

Link to coda https://coda.io/d/_dHnUHNps1YO#Escalations-Table_tuS42/r224&view=modal

Link to code that I think does this
https://github.com/buildkite/agent-stack-k8s/blob/aa898e835b15116951a1cd84bcd3ca4fb239563f/internal/controller/scheduler/scheduler.go#L156-L164

It seems a little odd to be using k8s and not specifiy a podSpec but if I'm reading the code correctly then it will default to the step/job command