### PR TITLE
Upload artifacts from artifact_paths as part of job execution

### DIFF
--- a/internal/controller/scheduler/completions.go
+++ b/internal/controller/scheduler/completions.go
@@ -61,7 +61,7 @@ func (w *completionsWatcher) OnUpdate(old interface{}, new interface{}) {
 func (w *completionsWatcher) cleanupSidecars(pod *v1.Pod) {
 	if terminated := getTermination(pod); terminated != nil {
 		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			ctx := context.Background()
+			ctx := context.TODO()
 			job, err := w.k8s.BatchV1().Jobs(pod.Namespace).Get(ctx, pod.Labels["job-name"], metav1.GetOptions{})
 			if err != nil {
 				return err

--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -263,6 +263,9 @@ func (w *jobWrapper) Build() (*batchv1.Job, error) {
 		}, corev1.EnvVar{
 			Name:  "BUILDKITE_SHELL",
 			Value: "/bin/sh -ec",
+		}, corev1.EnvVar{
+			Name:  "BUILDKITE_ARTIFACT_PATHS",
+			Value: w.envMap["BUILDKITE_ARTIFACT_PATHS"],
 		})
 		if c.Name == "" {
 			c.Name = fmt.Sprintf("%s-%d", "container", i)
@@ -284,39 +287,6 @@ func (w *jobWrapper) Build() (*batchv1.Job, error) {
 		c.VolumeMounts = append(c.VolumeMounts, volumeMounts...)
 		c.EnvFrom = append(c.EnvFrom, w.k8sPlugin.GitEnvFrom...)
 		podSpec.Containers = append(podSpec.Containers, c)
-	}
-
-	if artifactPaths, found := w.envMap["BUILDKITE_ARTIFACT_PATHS"]; found && artifactPaths != "" {
-		artifactsContainer := corev1.Container{
-			Name:            "upload-artifacts",
-			Image:           w.cfg.Image,
-			Args:            []string{"bootstrap"},
-			WorkingDir:      "/workspace",
-			VolumeMounts:    volumeMounts,
-			ImagePullPolicy: corev1.PullAlways,
-			Env: []corev1.EnvVar{{
-				Name:  "BUILDKITE_AGENT_EXPERIMENT",
-				Value: "kubernetes-exec",
-			}, {
-				Name:  "BUILDKITE_BOOTSTRAP_PHASES",
-				Value: "command",
-			}, {
-				Name:  "BUILDKITE_COMMAND",
-				Value: "true",
-			}, {
-				Name:  "BUILDKITE_AGENT_NAME",
-				Value: "buildkite",
-			}, {
-				Name:  "BUILDKITE_CONTAINER_ID",
-				Value: strconv.Itoa(containerCount),
-			}, {
-				Name:  "BUILDKITE_ARTIFACT_PATHS",
-				Value: artifactPaths,
-			}},
-		}
-		artifactsContainer.Env = append(artifactsContainer.Env, env...)
-		containerCount++
-		podSpec.Containers = append(podSpec.Containers, artifactsContainer)
 	}
 
 	agentTags := []agentTag{

--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -24,8 +24,9 @@ import (
 )
 
 const (
-	agentTokenKey      = "BUILDKITE_AGENT_TOKEN"
-	AgentContainerName = "agent"
+	defaultTermGracePeriodSeconds = 60
+	agentTokenKey                 = "BUILDKITE_AGENT_TOKEN"
+	AgentContainerName            = "agent"
 )
 
 type Config struct {
@@ -187,6 +188,8 @@ func (w *jobWrapper) Build() (*batchv1.Job, error) {
 	kjob.Annotations = w.k8sPlugin.Metadata.Annotations
 	kjob.Spec.Template.Annotations = w.k8sPlugin.Metadata.Annotations
 	kjob.Spec.BackoffLimit = pointer.Int32(0)
+	kjob.Spec.Template.Spec.TerminationGracePeriodSeconds = pointer.Int64(defaultTermGracePeriodSeconds)
+
 	env := []corev1.EnvVar{
 		{
 			Name:  "BUILDKITE_BUILD_PATH",

--- a/internal/integration/fixtures/artifact-upload-failed-job.yaml
+++ b/internal/integration/fixtures/artifact-upload-failed-job.yaml
@@ -1,0 +1,16 @@
+steps:
+- label: Test artifact upload for failed job
+  agents:
+    queue: {{.queue}}
+  artifact_paths:
+  - artifact.txt
+  plugins:
+  - kubernetes:
+      podSpec:
+        containers:
+        - image: alpine:latest
+          command: [sh, -c]
+          args:
+          - |-
+            echo "Artifact Data" > artifact.txt
+            exit 1

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -272,3 +272,19 @@ func TestImagePullBackOffCancelled(t *testing.T) {
 	tc.AssertFail(ctx, build)
 	tc.AssertLogsContain(build, "other job has run")
 }
+
+func TestArtifactsUploadFailedJobs(t *testing.T) {
+	tc := testcase{
+		T:       t,
+		Fixture: "artifact-upload-failed-job.yaml",
+		Repo:    repoHTTP,
+		GraphQL: api.NewClient(cfg.BuildkiteToken),
+	}.Init()
+	ctx := context.Background()
+	pipelineID, cleanup := tc.CreatePipeline(ctx)
+	t.Cleanup(cleanup)
+	tc.StartController(ctx, cfg)
+	build := tc.TriggerBuild(ctx, pipelineID)
+	tc.AssertFail(ctx, build)
+	tc.AssertArtifactsContain(build, "artifact.txt")
+}


### PR DESCRIPTION
This removes the artifacts container and makes each job container upload artifacts.

Each job container runs `buildkite-agent bootstrap` with a command phase.
Searching artifact paths and uploading the results is [part of the definition](https://github.com/buildkite/agent/blob/c7693c49ad7ac52bfaf1270dab35dfc447f23228/internal/job/executor.go#L184-L225) of the command phase.

So this should fix #203. To verify this, I've added an integration test that an artifact is uploaded from a job container whose command fails.

Fixes: #203
Closes: #238