### PR TITLE
Skip checkout when there are parse errors

### DIFF
--- a/.buildkite/steps/tests.sh
+++ b/.buildkite/steps/tests.sh
@@ -13,6 +13,5 @@ export IMAGE
 
 gotestsum --junitfile "junit-${BUILDKITE_JOB_ID}.xml" -- \
   -count=1 \
-  -failfast \
   -ldflags="-X ${package}.branch=${branch}" \
   ./...

--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -501,7 +501,17 @@ func (w *jobWrapper) BuildFailureJob(err error) (*batchv1.Job, error) {
 		PodSpec: &corev1.PodSpec{
 			Containers: []corev1.Container{
 				{
-					Image:   w.cfg.Image,
+					// the configured agent image may be private. If there is an error in specifying the
+					// secrets for this image, we should still be able to run the failure job. So, we
+					// bypass the potentially private image and use a public one. We could use a
+					// thinner public image like `alpine:latest`, but it's generally unwise to depend
+					// on an image that's not published by us.
+					//
+					// TODO: pin the version of the agent image and use that here.
+					// Currently, DefaultAgentImage has a latest tag. That's not ideal as
+					// a given version of agent stack-k8s may use different versions of the agent image over
+					// time. We should consider using a specific version of the agent image here.
+					Image:   config.DefaultAgentImage,
 					Command: []string{fmt.Sprintf("echo %q && exit 1", err.Error())},
 				},
 			},

--- a/internal/controller/scheduler/scheduler_test.go
+++ b/internal/controller/scheduler/scheduler_test.go
@@ -63,7 +63,7 @@ func TestJobPluginConversion(t *testing.T) {
 		input,
 		scheduler.Config{AgentToken: "token-secret"},
 	)
-	result, err := wrapper.ParsePlugins().Build()
+	result, err := wrapper.ParsePlugins().Build(false)
 	require.NoError(t, err)
 
 	assert.Len(t, result.Spec.Template.Spec.Containers, 3)
@@ -122,7 +122,7 @@ func TestTagEnv(t *testing.T) {
 		AgentQueryRules: []string{"queue=kubernetes"},
 	}
 	wrapper := scheduler.NewJobWrapper(logger, input, scheduler.Config{AgentToken: "token-secret"})
-	result, err := wrapper.ParsePlugins().Build()
+	result, err := wrapper.ParsePlugins().Build(false)
 	require.NoError(t, err)
 
 	container := findContainer(t, result.Spec.Template.Spec.Containers, "agent")
@@ -152,7 +152,7 @@ func TestJobWithNoKubernetesPlugin(t *testing.T) {
 		AgentQueryRules: []string{},
 	}
 	wrapper := scheduler.NewJobWrapper(zaptest.NewLogger(t), input, scheduler.Config{})
-	result, err := wrapper.ParsePlugins().Build()
+	result, err := wrapper.ParsePlugins().Build(false)
 	require.NoError(t, err)
 
 	require.Len(t, result.Spec.Template.Spec.Containers, 3)
@@ -179,7 +179,7 @@ func TestFailureJobs(t *testing.T) {
 		AgentQueryRules: []string{"queue=kubernetes"},
 	}
 	wrapper := scheduler.NewJobWrapper(zaptest.NewLogger(t), input, scheduler.Config{})
-	_, err = wrapper.ParsePlugins().Build()
+	_, err = wrapper.ParsePlugins().Build(false)
 	require.Error(t, err)
 
 	result, err := wrapper.BuildFailureJob(err)


### PR DESCRIPTION
When the controller attempts to parse the Kubernetes plugin config and encounters an error, it will run a "failure job" that echos the error message as the command so that it is surfaced in the job logs. However, for private repositories that need secrets for checkout, this will fail because the container is not given access to those secrets.

Rather than give the container access to the secrets, in this PR, we skip the checkout step entirely when there are such errors: it is not needed and can only slow down the job or cause some other error.

The error message container is run with the default agent image, which is public, so it should not need any more resources like `imagePullSecrets` to run. I guess this means that it won't necessarily work on k8s clusters that are air-gapped, but this image is needed for other containers like the `agent start` container and the `init` container, so no other jobs would work on such clusters anyway.

In any case, I don't think transferring things like `gitEnvFrom` and `imagePullSecret` are going to work if there was an error in the specification of those fields. We want this failure job to be as bare bones as possible to reduce the chance of errors in the Pipeline YAML from preventing it from running.

Fixes: #233, #273

#### Note to reviews
I've implemented this as a `skipCheckout` flag on the `Build` method. I'm aware that such practices don't align with our coding standards. But, I think the entire `Build` method needs to refactored, and I don't want to do that yet. There are a few PRs in flight (#262, #248, #258) that modify the `Build` method, so a significant refactor would introduce too many merge conflicts.

After they are merged, we should refactor this method into smaller, composable pieces so that when there is a parse error, the checkout container is omitted and an error message container is substituted for the job command containers.