### PR TITLE
Fix k8s-stack only getting jobs that have equal set of agent query rules

### DIFF
--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -242,34 +242,47 @@ func (w *jobWrapper) Build() (*batchv1.Job, error) {
 		c.Args = []string{"bootstrap"}
 		c.ImagePullPolicy = corev1.PullAlways
 		c.Env = append(c.Env, env...)
-		c.Env = append(c.Env, corev1.EnvVar{
-			Name:  "BUILDKITE_COMMAND",
-			Value: command,
-		}, corev1.EnvVar{
-			Name:  "BUILDKITE_AGENT_EXPERIMENT",
-			Value: "kubernetes-exec",
-		}, corev1.EnvVar{
-			Name:  "BUILDKITE_BOOTSTRAP_PHASES",
-			Value: "plugin,command",
-		}, corev1.EnvVar{
-			Name:  "BUILDKITE_AGENT_NAME",
-			Value: "buildkite",
-		}, corev1.EnvVar{
-			Name:  "BUILDKITE_CONTAINER_ID",
-			Value: strconv.Itoa(i + systemContainers),
-		}, corev1.EnvVar{
-			Name:  "BUILDKITE_PLUGINS_PATH",
-			Value: "/tmp",
-		}, corev1.EnvVar{
-			Name:  clicommand.RedactedVars.EnvVar,
-			Value: strings.Join(clicommand.RedactedVars.Value.Value(), ","),
-		}, corev1.EnvVar{
-			Name:  "BUILDKITE_SHELL",
-			Value: "/bin/sh -ec",
-		}, corev1.EnvVar{
-			Name:  "BUILDKITE_ARTIFACT_PATHS",
-			Value: w.envMap["BUILDKITE_ARTIFACT_PATHS"],
-		})
+		c.Env = append(c.Env,
+			corev1.EnvVar{
+				Name:  "BUILDKITE_COMMAND",
+				Value: command,
+			},
+			corev1.EnvVar{
+				Name:  "BUILDKITE_AGENT_EXPERIMENT",
+				Value: "kubernetes-exec",
+			},
+			corev1.EnvVar{
+				Name:  "BUILDKITE_BOOTSTRAP_PHASES",
+				Value: "plugin,command",
+			},
+			corev1.EnvVar{
+				Name:  "BUILDKITE_AGENT_NAME",
+				Value: "buildkite",
+			},
+			corev1.EnvVar{
+				Name:  "BUILDKITE_CONTAINER_ID",
+				Value: strconv.Itoa(i + systemContainers),
+			},
+			corev1.EnvVar{
+				Name:  "BUILDKITE_PLUGINS_PATH",
+				Value: "/tmp",
+			},
+			corev1.EnvVar{
+				Name:  "BUILDKITE_SOCKETS_PATH",
+				Value: "/workspace/sockets",
+			},
+			corev1.EnvVar{
+				Name:  clicommand.RedactedVars.EnvVar,
+				Value: strings.Join(clicommand.RedactedVars.Value.Value(), ","),
+			},
+			corev1.EnvVar{
+				Name:  "BUILDKITE_SHELL",
+				Value: "/bin/sh -ec",
+			},
+			corev1.EnvVar{
+				Name:  "BUILDKITE_ARTIFACT_PATHS",
+				Value: w.envMap["BUILDKITE_ARTIFACT_PATHS"],
+			})
 		if c.Name == "" {
 			c.Name = fmt.Sprintf("%s-%d", "container", i)
 		}

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -33,6 +33,26 @@ func TestWalkingSkeleton(t *testing.T) {
 	)
 }
 
+func TestControllerPicksUpJobsWithSubsetOfAgentTags(t *testing.T) {
+	tc := testcase{
+		T:       t,
+		Fixture: "helloworld.yaml",
+		Repo:    repoHTTP,
+		GraphQL: api.NewClient(cfg.BuildkiteToken),
+	}.Init()
+
+	ctx := context.Background()
+	pipelineID, cleanup := tc.CreatePipeline(ctx)
+	t.Cleanup(cleanup)
+
+	cfg := cfg
+	cfg.Tags = append(cfg.Tags, "foo=bar") // job has queue=<something>, agent has queue=<something> and foo=bar
+
+	tc.StartController(ctx, cfg)
+	build := tc.TriggerBuild(ctx, pipelineID)
+	tc.AssertSuccess(ctx, build)
+}
+
 func TestChown(t *testing.T) {
 	tc := testcase{
 		T:       t,

--- a/internal/integration/monitor_test.go
+++ b/internal/integration/monitor_test.go
@@ -16,7 +16,7 @@ func TestInvalidOrg(t *testing.T) {
 		Token:       os.Getenv("BUILDKITE_TOKEN"),
 		MaxInFlight: 1,
 		Org:         "foo",
-		Tags:        []string{"foo=bar"},
+		Tags:        []string{"queue=default", "foo=bar"},
 	})
 	require.NoError(t, err)
 

--- a/internal/integration/testcase_test.go
+++ b/internal/integration/testcase_test.go
@@ -148,6 +148,8 @@ func (t testcase) TriggerBuild(ctx context.Context, pipelineID string) api.Build
 	_, ok := node.(*api.JobJobTypeCommand)
 	require.True(t, ok)
 
+	t.Logf("Triggered build: https://buildkite.com/buildkite-kubernetes-stack/%s/builds/%d", t.PipelineName, build.Number)
+
 	return build.Build
 }
 

--- a/internal/integration/testcase_test.go
+++ b/internal/integration/testcase_test.go
@@ -114,8 +114,18 @@ func (t testcase) StartController(ctx context.Context, cfg config.Config) {
 func (t testcase) TriggerBuild(ctx context.Context, pipelineID string) api.Build {
 	t.Helper()
 
+	authorEmail := os.Getenv("BUILDKITE_BUILD_CREATOR_EMAIL")
+	authorName := os.Getenv("BUILDKITE_BUILD_CREATOR")
+	if authorName == "" {
+		authorName = "Agent Stack K8s Integration Test"
+	}
+
 	// trigger build
 	createBuild, err := api.BuildCreate(ctx, t.GraphQL, api.BuildCreateInput{
+		Author: api.BuildAuthorInput{
+			Email: authorEmail,
+			Name:  authorName,
+		},
 		PipelineID: pipelineID,
 		Commit:     "HEAD",
 		Branch:     branch,

--- a/justfile
+++ b/justfile
@@ -61,7 +61,7 @@ deploy *FLAGS:
     --wait \
     {{FLAGS}}
 
-# Invoke with CLEAN_PIPELINES=true
+# Invoke with CLEANUP_PIPELINES=true
 # pass in --org=<org slug of k8s pipeline> --buildkite-token=<graphql-token>
 cleanup-orphans *FLAGS:
   @go test -v -run TestCleanupOrphanedPipelines ./internal/integration {{FLAGS}}


### PR DESCRIPTION
The k8s stack as it currently stands has a bug:

Let's say that we launch a k8s stack with the following tags:
```
  queue=cotopaxi
  colour=chartreuse
  lake=quilotoa
```

The way Buildkite normally works, and the way we would expect the k8s stack to work, is that the k8s stack would pick up any job that has agent query rules that cover a __subset__ of these tags. That is, we might expect that a jobs with agent query rules:
```
  queue=cotopaxi
  lake=quilotoa
```
or
```
  queue=cotopaxi
```
would be picked up by the k8s stack.

Unfortunately, there's a bug in the way we query for jobs where, essentially, agent query rules get ANDed together, and as a result, the k8s stack will only pick up jobs that have __the complete set__ of agent query rules matching the agent's tags. That is, the agent mentioned above will __only__ pick up jobs that have all of `queue=cotopaxi, colour=chartreuse, lake=quilotoa`. This is a bug.

To fix this, i've implemented the following fix:
- instead of explicitly querying jobs that match the tags for our agent, we'll __only__ query for the ones that match the queue for our instance
- from here we'll decide if we're a valid instance to execute that job - eg, if the job has an agent query rule that excludes us, we'll ignore it. Previously, we were relying on the backend to do this for us, but this is where the query is broken for our use case