### PR TITLE
Fix resource.Quantity parsing

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"reflect"
 	"strings"
 	"time"
 
@@ -22,6 +23,7 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/client-go/kubernetes"
 	restconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
@@ -121,15 +123,40 @@ func ReadConfigFromFileArgsAndEnv(cmd *cobra.Command, args []string) (*viper.Vip
 	return v, nil
 }
 
+var resourceQuantityType = reflect.TypeOf(resource.Quantity{})
+
+// This mapstructure.DecodeHookFunc is needed to decode quantities (as used in
+// podSpecs) properly. Without this, viper (which uses mapstructure) doesn't
+// know how to put a string (e.g. "100m") into a "map" (resource.Quantity) and
+// will error out.
+func stringToResourceQuantity(f, t reflect.Type, data any) (any, error) {
+	if f.Kind() != reflect.String {
+		return data, nil
+	}
+	if t != resourceQuantityType {
+		return data, nil
+	}
+	return resource.ParseQuantity(data.(string))
+}
+
+// This viper.DecoderConfigOption is needed to make mapstructure (used by viper)
+// use the same struct tags that the k8s libraries provide.
+func useJSONTagForDecoder(c *mapstructure.DecoderConfig) {
+	c.TagName = "json"
+}
+
 // ParseAndValidateConfig parses the config into a struct and validates the values.
 func ParseAndValidateConfig(v *viper.Viper) (*config.Config, error) {
 	// We want to let the user know if they have any extra fields, so use UnmarshalExact.
 	// The user likely expects every part of their config to be meaningful, so if some of it is
 	// ignored in parsing, they almost certainly want to know about it.
 	cfg := &config.Config{}
-	if err := v.UnmarshalExact(cfg, func(c *mapstructure.DecoderConfig) {
-		c.TagName = "json"
-	}); err != nil {
+	decodeHook := viper.DecodeHook(mapstructure.ComposeDecodeHookFunc(
+		stringToResourceQuantity,
+		mapstructure.StringToTimeDurationHookFunc(),
+		mapstructure.StringToSliceHookFunc(","),
+	))
+	if err := v.UnmarshalExact(cfg, useJSONTagForDecoder, decodeHook); err != nil {
 		return nil, fmt.Errorf("failed to parse config: %w", err)
 	}
 

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -151,6 +151,8 @@ func ParseAndValidateConfig(v *viper.Viper) (*config.Config, error) {
 	// The user likely expects every part of their config to be meaningful, so if some of it is
 	// ignored in parsing, they almost certainly want to know about it.
 	cfg := &config.Config{}
+	// This decode hook = the default Viper decode hooks + stringToResourceQuantity
+	// (Setting this option overrides the default.)
 	decodeHook := viper.DecodeHook(mapstructure.ComposeDecodeHookFunc(
 		stringToResourceQuantity,
 		mapstructure.StringToTimeDurationHookFunc(),

--- a/cmd/controller/controller_test.go
+++ b/cmd/controller/controller_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 func ptr[T any](v T) *T {
@@ -44,6 +45,15 @@ func TestReadAndParseConfig(t *testing.T) {
 									Key: "github-token",
 								},
 							},
+						},
+					},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							"cpu": resource.MustParse("100m"),
+							"mem": resource.MustParse("50Mi"),
+						},
+						Limits: corev1.ResourceList{
+							"mem": resource.MustParse("1Gi"),
 						},
 					},
 				},

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -27,3 +27,9 @@ pod-spec-patch:
         secretKeyRef:
           name: github-secrets
           key: github-token
+    resources:
+      requests:
+        cpu: 100m
+        mem: 50Mi
+      limits:
+        mem: 1Gi


### PR DESCRIPTION
Fixes #293

Fortunately this error was easy enough to replicate without Helm or having to set up a local registry: `just run --org (org) --buildkite-token (token) --debug -f config.yaml` where config.yaml was:

```yaml
pod-spec-patch:
  containers:
    - name: container-0
      resources:
        requests:
          cpu: 100m
```


For parsing our config once the controller starts, Viper gets the first bite (pun intended), and it uses mapstructure. Immediately before the failing call (`v.UnmarshalExact(...)`), Viper contains something like (obtained with `v.Debug()`):

```
Config:
map[string]interface {}{"pod-spec-patch":map[string]interface {}{"containers":[]interface {}{map[string]interface {}{"name":"container-0", "resources":map[string]interface {}{"requests":map[string]interface {}{"cpu":"100m"}}}}}}
```

Viper doesn't know how to put `"100m"` into a `resource.Quantity`. `resource.Quantity` knows how to unmarshal itself from JSON, but neither mapstructure nor Viper call that. Instead we must alter the decode hook used by Viper from its default (that conveniently understands `time.Duration` strings and comma-separated lists).