### PR TITLE
Use same agent image version as in go.mod

### DIFF
--- a/.buildkite/steps/agent.sh
+++ b/.buildkite/steps/agent.sh
@@ -7,8 +7,12 @@ apk add --update-cache --no-progress skopeo
 
 repo="docker.io/buildkite/agent"
 
+echo --- Awking go.mod for agent version
+agent_version="$(awk '/github\.com\/buildkite\/agent\/v3/ { print $2 }' go.mod | cut -c 2- )"
+echo "Using agent version ${agent_version} as image tag"
+
 echo --- :docker: Inspecting agent docker image manifest
-digest=$(skopeo inspect "docker://${repo}:stable" --format {{.Digest}})
+digest=$(skopeo inspect "docker://${repo}:${agent_version}" --format {{.Digest}})
 
 echo Choosing image "${repo}@${digest}"
 buildkite-agent meta-data set agent-image "${repo}@${digest}"


### PR DESCRIPTION
Using the `stable` tag for choosing the agent image is reasonable, but not great for reproducibility. It'd be better to pin the agent version used to find the agent container image. Since the stack has a Go module dependency on the agent, we can use that as the agent image tag (this keeps them consistent).