### PR TITLE
Create a DEVELOPMENT.md file to describe how to clean up after integration tests

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,71 @@
+Agent Stack K8s Development
+===
+
+# Local Dependencies
+Install dependencies with Homebrew via:
+
+```bash
+brew bundle
+```
+
+Run tasks via [just](https://github.com/casey/just):
+
+```bash
+just --list
+```
+
+# Integration Tests
+For running the integration tests you'll need to add some additional scopes to your Buildkite API token:
+
+- `read_artifacts`
+- `read_build_logs`
+- `write_pipelines`
+
+You'll also need to create an SSH secret in your cluster to run [this test pipeline](internal/integration/fixtures/secretref.yaml). This SSH key needs to be associated with your GitHub account to be able to clone this public repo, and must be in a form acceptable to OpenSSH (aka `BEGIN OPENSSH PRIVATE KEY`, not `BEGIN PRIVATE KEY`).
+
+```bash
+kubectl create secret generic agent-stack-k8s --from-file=SSH_PRIVATE_RSA_KEY=$HOME/.ssh/id_github
+```
+
+# Run from source
+
+First store the agent token in a Kubernetes secret:
+
+```bash!
+kubectl create secret generic buildkite-agent-token --from-literal=BUILDKITE_AGENT_TOKEN=my-agent-token
+```
+
+Next start the controller:
+
+```bash!
+just run --org my-org --buildkite-token my-api-token --debug
+```
+
+## Local Deployment with Helm
+
+`just deploy` will build the container image using [ko](https://ko.build/) and
+deploy it with [Helm](https://helm.sh/).
+
+You'll need to have set `KO_DOCKER_REPO` to a repository you have push access
+to. For development something like the [kind local
+registry](https://kind.sigs.k8s.io/docs/user/local-registry/) or the [minikube
+registry](https://minikube.sigs.k8s.io/docs/handbook/registry) can be used. More
+information is available at [ko's
+website](https://ko.build/configuration/#local-publishing-options).
+
+You'll also need to provide required configuration values to Helm, which can be done by passing extra args to `just`:
+
+```bash
+just deploy --values config.yaml
+```
+
+With config.yaml being a file containing [required Helm values](values.yaml), such as:
+
+```yaml
+agentToken: "abcdef"
+graphqlToken: "12345"
+config:
+  org: "my-buildkite-org"
+```
+
+The `config` key contains configuration passed directly to the binary, and so supports all the keys documented in [the example](examples/config.yaml).

--- a/README.md
+++ b/README.md
@@ -245,83 +245,13 @@ sequenceDiagram
     bc->>kubernetes: cleanup finished pods
 ```
 
-## Development
-
-Install dependencies with Homebrew via:
-
-```bash
-brew bundle
-```
-
-Run tasks via [just](https://github.com/casey/just):
-
-```bash
-just --list
-```
-
-For running the integration tests you'll need to add some additional scopes to your Buildkite API token:
-
-- `read_artifacts`
-- `read_build_logs`
-- `write_pipelines`
-
-You'll also need to create an SSH secret in your cluster to run [this test pipeline](internal/integration/fixtures/secretref.yaml). This SSH key needs to be associated with your GitHub account to be able to clone this public repo, and must be in a form acceptable to OpenSSH (aka `BEGIN OPENSSH PRIVATE KEY`, not `BEGIN PRIVATE KEY`).
-
-```bash
-kubectl create secret generic agent-stack-k8s --from-file=SSH_PRIVATE_RSA_KEY=$HOME/.ssh/id_github
-```
-
-### Run from source
-
-First store the agent token in a Kubernetes secret:
-
-```bash!
-kubectl create secret generic buildkite-agent-token --from-literal=BUILDKITE_AGENT_TOKEN=my-agent-token
-```
-
-Next start the controller:
-
-```bash!
-just run --org my-org --buildkite-token my-api-token --debug
-```
-
-### Local Deployment with Helm
-
-`just deploy` will build the container image using [ko](https://ko.build/) and
-deploy it with [Helm](https://helm.sh/).
-
-You'll need to have set `KO_DOCKER_REPO` to a repository you have push access
-to. For development something like the [kind local
-registry](https://kind.sigs.k8s.io/docs/user/local-registry/) or the [minikube
-registry](https://minikube.sigs.k8s.io/docs/handbook/registry) can be used. More
-information is available at [ko's
-website](https://ko.build/configuration/#local-publishing-options).
-
-You'll also need to provide required configuration values to Helm, which can be done by passing extra args to `just`:
-
-```bash
-just deploy --values config.yaml
-```
-
-With config.yaml being a file containing [required Helm values](values.yaml), such as:
-
-```yaml
-agentToken: "abcdef"
-graphqlToken: "12345"
-config:
-  org: "my-buildkite-org"
-```
-
-The `config` key contains configuration passed directly to the binary, and so supports all the keys documented in [the example](examples/config.yaml).
-
-## Collect logs via script
+## Debugging
 Use the `log-collector` script in the `utils` folder to collect logs for agent-stack-k8s.
 
 ### Prerequisites
 
-kubectl binary
-
-kubectl setup and authenticated to correct k8s cluster
+- kubectl binary
+- kubectl setup and authenticated to correct k8s cluster
 
 ### Inputs to the script
 


### PR DESCRIPTION
I moved an existing section in the README into a new doc just for development purposes. The README should mainly contain customer facing documentation.