### PR TITLE
Set BUILDKITE_HOOKS_PATH by default

### DIFF
--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -197,6 +197,9 @@ func (w *jobWrapper) Build() (*batchv1.Job, error) {
 		}, {
 			Name:  "BUILDKITE_BIN_PATH",
 			Value: "/workspace",
+		}, {	
+			Name:  "BUILDKITE_HOOKS_PATH",
+			Value: "/buildkite/hooks",
 		}, {
 			Name: agentTokenKey,
 			ValueFrom: &corev1.EnvVarSource{


### PR DESCRIPTION
I was having trouble getting hooks to run with k8s agents, then finally realized that although the agent containers have a `/buildkite/hooks` directory created in them, nothing was pointing the agent at that directory.  I was able to get the hooks working by simply setting this env var -- seems like this is something that should be done automatically but let me know if I'm off base!