### PR TITLE
Enable plugin phase in checkout container (take 2)

### DIFF
--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -283,6 +283,10 @@ func (w *jobWrapper) Build(skipCheckout bool) (*batchv1.Job, error) {
 			Value: w.envMap["BUILDKITE_ARTIFACT_PATHS"],
 		},
 		{
+			Name:  "BUILDKITE_PLUGINS_PATH",
+			Value: "/workspace/plugins",
+		},
+		{
 			Name:  "BUILDKITE_SOCKETS_PATH",
 			Value: "/workspace/sockets",
 		},
@@ -523,7 +527,7 @@ func (w *jobWrapper) createCheckoutContainer(
 			},
 			{
 				Name:  "BUILDKITE_BOOTSTRAP_PHASES",
-				Value: "checkout",
+				Value: "plugin,checkout",
 			},
 			{
 				Name:  "BUILDKITE_AGENT_NAME",
@@ -532,6 +536,10 @@ func (w *jobWrapper) createCheckoutContainer(
 			{
 				Name:  "BUILDKITE_CONTAINER_ID",
 				Value: "0",
+			},
+			{
+				Name:  "BUILDKITE_PLUGINS_PATH",
+				Value: "/workspace/plugins",
 			},
 		},
 		EnvFrom: w.k8sPlugin.GitEnvFrom,

--- a/internal/integration/fixtures/plugin-checkout-hook.yaml
+++ b/internal/integration/fixtures/plugin-checkout-hook.yaml
@@ -1,0 +1,21 @@
+steps:
+  - label: ":earth_asia:"
+    agents:
+      queue: {{.queue}}
+    env:
+      BUILDKITE_SHELL: /bin/sh -ec
+    plugins:
+      - improbable-eng/metahook#v0.4.1:
+          pre-checkout: echo The pre-checkout hook ran!
+          post-checkout: echo The post-checkout hook ran!
+      - kubernetes:
+          podSpec:
+            containers:
+              # A container with Bash is needed to run the metahook hooks
+              # (that are empty, because only pre- and post-checkout are set).
+              - image: bash:latest
+                command:
+                - echo
+                args:
+                - >-
+                  The command ran!

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -147,6 +147,26 @@ func TestControllerSetsAdditionalRedactedVars(t *testing.T) {
 	assert.NotContains(t, logs, "white pepper and 10 others")
 }
 
+func TestPrePostCheckoutHooksRun(t *testing.T) {
+	tc := testcase{
+		T:       t,
+		Fixture: "plugin-checkout-hook.yaml",
+		Repo:    repoHTTP,
+		GraphQL: api.NewClient(cfg.BuildkiteToken),
+	}.Init()
+
+	ctx := context.Background()
+	pipelineID, cleanup := tc.CreatePipeline(ctx)
+	t.Cleanup(cleanup)
+
+	tc.StartController(ctx, cfg)
+	build := tc.TriggerBuild(ctx, pipelineID)
+	tc.AssertSuccess(ctx, build)
+	logs := tc.FetchLogs(build)
+	assert.Contains(t, logs, "The pre-checkout hook ran!")
+	assert.Contains(t, logs, "The post-checkout hook ran!")
+}
+
 func TestChown(t *testing.T) {
 	tc := testcase{
 		T:       t,


### PR DESCRIPTION
With agent v3.68.0, the plugins we use in our own CI shouldn't try to execute pre-exit hooks in the checkout container.

Reverts #285 (effectively a repeat of #281)