### PR TITLE
Name integration test pipeline after test name

### DIFF
--- a/internal/controller/monitor/monitor.go
+++ b/internal/controller/monitor/monitor.go
@@ -43,11 +43,11 @@ func New(logger *zap.Logger, k8s kubernetes.Interface, cfg Config) (*Monitor, er
 	}, nil
 }
 
-// jobResp is used to identify the reponse types from methods that call the GraphQL API
+// jobResp is used to identify the response types from methods that call the GraphQL API
 // in the cases where a cluster is specified or otherwise.
 // The return types are are isomorphic, but this has been lost in the generation of the
-// API calling methods. As such, the implmentations should syntacticaly identical, but
-// sematically, they operate on differnt types.
+// API calling methods. As such, the implementations should be syntacticaly identical, but
+// semantically, they operate on different types.
 type jobResp interface {
 	OrganizationExists() bool
 	CommandJobs() []*api.JobJobTypeCommand

--- a/internal/integration/cleanup_test.go
+++ b/internal/integration/cleanup_test.go
@@ -22,7 +22,7 @@ func TestCleanupOrphanedPipelines(t *testing.T) {
 	ctx := context.Background()
 	graphqlClient := api.NewClient(cfg.BuildkiteToken)
 
-	pipelines, err := api.SearchPipelines(ctx, graphqlClient, cfg.Org, "agent-stack-k8s-", 100)
+	pipelines, err := api.SearchPipelines(ctx, graphqlClient, cfg.Org, "test-", 100)
 	require.NoError(t, err)
 
 	numPipelines := len(pipelines.Organization.Pipelines.Edges)

--- a/internal/integration/fixtures/extra-volume-mounts.yaml
+++ b/internal/integration/fixtures/extra-volume-mounts.yaml
@@ -10,29 +10,26 @@ steps:
       podSpec:
         containers:
         - image: alpine:latest
-          command: [ash, -c]
+          command: [touch]
           args:
-          - |-
-            echo volume_mounted > "/tmp/buildkite-git-mirrors/foo-$${BUILDKITE_JOB_ID}.txt"
-            ls -lA /tmp/buildkite-git-mirrors
-            cat "/tmp/buildkite-git-mirrors/foo-$${BUILDKITE_JOB_ID}.txt"
+          - /tmp/buildkite-git-mirrors/foo-$$(BUILDKITE_JOB_ID).txt
         - image: alpine:latest
           command: [ash, -c]
           args:
           - |-
             COUNT=0
             until [[ $$((COUNT++)) == 9 ]]; do
-              grep -Fx volume_mounted "/tmp/buildkite-git-mirrors/foo-$${BUILDKITE_JOB_ID}.txt" && break
-              echo "Waiting for 'volume_mounted' to be written to /tmp/buildkite-git-mirrors/foo-$${BUILDKITE_JOB_ID}.txt"
+              [[ -f "/tmp/buildkite-git-mirrors/foo-$${BUILDKITE_JOB_ID}.txt" ]] && break
+              echo "⚠️ Waiting for /tmp/buildkite-git-mirrors/foo-$${BUILDKITE_JOB_ID}.txt to be written..."
               sleep 1
             done
 
-            if ! grep -Fx volume_mounted "/tmp/buildkite-git-mirrors/foo-$${BUILDKITE_JOB_ID}.txt"; then
-              echo "'volume_mounted' has not been written to /tmp/buildkite-git-mirrors/foo-$${BUILDKITE_JOB_ID}.txt"
+            if ! [[ -f "/tmp/buildkite-git-mirrors/foo-$${BUILDKITE_JOB_ID}.txt" ]]; then
+              echo "⛔ /tmp/buildkite-git-mirrors/foo-$${BUILDKITE_JOB_ID}.txt has not been written"
               exit 1
             fi
 
-            echo "'volume_mounted' has been written to /tmp/buildkite-git-mirrors/foo-$${BUILDKITE_JOB_ID}.txt"
+            echo "✅ /tmp/buildkite-git-mirrors/foo-$${BUILDKITE_JOB_ID}.txt has been written"
             rm -f "/tmp/buildkite-git-mirrors/foo-$${BUILDKITE_JOB_ID}.txt"
         volumes:
         - name: host-volume

--- a/internal/integration/fixtures/extra-volume-mounts.yaml
+++ b/internal/integration/fixtures/extra-volume-mounts.yaml
@@ -12,7 +12,9 @@ steps:
         - image: alpine:latest
           command: [ash, -c]
           args:
-          - echo volume_mounted > "/tmp/buildkite-git-mirrors/foo-$${BUILDKITE_JOB_ID}.txt"
+          - |-
+            echo volume_mounted > "/tmp/buildkite-git-mirrors/foo-$${BUILDKITE_JOB_ID}.txt"
+            cat "/tmp/buildkite-git-mirrors/foo-$${BUILDKITE_JOB_ID}.txt"
         - image: alpine:latest
           command: [ash, -c]
           args:

--- a/internal/integration/fixtures/extra-volume-mounts.yaml
+++ b/internal/integration/fixtures/extra-volume-mounts.yaml
@@ -20,7 +20,7 @@ steps:
           args:
           - |-
             COUNT=0
-            until [[ $$((COUNT++)) == 4 ]]; do
+            until [[ $$((COUNT++)) == 9 ]]; do
               grep -Fx volume_mounted "/tmp/buildkite-git-mirrors/foo-$${BUILDKITE_JOB_ID}.txt" && break
               echo "Waiting for 'volume_mounted' to be written to /tmp/buildkite-git-mirrors/foo-$${BUILDKITE_JOB_ID}.txt"
               sleep 1

--- a/internal/integration/fixtures/extra-volume-mounts.yaml
+++ b/internal/integration/fixtures/extra-volume-mounts.yaml
@@ -12,25 +12,25 @@ steps:
         - image: alpine:latest
           command: [ash, -c]
           args:
-          - echo volume_mounted > "/tmp/buildkite-git-mirrors/foo-${BUILDKITE_JOB_ID}.txt"
+          - echo volume_mounted > "/tmp/buildkite-git-mirrors/foo-$${BUILDKITE_JOB_ID}.txt"
         - image: alpine:latest
           command: [ash, -c]
           args:
           - |-
             COUNT=0
-            until [[ $((COUNT++)) == 4 ]]; do
-              grep -Fx volume_mounted "/tmp/buildkite-git-mirrors/foo-${BUILDKITE_JOB_ID}.txt" && break
-              echo "Waiting for 'volume_mounted' to be written to /tmp/buildkite-git-mirrors/foo-${BUILDKITE_JOB_ID}.txt"
+            until [[ $$((COUNT++)) == 4 ]]; do
+              grep -Fx volume_mounted "/tmp/buildkite-git-mirrors/foo-$${BUILDKITE_JOB_ID}.txt" && break
+              echo "Waiting for 'volume_mounted' to be written to /tmp/buildkite-git-mirrors/foo-$${BUILDKITE_JOB_ID}.txt"
               sleep 1
             done
 
-            if ! grep -Fx volume_mounted "/tmp/buildkite-git-mirrors/foo-${BUILDKITE_JOB_ID}.txt"; then
-              echo "'volume_mounted' has not been written to /tmp/buildkite-git-mirrors/foo-${BUILDKITE_JOB_ID}.txt"
+            if ! grep -Fx volume_mounted "/tmp/buildkite-git-mirrors/foo-$${BUILDKITE_JOB_ID}.txt"; then
+              echo "'volume_mounted' has not been written to /tmp/buildkite-git-mirrors/foo-$${BUILDKITE_JOB_ID}.txt"
               exit 1
             fi
 
-            echo "'volume_mounted' has been written to /tmp/buildkite-git-mirrors/foo-${BUILDKITE_JOB_ID}.txt"
-            rm -f "/tmp/buildkite-git-mirrors/foo-${BUILDKITE_JOB_ID}.txt"
+            echo "'volume_mounted' has been written to /tmp/buildkite-git-mirrors/foo-$${BUILDKITE_JOB_ID}.txt"
+            rm -f "/tmp/buildkite-git-mirrors/foo-$${BUILDKITE_JOB_ID}.txt"
         volumes:
         - name: host-volume
           hostPath:

--- a/internal/integration/fixtures/extra-volume-mounts.yaml
+++ b/internal/integration/fixtures/extra-volume-mounts.yaml
@@ -14,6 +14,7 @@ steps:
           args:
           - |-
             echo volume_mounted > "/tmp/buildkite-git-mirrors/foo-$${BUILDKITE_JOB_ID}.txt"
+            ls -lA /tmp/buildkite-git-mirrors
             cat "/tmp/buildkite-git-mirrors/foo-$${BUILDKITE_JOB_ID}.txt"
         - image: alpine:latest
           command: [ash, -c]

--- a/internal/integration/fixtures/extra-volume-mounts.yaml
+++ b/internal/integration/fixtures/extra-volume-mounts.yaml
@@ -10,32 +10,27 @@ steps:
       podSpec:
         containers:
         - image: alpine:latest
-          command: [ash]
+          command: [ash, -c]
           args:
-          - -c
-          - '"echo volume_mounted > /tmp/buildkite-git-mirrors/foo.txt"'
-        volumes:
-        - name: host-volume
-          hostPath:
-            path: /tmp/volumes/{{.queue}}
-            type: DirectoryOrCreate
-      extraVolumeMounts:
-      - name: host-volume
-        mountPath: /tmp/buildkite-git-mirrors
-        subPath: buildkite-git-mirrors
-- label: ":git: Check File in Git Mirror Dir"
-  key: check-file-in-git-mirror-dir
-  depends_on:
-  - write-file-to-git-mirror-dir
-  plugins:
-  - kubernetes:
-      podSpec:
-        containers:
+          - echo volume_mounted > "/tmp/buildkite-git-mirrors/foo-${BUILDKITE_JOB_ID}.txt"
         - image: alpine:latest
-          command: [ash]
+          command: [ash, -c]
           args:
-          - -c
-          - '"grep -Fx volume_mounted /tmp/buildkite-git-mirrors/foo.txt"'
+          - |-
+            COUNT=0
+            until [[ $((COUNT++)) == 4 ]]; do
+              grep -Fx volume_mounted "/tmp/buildkite-git-mirrors/foo-${BUILDKITE_JOB_ID}.txt" && break
+              echo "Waiting for 'volume_mounted' to be written to /tmp/buildkite-git-mirrors/foo-${BUILDKITE_JOB_ID}.txt"
+              sleep 1
+            done
+
+            if ! grep -Fx volume_mounted "/tmp/buildkite-git-mirrors/foo-${BUILDKITE_JOB_ID}.txt"; then
+              echo "'volume_mounted' has not been written to /tmp/buildkite-git-mirrors/foo-${BUILDKITE_JOB_ID}.txt"
+              exit 1
+            fi
+
+            echo "'volume_mounted' has been written to /tmp/buildkite-git-mirrors/foo-${BUILDKITE_JOB_ID}.txt"
+            rm -f "/tmp/buildkite-git-mirrors/foo-${BUILDKITE_JOB_ID}.txt"
         volumes:
         - name: host-volume
           hostPath:

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -201,7 +201,6 @@ func TestExtraVolumeMounts(t *testing.T) {
 	tc.StartController(ctx, cfg)
 	build := tc.TriggerBuild(ctx, pipelineID)
 	tc.AssertSuccess(ctx, build)
-	tc.AssertLogsContain(build, "volume_mounted")
 }
 
 func TestInvalidPodSpec(t *testing.T) {

--- a/internal/integration/testcase_test.go
+++ b/internal/integration/testcase_test.go
@@ -52,7 +52,7 @@ func (t testcase) Init() testcase {
 	if jobID == "" {
 		jobID = strconv.FormatInt(time.Now().Unix(), 10)
 	}
-	t.PipelineName = strings.ToLower(fmt.Sprintf("%s-%s", namePrefix, jobID))
+	t.PipelineName = strings.ToLower(fmt.Sprintf("test-%s-%s", namePrefix, jobID))
 
 	t.Logger = zaptest.NewLogger(t).Named(t.Name())
 

--- a/internal/integration/testcase_test.go
+++ b/internal/integration/testcase_test.go
@@ -52,7 +52,7 @@ func (t testcase) Init() testcase {
 	if jobID == "" {
 		jobID = strconv.FormatInt(time.Now().Unix(), 10)
 	}
-	t.PipelineName = fmt.Sprintf("%s-%s", namePrefix, jobID)
+	t.PipelineName = strings.ToLower(fmt.Sprintf("%s-%s", namePrefix, jobID))
 
 	t.Logger = zaptest.NewLogger(t).Named(t.Name())
 

--- a/internal/integration/testcase_test.go
+++ b/internal/integration/testcase_test.go
@@ -53,7 +53,7 @@ func (t testcase) Init() testcase {
 		namePrefix := t.Name()
 		jobID := os.Getenv("BUILDKITE_JOB_ID")
 		if jobID == "" {
-			jobID = strconv.FormatInt(time.Now().Unix(), 10)
+			jobID = strconv.FormatInt(time.Now().UnixNano(), 10)
 		}
 		t.PipelineName = strings.ToLower(fmt.Sprintf("test-%s-%s", namePrefix, jobID))
 	}

--- a/internal/integration/testcase_test.go
+++ b/internal/integration/testcase_test.go
@@ -47,12 +47,14 @@ func (t testcase) Init() testcase {
 	t.Helper()
 	t.Parallel()
 
-	namePrefix := t.Name()
-	jobID := os.Getenv("BUILDKITE_JOB_ID")
-	if jobID == "" {
-		jobID = strconv.FormatInt(time.Now().Unix(), 10)
+	if t.PipelineName == "" {
+		namePrefix := t.Name()
+		jobID := os.Getenv("BUILDKITE_JOB_ID")
+		if jobID == "" {
+			jobID = strconv.FormatInt(time.Now().Unix(), 10)
+		}
+		t.PipelineName = strings.ToLower(fmt.Sprintf("test-%s-%s", namePrefix, jobID))
 	}
-	t.PipelineName = strings.ToLower(fmt.Sprintf("test-%s-%s", namePrefix, jobID))
 
 	t.Logger = zaptest.NewLogger(t).Named(t.Name())
 

--- a/internal/integration/testcase_test.go
+++ b/internal/integration/testcase_test.go
@@ -39,6 +39,8 @@ type testcase struct {
 	PipelineName string
 }
 
+// k8s labels are limited to length 63, we use the pipeline name as a label.
+// So we sometimes need to limit the length of the pipeline name too.
 func (t *testcase) ShortPipelineName() string {
 	return t.PipelineName[:min(len(t.PipelineName), 63)]
 }
@@ -79,11 +81,7 @@ func (t testcase) CreatePipeline(ctx context.Context) (string, func()) {
 	require.NoError(t, err)
 
 	var steps bytes.Buffer
-	require.NoError(t, tpl.Execute(&steps, map[string]string{
-		// k8s labels are limited to length 63, we use the pipeline name as a label.
-		// So we need to limit the length of the pipeline name too.
-		"queue": t.ShortPipelineName(),
-	}))
+	require.NoError(t, tpl.Execute(&steps, map[string]string{"queue": t.ShortPipelineName()}))
 	pipeline, _, err := t.Buildkite.Pipelines.Create(cfg.Org, &buildkite.CreatePipeline{
 		Name:       t.PipelineName,
 		Repository: t.Repo,

--- a/internal/integration/testcase_test.go
+++ b/internal/integration/testcase_test.go
@@ -30,14 +30,17 @@ import (
 
 type testcase struct {
 	*testing.T
-	Logger            *zap.Logger
-	Fixture           string
-	Repo              string
-	GraphQL           graphql.Client
-	Kubernetes        kubernetes.Interface
-	Buildkite         *buildkite.Client
-	ShortPipelineName string
-	PipelineName      string
+	Logger       *zap.Logger
+	Fixture      string
+	Repo         string
+	GraphQL      graphql.Client
+	Kubernetes   kubernetes.Interface
+	Buildkite    *buildkite.Client
+	PipelineName string
+}
+
+func (t *testcase) ShortPipelineName() string {
+	return t.PipelineName[:min(len(t.PipelineName), 63)]
 }
 
 func (t testcase) Init() testcase {
@@ -50,7 +53,6 @@ func (t testcase) Init() testcase {
 		jobID = strconv.FormatInt(time.Now().Unix(), 10)
 	}
 	t.PipelineName = fmt.Sprintf("%s-%s", namePrefix, jobID)
-	t.ShortPipelineName = t.PipelineName[:min(len(t.PipelineName), 63)]
 
 	t.Logger = zaptest.NewLogger(t).Named(t.Name())
 
@@ -78,7 +80,7 @@ func (t testcase) CreatePipeline(ctx context.Context) (string, func()) {
 	require.NoError(t, tpl.Execute(&steps, map[string]string{
 		// k8s labels are limited to length 63, we use the pipeline name as a label.
 		// So we need to limit the length of the pipeline name too.
-		"queue": t.ShortPipelineName,
+		"queue": t.ShortPipelineName(),
 	}))
 	pipeline, _, err := t.Buildkite.Pipelines.Create(cfg.Org, &buildkite.CreatePipeline{
 		Name:       t.PipelineName,
@@ -103,7 +105,7 @@ func (t testcase) StartController(ctx context.Context, cfg config.Config) {
 	runCtx, cancel := context.WithCancel(ctx)
 	EnsureCleanup(t.T, cancel)
 
-	cfg.Tags = []string{fmt.Sprintf("queue=%s", t.ShortPipelineName)}
+	cfg.Tags = []string{fmt.Sprintf("queue=%s", t.ShortPipelineName())}
 	cfg.Debug = true
 
 	go controller.Run(runCtx, t.Logger, t.Kubernetes, cfg)
@@ -161,7 +163,7 @@ func (t testcase) AssertLogsContain(build api.Build, content string) {
 
 		jobLog, _, err := client.Jobs.GetJobLog(
 			cfg.Org,
-			t.ShortPipelineName,
+			t.PipelineName,
 			strconv.Itoa(build.Number),
 			job.Uuid,
 		)
@@ -184,7 +186,7 @@ func (t testcase) AssertArtifactsContain(build api.Build, expected ...string) {
 
 	artifacts, _, err := client.Artifacts.ListByBuild(
 		cfg.Org,
-		t.ShortPipelineName,
+		t.PipelineName,
 		strconv.Itoa(build.Number),
 		nil,
 	)
@@ -231,7 +233,7 @@ func (t testcase) waitForBuild(ctx context.Context, build api.Build) api.BuildSt
 func (t testcase) AssertMetadata(ctx context.Context, annotations, labelz map[string]string) {
 	t.Helper()
 
-	tagReq, err := labels.NewRequirement("tag.buildkite.com/queue", selection.Equals, []string{t.ShortPipelineName})
+	tagReq, err := labels.NewRequirement("tag.buildkite.com/queue", selection.Equals, []string{t.ShortPipelineName()})
 	require.NoError(t, err)
 
 	selector := labels.NewSelector().Add(*tagReq)


### PR DESCRIPTION
The pipeline that each integration test creates will now be named after the test, which makes it earlier to find when debugging. The format is something like: `<test name>-<job id>`, so tests with the same name from multiple jobs will be time ordered (since job id is time ordered).

I've also cleaned up the integration tests a bit, and fixed a few issues with them.