### PR TITLE
Remove `-G.` from code generation check

### DIFF
--- a/.buildkite/steps/check-code-generation.sh
+++ b/.buildkite/steps/check-code-generation.sh
@@ -9,9 +9,8 @@ echo --- :golang: Generating code
 go generate ./...
 
 echo --- :git: Checking generated code matches commit
-# TODO: remove `-G.` once chmod 777 issue is fixed
-if ! git diff -G. --no-ext-diff --exit-code; then
-  echo +++ :x: Generated code was not commited.
+if ! git diff --no-ext-diff --exit-code; then
+  echo +++ :x: Generated code was not committed.
   echo "Run"
   echo "  go generate ./..."
   echo "and make a commit."


### PR DESCRIPTION
This was in place because agent-stack-k8s used to mess with the file
permissions in the workspace. That's no longer the case, so we can
remove it. `-G.` effectively means ignore permissions in the diff, but I
think its safer to not ignore them as long as they don't cause false
positives, which they always did prior to https://github.com/buildkite/agent-stack-k8s/pull/246