### PR TITLE
Update examples to clarify role of `command` and `args`

### DIFF
--- a/internal/integration/fixtures/artifact-upload-failed-job.yaml
+++ b/internal/integration/fixtures/artifact-upload-failed-job.yaml
@@ -9,8 +9,7 @@ steps:
       podSpec:
         containers:
         - image: alpine:latest
-          command: [sh, -c]
-          args:
+          command:
           - |-
             echo "Artifact Data" > artifact.txt
             exit 1

--- a/internal/integration/fixtures/chown.yaml
+++ b/internal/integration/fixtures/chown.yaml
@@ -17,9 +17,6 @@ steps:
           - -la
         - image: alpine:latest
           command:
-          - ash
-          - -c
-          args:
           - |-
             echo "some contents" > some-file
         securityContext:

--- a/internal/integration/fixtures/extra-volume-mounts.yaml
+++ b/internal/integration/fixtures/extra-volume-mounts.yaml
@@ -14,8 +14,7 @@ steps:
           args:
           - /tmp/buildkite-git-mirrors/foo-$$(BUILDKITE_JOB_ID).txt
         - image: alpine:latest
-          command: [ash, -c]
-          args:
+          command:
           - |-
             COUNT=0
             until [[ $$((COUNT++)) == 9 ]]; do

--- a/internal/integration/fixtures/helloworld.yaml
+++ b/internal/integration/fixtures/helloworld.yaml
@@ -17,4 +17,4 @@ steps:
                 args: [README.md]
               - image: buildkite/agent:latest
                 command: [buildkite-agent]
-                args: [artifact upload "README.md"]
+                args: [artifact, upload, "README.md"]

--- a/internal/integration/fixtures/invalid2.yaml
+++ b/internal/integration/fixtures/invalid2.yaml
@@ -10,7 +10,7 @@ steps:
             containers:
               - image: alpine:latest
                 name: invalid
-                command: [echo hello world]
+                command: [echo, hello world]
                 env:
                   - name: CGO_ENABLED
                     value: 0 # invalid type, should be string

--- a/internal/integration/fixtures/parallel.yaml
+++ b/internal/integration/fixtures/parallel.yaml
@@ -3,8 +3,6 @@ steps:
     parallelism: 4
     agents:
       queue: {{.queue}}
-    env:
-      BUILDKITE_SHELL: /bin/sh -e -c
     plugins:
       - kubernetes:
           podSpec:

--- a/internal/integration/fixtures/sidecars.yaml
+++ b/internal/integration/fixtures/sidecars.yaml
@@ -2,8 +2,6 @@ steps:
   - label: ":wave:"
     agents:
       queue: {{.queue}}
-    env:
-      BUILDKITE_SHELL: /bin/sh -e -c
     plugins:
       - kubernetes:
           sidecars:

--- a/internal/integration/fixtures/unknown-plugin.yaml
+++ b/internal/integration/fixtures/unknown-plugin.yaml
@@ -2,8 +2,6 @@ steps:
   - label: ":wave:"
     agents:
       queue: {{.queue}}
-    env:
-      BUILDKITE_SHELL: /bin/sh -e -c
     plugins:
       - kubernetes:
           podSpec:


### PR DESCRIPTION
In k8s containers, `command` is the executable to run, and `args` are the arguments to pass to it. However, in `agent-stack-k8s`, these are substituted with `buildkite-agent` and various commands like `start` and `bootstrap`.

The `command` and `args` that the user specifies in their `podSpec` is joined with spaces and set as the `BUILDKITE_COMMAND` environment variable for the `bootstrap` command: https://github.com/buildkite/agent-stack-k8s/blob/aa3cddf123470b7788426e3c49a02f873d451319/internal/controller/scheduler/scheduler.go#L240

This can lead to confusing situations, so I've updated the docs and the test fixture examples to discourage specifying both. Users should stick to just specifying `command`, but feel free to write a shell script with multiple commands.