### PR TITLE
Update README and help text to clarify a few things

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -53,8 +53,8 @@ steps:
   - kubernetes:
       podSpec:
         containers:
-        - image: golangci/golangci-lint:v1.55.2
-          command: [golangci-lint, run, ./...]
+        - image: golangci/golangci-lint:v1.56.1
+          command: [golangci-lint, run, -v, ./...]
           resources:
             requests:
               cpu: 1000m

--- a/README.md
+++ b/README.md
@@ -99,19 +99,32 @@ Configuration can also be provided by a config file (`--config` or `CONFIG`), or
 For simple commands, you merely have to target the queue you configured agent-stack-k8s with.
 ```yaml
 steps:
-  - label: Hello World!
-    command: echo Hello World!
-    agents:
-      queue: kubernetes
+- label: Hello World!
+  command: echo Hello World!
+  agents:
+    queue: kubernetes
 ```
-
-The `podSpec` of the `kubernetes` plugin can support any field from the `PodSpec` resource [in the Kubernetes API documentation](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#podspec-v1-core).
-
-If however no `podSpec` is specified then behaviour will default to the command step.
+For more complicated steps, you have access to the [`PodSpec`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#podspec-v1-core) Kubernetes API resource that will be used in a Kubernetes [`Job`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#job-v1-batch).
+For now, this is nested under a `kubernetes` plugin.
+But unlike other Buildkite plugins, there is no corresponding plugin repository.
+Rather this is syntax that is interpreted by the `agent-stack-k8s` controller.
 ```yaml
 steps:
-  - command: "blah.sh"
+- label: Hello World!
+  agents:
+    queue: kubernetes
+  plugins:
+  - kubernetes:
+      podSpec:
+        containers:
+        - image: alpine:latest
+          command: [sh]
+          args:
+          - -c
+          - echo 'Hello World!'
 ```
+Note how this example demonstrates a subtlety when attempting to use shell syntax for Kubernetes Containers: the `command` should be an executable, and shells typically execute a script as a `command_string` that is required to be single argument that follows `-c`.
+Within the command string, shell syntax such `>` for output redirection may be used, but outside of it, Kubernetes will not interpret it.
 
 More samples can be found in the [integration test fixtures directory](internal/integration/fixtures).
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ steps:
           - -c
           - echo 'Hello World!'
 ```
+Note that almost any container image may be used, but it MUST have a POSIX shell available to be executed at `/bin/sh`.
+
 Note how this example demonstrates a subtlety when attempting to use shell syntax for Kubernetes Containers: the `command` should be an executable, and shells typically execute a script as a `command_string` that is required to be single argument that follows `-c`.
 Within the command string, shell syntax such `>` for output redirection may be used, but outside of it, Kubernetes will not interpret it.
 

--- a/README.md
+++ b/README.md
@@ -95,21 +95,14 @@ Use "agent-stack-k8s [command] --help" for more information about a command.
 
 Configuration can also be provided by a config file (`--config` or `CONFIG`), or environment variables. In the [examples](examples) folder there is a sample [YAML config](examples/config.yaml) and a sample [dotenv config](examples/config.env).
 
-### Sample buildkite pipeline
-
+### Sample Buildkite Pipelines
+For simple commands, you merely have to target the queue you configured agent-stack-k8s with.
 ```yaml
 steps:
-  - label: build image
+  - label: Hello World!
+    command: echo Hello World!
     agents:
       queue: kubernetes
-    plugins:
-      - kubernetes:
-          podSpec:
-            containers:
-              - image: alpine:latest
-                command: [echo]
-                args:
-                - "Hello, world!"
 ```
 
 The `podSpec` of the `kubernetes` plugin can support any field from the `PodSpec` resource [in the Kubernetes API documentation](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#podspec-v1-core).

--- a/README.md
+++ b/README.md
@@ -118,14 +118,13 @@ steps:
       podSpec:
         containers:
         - image: alpine:latest
-          command: [sh]
+          command: [sh, -c]
           args:
-          - -c
-          - echo 'Hello World!'
+          - "'echo Hello World!'"
 ```
 Note that almost any container image may be used, but it MUST have a POSIX shell available to be executed at `/bin/sh`.
 
-Note how this example demonstrates a subtlety when attempting to use shell syntax for Kubernetes Containers: the `command` should be an executable, and shells typically execute a script as a `command_string` that is required to be single argument that follows `-c`.
+Note how this example demonstrates a subtlety when attempting to use shell syntax for Kubernetes Containers: the `command` should be an executable, and shells typically execute a script as a [`command_string`](https://man7.org/linux/man-pages/man1/sh.1p.html) that is required to be single argument that follows `-c`.
 Within the command string, shell syntax such `>` for output redirection may be used, but outside of it, Kubernetes will not interpret it.
 
 More samples can be found in the [integration test fixtures directory](internal/integration/fixtures).

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ helm upgrade --install agent-stack-k8s oci://ghcr.io/buildkite/helm/agent-stack-
 We're using Helm's support for [OCI-based registries](https://helm.sh/docs/topics/registries/),
 which means you'll need Helm version 3.8.0 or newer.
 
+This will create an agent-stack-k8s installation that will listen to the `kubernetes` queue.
+See the `--tags` [option](#Options) for specifying a different queue.
+
 #### Externalize Secrets
 
 You can also have an external provider create a secret for you in the namespace before deploying the chart with helm. If the secret is pre-provisioned, replace the `agentToken` and `graphqlToken` arguments with:
@@ -62,7 +65,6 @@ Available versions and their digests can be found on [the releases page](https:/
 ### Options
 
 ```text
-$ agent-stack-k8s --help
 Usage:
   agent-stack-k8s [flags]
   agent-stack-k8s [command]
@@ -80,13 +82,15 @@ Flags:
   -f, --config string               config file path
       --debug                       debug logs
   -h, --help                        help for agent-stack-k8s
-      --image string                The image to use for the Buildkite agent (default "ghcr.io/buildkite/agent-k8s:latest")
+      --image string                The image to use for the Buildkite agent (default "ghcr.io/buildkite/agent-stack-k8s/agent:latest")
       --job-ttl duration            time to retain kubernetes jobs after completion (default 10m0s)
       --max-in-flight int           max jobs in flight, 0 means no max (default 25)
       --namespace string            kubernetes namespace to create resources in (default "default")
       --org string                  Buildkite organization name to watch
       --profiler-address string     Bind address to expose the pprof profiler (e.g. localhost:6060)
-      --tags strings                A comma-separated list of tags for the agent (for example, "linux" or "mac,xcode=8") (default [queue=kubernetes])
+      --tags strings                A comma-separated list of agent tags. The "queue" tag must be unique (e.g. "queue=kubernetes,os=linux") (default [queue=kubernetes])
+
+Use "agent-stack-k8s [command] --help" for more information about a command.
 ```
 
 Configuration can also be provided by a config file (`--config` or `CONFIG`), or environment variables. In the [examples](examples) folder there is a sample [YAML config](examples/config.yaml) and a sample [dotenv config](examples/config.env).

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -30,28 +30,47 @@ func addFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&configFile, "config", "f", "", "config file path")
 
 	// not in the config file
-	cmd.Flags().
-		String("agent-token-secret", "buildkite-agent-token", "name of the Buildkite agent token secret")
+	cmd.Flags().String(
+		"agent-token-secret",
+		"buildkite-agent-token",
+		"name of the Buildkite agent token secret",
+	)
 	cmd.Flags().String("buildkite-token", "", "Buildkite API token with GraphQL scopes")
 
 	// in the config file
 	cmd.Flags().String("org", "", "Buildkite organization name to watch")
-	cmd.Flags().
-		String("image", config.DefaultAgentImage, "The image to use for the Buildkite agent")
-	cmd.Flags().StringSlice(
-		"tags", []string{"queue=kubernetes"}, `A comma-separated list of tags for the agent (for example, "linux" or "mac,xcode=8")`,
+	cmd.Flags().String(
+		"image",
+		config.DefaultAgentImage,
+		"The image to use for the Buildkite agent",
 	)
-	cmd.Flags().
-		String("namespace", config.DefaultNamespace, "kubernetes namespace to create resources in")
+	cmd.Flags().StringSlice(
+		"tags",
+		[]string{"queue=kubernetes"},
+		`A comma-separated list of agent tags. The "queue" tag must be unique (e.g. "queue=kubernetes,os=linux")`,
+	)
+	cmd.Flags().String(
+		"namespace",
+		config.DefaultNamespace,
+		"kubernetes namespace to create resources in",
+	)
 	cmd.Flags().Bool("debug", false, "debug logs")
 	cmd.Flags().Int("max-in-flight", 25, "max jobs in flight, 0 means no max")
-	cmd.Flags().
-		Duration("job-ttl", 10*time.Minute, "time to retain kubernetes jobs after completion")
-	cmd.Flags().String(
-		"cluster-uuid", "", "UUID of the Buildkite Cluster. The agent token must be for the Buildkite Cluster.",
+	cmd.Flags().Duration(
+		"job-ttl",
+		10*time.Minute,
+		"time to retain kubernetes jobs after completion",
 	)
-	cmd.Flags().
-		String("profiler-address", "", "Bind address to expose the pprof profiler (e.g. localhost:6060)")
+	cmd.Flags().String(
+		"cluster-uuid",
+		"",
+		"UUID of the Buildkite Cluster. The agent token must be for the Buildkite Cluster.",
+	)
+	cmd.Flags().String(
+		"profiler-address",
+		"",
+		"Bind address to expose the pprof profiler (e.g. localhost:6060)",
+	)
 }
 
 func ParseConfig(cmd *cobra.Command, args []string) (config.Config, error) {


### PR DESCRIPTION
- clarifies that a single agent-stack-k8s controller can only listen to a single queue.
- more detail to the example pipeline, and switch the order so that the simpler example is first
- clarify how `gitEnvFrom` works
- clarify requirement for POSIX shell in image

Fixes: #222 #221