### PR TITLE
Fix go required in release step

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -269,7 +269,7 @@ steps:
         serviceAccountName: release
         containers:
         - name: release
-          image: alpine:latest
+          image: golang:1.22-alpine # Note goreleaser shells out to go!
           command: [.buildkite/steps/release.sh]
           envFrom:
           - secretRef:

--- a/.buildkite/steps/release.sh
+++ b/.buildkite/steps/release.sh
@@ -9,21 +9,11 @@ if [[ -z "${BUILDKITE_TAG:-}" ]]; then
 fi
 
 ARCH=$(uname -m)
-GOARCH=""
-case "$ARCH" in
-  x86_64 | amd64)
-    GOARCH="amd64"
-    ;;
-  aarch64 | arm64)
-    GOARCH="arm64"
-    ;;
-esac
-
 GORELEASER_VERSION=1.19.2
 GORELEASER_URL=https://github.com/goreleaser/goreleaser/releases/download
 GORELEASER_FILE="goreleaser_${GORELEASER_VERSION}_${ARCH}.apk"
 GHCH_VERSION=0.11.0
-GHCH_URL="https://github.com/buildkite/ghch/releases/download/v${GHCH_VERSION}/ghch-${GOARCH}"
+GHCH_URL="https://github.com/buildkite/ghch/releases/download/v${GHCH_VERSION}/ghch-$(go env GOARCH)"
 
 echo --- :hammer: Installing packages
 apk add --no-progress crane git


### PR DESCRIPTION
We had thought we did not need it, but it turns out goreleaser is configured to use `go` when building the release.
By default, gorealear fails the release if these command (`go mod tidy` and `go generate ./...`) leave the working directory dirty, so
I think keeping them in the goreleaser config is a good idea.