### PR TITLE
Enable plugin phase in checkout container

### DIFF
--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -283,6 +283,10 @@ func (w *jobWrapper) Build(skipCheckout bool) (*batchv1.Job, error) {
 			Value: w.envMap["BUILDKITE_ARTIFACT_PATHS"],
 		},
 		{
+			Name:  "BUILDKITE_PLUGINS_PATH",
+			Value: "/workspace/plugins",
+		},
+		{
 			Name:  "BUILDKITE_SOCKETS_PATH",
 			Value: "/workspace/sockets",
 		},
@@ -523,7 +527,7 @@ func (w *jobWrapper) createCheckoutContainer(
 			},
 			{
 				Name:  "BUILDKITE_BOOTSTRAP_PHASES",
-				Value: "checkout",
+				Value: "plugin,checkout",
 			},
 			{
 				Name:  "BUILDKITE_AGENT_NAME",
@@ -532,6 +536,10 @@ func (w *jobWrapper) createCheckoutContainer(
 			{
 				Name:  "BUILDKITE_CONTAINER_ID",
 				Value: "0",
+			},
+			{
+				Name:  "BUILDKITE_PLUGINS_PATH",
+				Value: "/workspace/plugins",
 			},
 		},
 		EnvFrom: w.k8sPlugin.GitEnvFrom,

--- a/internal/integration/fixtures/plugin-checkout-hook.yaml
+++ b/internal/integration/fixtures/plugin-checkout-hook.yaml
@@ -1,0 +1,21 @@
+steps:
+  - label: ":earth_asia:"
+    agents:
+      queue: {{.queue}}
+    env:
+      BUILDKITE_SHELL: /bin/sh -ec
+    plugins:
+      - improbable-eng/metahook#v0.4.1:
+          pre-checkout: echo The pre-checkout hook ran!
+          post-checkout: echo The post-checkout hook ran!
+      - kubernetes:
+          podSpec:
+            containers:
+              # A container with Bash is needed to run the metahook hooks
+              # (that are empty, because only pre- and post-checkout are set).
+              - image: bash:latest
+                command:
+                - echo
+                args:
+                - >-
+                  The command ran!

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -147,6 +147,26 @@ func TestControllerSetsAdditionalRedactedVars(t *testing.T) {
 	assert.NotContains(t, logs, "white pepper and 10 others")
 }
 
+func TestPrePostCheckoutHooksRun(t *testing.T) {
+	tc := testcase{
+		T:       t,
+		Fixture: "plugin-checkout-hook.yaml",
+		Repo:    repoHTTP,
+		GraphQL: api.NewClient(cfg.BuildkiteToken),
+	}.Init()
+
+	ctx := context.Background()
+	pipelineID, cleanup := tc.CreatePipeline(ctx)
+	t.Cleanup(cleanup)
+
+	tc.StartController(ctx, cfg)
+	build := tc.TriggerBuild(ctx, pipelineID)
+	tc.AssertSuccess(ctx, build)
+	logs := tc.FetchLogs(build)
+	assert.Contains(t, logs, "The pre-checkout hook ran!")
+	assert.Contains(t, logs, "The post-checkout hook ran!")
+}
+
 func TestChown(t *testing.T) {
 	tc := testcase{
 		T:       t,


### PR DESCRIPTION
This implements the suggestion of @moskyb in #239

> wrt. plugin hooks not firing, i believe this can be fixed by changing [this line](https://github.com/buildkite/agent-stack-k8s/blob/main/internal/controller/scheduler/scheduler.go#L405) to Value: "plugin,checkout", - this will make the checkout container check out and execute plugins hooks, though only for the environment and (pre-, post- ) checkout hooks.

henceforth people won't have to fork the stack in order to enable plugins in the checkout container. This should address #227 as well - a plugin with a checkout hook should be able to customise the checkout.

Note there is still no way to customise the specifics (that should be coming with PodSpecPatch™ #282)

In case of other plugins, this PR removes the need to check out plugins in the command container, since plugins are enabled in the checkout container and saved in `/workspace/plugins` instead of `/tmp`. This should allow the use of command container images that don't contain `git` in that scenario.

The integration test uses improbable-eng/metahook (awesome!). Although only two hooks are set (`pre-checkout`, `post-checkout`), metahook hooks almost everything, and its hooks all start with `#!/usr/bin/env bash`. So the integration test needs a command container image with bash in it.
