### PR TITLE
Remove duplicate BUILDKITE_PLUGINS_PATH

### DIFF
--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -278,10 +278,6 @@ func (w *jobWrapper) Build(skipCheckout bool) (*batchv1.Job, error) {
 			Value: "buildkite",
 		},
 		{
-			Name:  "BUILDKITE_PLUGINS_PATH",
-			Value: "/tmp",
-		},
-		{
 			Name:  clicommand.RedactedVars.EnvVar,
 			Value: strings.Join(redactedVars, ","),
 		},


### PR DESCRIPTION
The later one overrides the previous one, so it can be safely removed.