### PR TITLE
[WIP] Pass a pre-bootstrap hook into agent server container

### DIFF
--- a/charts/agent-stack-k8s/templates/config.yaml.tpl
+++ b/charts/agent-stack-k8s/templates/config.yaml.tpl
@@ -8,3 +8,6 @@ data:
     agent-token-secret: {{ if .Values.agentStackSecret }}{{ .Values.agentStackSecret }}{{ else }}{{ .Release.Name }}-secrets{{ end }}
     namespace: {{ .Release.Namespace }}
     {{- .Values.config | toYaml | nindent 4 }}
+  {{ with .Files.Get "pre-bootstrap" -}}
+  pre-bootstrap: |-
+    {{- . | nindent 4 }}{{ end }}

--- a/charts/agent-stack-k8s/templates/deployment.yaml.tpl
+++ b/charts/agent-stack-k8s/templates/deployment.yaml.tpl
@@ -31,9 +31,12 @@ spec:
           - secretRef:
               name: {{ if .Values.agentStackSecret }}{{ .Values.agentStackSecret }}{{ else }}{{ .Release.Name }}-secrets{{ end }}
         volumeMounts:
-          - name: config
+          - name: config-volume
             mountPath: /etc/config.yaml
             subPath: config.yaml
+          - name: config-volume
+            mountPath: /etc/buildkite-agent/hooks/pre-bootstrap
+            subPath: pre-bootstrap
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
         securityContext:
@@ -46,6 +49,6 @@ spec:
           seccompProfile:
             type: RuntimeDefault
       volumes:
-        - name: config
+        - name: config-volume
           configMap:
             name: {{ .Release.Name }}-config

--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -278,10 +278,6 @@ func (w *jobWrapper) Build(skipCheckout bool) (*batchv1.Job, error) {
 			Value: "buildkite",
 		},
 		{
-			Name:  "BUILDKITE_PLUGINS_PATH",
-			Value: "/tmp",
-		},
-		{
 			Name:  clicommand.RedactedVars.EnvVar,
 			Value: strings.Join(redactedVars, ","),
 		},


### PR DESCRIPTION
The more reliable approach is to build a container image containing the hooks you want and then set `BUILDKITE_HOOKS_PATH`.

But if that's too much work, a pre-bootstrap script might be small enough to smuggle through a configMap object, and this provides a way to do that.