### PR TITLE
Add redacted-vars config

### DIFF
--- a/charts/agent-stack-k8s/values.schema.json
+++ b/charts/agent-stack-k8s/values.schema.json
@@ -204,6 +204,15 @@
           "default": "",
           "title": "The UUID of the Buildkite cluster to pull Jobs from",
           "examples": [""]
+        },
+        "redacted-vars": {
+          "type": "array",
+          "default": [],
+          "title": "Additional environment variables to redact values from logs",
+          "items": {
+            "type": "string"
+          },
+          "examples": [["SECRET_RECIPE"]]
         }
       },
       "examples": [

--- a/charts/agent-stack-k8s/values.schema.json
+++ b/charts/agent-stack-k8s/values.schema.json
@@ -205,7 +205,7 @@
           "title": "The UUID of the Buildkite cluster to pull Jobs from",
           "examples": [""]
         },
-        "redacted-vars": {
+        "additional-redacted-vars": {
           "type": "array",
           "default": [],
           "title": "Additional environment variables to redact values from logs",

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -15,18 +15,18 @@ const (
 )
 
 type Config struct {
-	Debug            bool          `mapstructure:"debug"`
-	AgentTokenSecret string        `mapstructure:"agent-token-secret" validate:"required"`
-	BuildkiteToken   string        `mapstructure:"buildkite-token"    validate:"required"`
-	Image            string        `mapstructure:"image"              validate:"required"`
-	JobTTL           time.Duration `mapstructure:"job-ttl"`
-	MaxInFlight      int           `mapstructure:"max-in-flight"      validate:"min=0"`
-	Namespace        string        `mapstructure:"namespace"          validate:"required"`
-	Org              string        `mapstructure:"org"                validate:"required"`
-	Tags             stringSlice   `mapstructure:"tags"               validate:"min=1"`
-	ProfilerAddress  string        `mapstructure:"profiler-address"   validate:"omitempty,hostname_port"`
-	ClusterUUID      string        `mapstructure:"cluster-uuid"       validate:"omitempty"`
-	RedactedVars     stringSlice   `mapstructure:"redacted-vars"      validate:"omitempty"`
+	Debug                  bool          `mapstructure:"debug"`
+	AgentTokenSecret       string        `mapstructure:"agent-token-secret"       validate:"required"`
+	BuildkiteToken         string        `mapstructure:"buildkite-token"          validate:"required"`
+	Image                  string        `mapstructure:"image"                    validate:"required"`
+	JobTTL                 time.Duration `mapstructure:"job-ttl"`
+	MaxInFlight            int           `mapstructure:"max-in-flight"            validate:"min=0"`
+	Namespace              string        `mapstructure:"namespace"                validate:"required"`
+	Org                    string        `mapstructure:"org"                      validate:"required"`
+	Tags                   stringSlice   `mapstructure:"tags"                     validate:"min=1"`
+	ProfilerAddress        string        `mapstructure:"profiler-address"         validate:"omitempty,hostname_port"`
+	ClusterUUID            string        `mapstructure:"cluster-uuid"             validate:"omitempty"`
+	AdditionalRedactedVars stringSlice   `mapstructure:"additional-redacted-vars" validate:"omitempty"`
 }
 
 type stringSlice []string
@@ -48,7 +48,7 @@ func (c Config) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	enc.AddString("org", c.Org)
 	enc.AddString("profiler-address", c.ProfilerAddress)
 	enc.AddString("cluster-uuid", c.ClusterUUID)
-	if err := enc.AddArray("redacted-vars", c.RedactedVars); err != nil {
+	if err := enc.AddArray("additional-redacted-vars", c.AdditionalRedactedVars); err != nil {
 		return err
 	}
 	return enc.AddArray("tags", c.Tags)

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	Tags             stringSlice   `mapstructure:"tags"               validate:"min=1"`
 	ProfilerAddress  string        `mapstructure:"profiler-address"   validate:"omitempty,hostname_port"`
 	ClusterUUID      string        `mapstructure:"cluster-uuid"       validate:"omitempty"`
+	RedactedVars     stringSlice   `mapstructure:"redacted-vars"      validate:"omitempty"`
 }
 
 type stringSlice []string
@@ -47,5 +48,8 @@ func (c Config) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	enc.AddString("org", c.Org)
 	enc.AddString("profiler-address", c.ProfilerAddress)
 	enc.AddString("cluster-uuid", c.ClusterUUID)
+	if err := enc.AddArray("redacted-vars", c.RedactedVars); err != nil {
+		return err
+	}
 	return enc.AddArray("tags", c.Tags)
 }

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -49,11 +49,11 @@ func Run(
 	}
 
 	sched := scheduler.New(logger.Named("scheduler"), k8sClient, scheduler.Config{
-		Namespace:    cfg.Namespace,
-		Image:        cfg.Image,
-		AgentToken:   cfg.AgentTokenSecret,
-		JobTTL:       cfg.JobTTL,
-		RedactedVars: cfg.RedactedVars,
+		Namespace:              cfg.Namespace,
+		Image:                  cfg.Image,
+		AgentToken:             cfg.AgentTokenSecret,
+		JobTTL:                 cfg.JobTTL,
+		AdditionalRedactedVars: cfg.AdditionalRedactedVars,
 	})
 	limiter := scheduler.NewLimiter(logger.Named("limiter"), sched, cfg.MaxInFlight)
 

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -49,10 +49,11 @@ func Run(
 	}
 
 	sched := scheduler.New(logger.Named("scheduler"), k8sClient, scheduler.Config{
-		Namespace:  cfg.Namespace,
-		Image:      cfg.Image,
-		AgentToken: cfg.AgentTokenSecret,
-		JobTTL:     cfg.JobTTL,
+		Namespace:    cfg.Namespace,
+		Image:        cfg.Image,
+		AgentToken:   cfg.AgentTokenSecret,
+		JobTTL:       cfg.JobTTL,
+		RedactedVars: cfg.RedactedVars,
 	})
 	limiter := scheduler.NewLimiter(logger.Named("limiter"), sched, cfg.MaxInFlight)
 

--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -30,11 +30,11 @@ const (
 )
 
 type Config struct {
-	Namespace    string
-	Image        string
-	AgentToken   string
-	JobTTL       time.Duration
-	RedactedVars []string
+	Namespace              string
+	Image                  string
+	AgentToken             string
+	JobTTL                 time.Duration
+	AdditionalRedactedVars []string
 }
 
 func New(logger *zap.Logger, client kubernetes.Interface, cfg Config) *worker {
@@ -229,7 +229,7 @@ func (w *jobWrapper) Build(skipCheckout bool) (*batchv1.Job, error) {
 		}
 	}
 
-	redactedVars := append(w.cfg.RedactedVars, clicommand.RedactedVars.Value.Value()...)
+	redactedVars := append(w.cfg.AdditionalRedactedVars, clicommand.RedactedVars.Value.Value()...)
 
 	volumeMounts := []corev1.VolumeMount{{Name: "workspace", MountPath: "/workspace"}}
 	volumeMounts = append(volumeMounts, w.k8sPlugin.ExtraVolumeMounts...)

--- a/internal/integration/fixtures/redacted-vars.yaml
+++ b/internal/integration/fixtures/redacted-vars.yaml
@@ -1,0 +1,20 @@
+steps:
+  - label: ":earth_asia:"
+    agents:
+      queue: {{.queue}}
+    env:
+      BUILDKITE_SHELL: /bin/sh -ec
+      # Note that this is example is a bit contrived, since environment
+      # variables and values can usually be browsed from the Buildkite UI.
+      ELEVEN_HERBS_AND_SPICES: white pepper and 10 others
+    plugins:
+      - kubernetes:
+          podSpec:
+            containers:
+              - image: alpine:latest
+                command:
+                - echo
+                args:
+                - >-
+                  This should be redacted:
+                  $${ELEVEN_HERBS_AND_SPICES}

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -54,7 +54,7 @@ func TestControllerPicksUpJobsWithSubsetOfAgentTags(t *testing.T) {
 	tc.AssertSuccess(ctx, build)
 }
 
-func TestControllerSetsRedactedVars(t *testing.T) {
+func TestControllerSetsAdditionalRedactedVars(t *testing.T) {
 	tc := testcase{
 		T:       t,
 		Fixture: "redacted-vars.yaml",
@@ -67,7 +67,7 @@ func TestControllerSetsRedactedVars(t *testing.T) {
 	t.Cleanup(cleanup)
 
 	cfg := cfg
-	cfg.RedactedVars = []string{"ELEVEN_HERBS_AND_SPICES"}
+	cfg.AdditionalRedactedVars = []string{"ELEVEN_HERBS_AND_SPICES"}
 
 	tc.StartController(ctx, cfg)
 	build := tc.TriggerBuild(ctx, pipelineID)

--- a/internal/integration/testcase_test.go
+++ b/internal/integration/testcase_test.go
@@ -158,7 +158,7 @@ func (t testcase) AssertSuccess(ctx context.Context, build api.Build) {
 	require.Equal(t, api.BuildStatesPassed, t.waitForBuild(ctx, build))
 }
 
-func (t testcase) AssertLogsContain(build api.Build, content string) {
+func (t testcase) FetchLogs(build api.Build) string {
 	t.Helper()
 
 	config, err := buildkite.NewTokenConfig(cfg.BuildkiteToken, false)
@@ -187,7 +187,19 @@ func (t testcase) AssertLogsContain(build api.Build, content string) {
 		assert.NoError(t, err)
 	}
 
-	assert.Contains(t, logs.String(), content)
+	return logs.String()
+}
+
+func (t testcase) AssertLogsContain(build api.Build, content string) {
+	t.Helper()
+
+	assert.Contains(t, t.FetchLogs(build), content)
+}
+
+func (t testcase) AssertLogsDoNotContain(build api.Build, content string) {
+	t.Helper()
+
+	assert.NotContains(t, t.FetchLogs, content)
 }
 
 func (t testcase) AssertArtifactsContain(build api.Build, expected ...string) {

--- a/internal/integration/testcase_test.go
+++ b/internal/integration/testcase_test.go
@@ -196,12 +196,6 @@ func (t testcase) AssertLogsContain(build api.Build, content string) {
 	assert.Contains(t, t.FetchLogs(build), content)
 }
 
-func (t testcase) AssertLogsDoNotContain(build api.Build, content string) {
-	t.Helper()
-
-	assert.NotContains(t, t.FetchLogs, content)
-}
-
 func (t testcase) AssertArtifactsContain(build api.Build, expected ...string) {
 	t.Helper()
 	config, err := buildkite.NewTokenConfig(cfg.BuildkiteToken, false)


### PR DESCRIPTION
Currently the scheduler always sets `BUILDKITE_REDACTED_VARS` to be the agent's default value for each container, with no way to specify additional variables to redact from logs. This was set in #81 (because default redaction wasn't working?)

This PR provides a way to add more variables to `BUILDKITE_REDACTED_VARS`.

### Changes

* Add `additional-redacted-vars` to `config.Config`, `scheduler.Config` and the json schema
* Pass it through to `jobWrapper.Build`
* Append the default redacted vars to the configured ones
* Add an integration test