### PR TITLE
[WIP] Pre-schedule hook

### DIFF
--- a/charts/agent-stack-k8s/templates/config.yaml.tpl
+++ b/charts/agent-stack-k8s/templates/config.yaml.tpl
@@ -9,4 +9,4 @@ data:
     namespace: {{ .Release.Namespace }}
     {{- .Values.config | toYaml | nindent 4 }}
   pre-schedule: |
-    {{- .Values.pre-schedule | nindent 4 }}
+    {{- index .Values "pre-schedule" | nindent 4 }}

--- a/charts/agent-stack-k8s/templates/config.yaml.tpl
+++ b/charts/agent-stack-k8s/templates/config.yaml.tpl
@@ -8,3 +8,5 @@ data:
     agent-token-secret: {{ if .Values.agentStackSecret }}{{ .Values.agentStackSecret }}{{ else }}{{ .Release.Name }}-secrets{{ end }}
     namespace: {{ .Release.Namespace }}
     {{- .Values.config | toYaml | nindent 4 }}
+  pre-schedule: |
+    {{- .Values.pre-schedule | nindent 4 }}

--- a/charts/agent-stack-k8s/templates/deployment.yaml.tpl
+++ b/charts/agent-stack-k8s/templates/deployment.yaml.tpl
@@ -26,14 +26,17 @@ spec:
         image: {{ .Values.image }}
         env:
         - name: CONFIG
-          value: /etc/config.yaml
+          value: /etc/agent-stack-k8s/config.yaml
         envFrom:
           - secretRef:
               name: {{ if .Values.agentStackSecret }}{{ .Values.agentStackSecret }}{{ else }}{{ .Release.Name }}-secrets{{ end }}
         volumeMounts:
           - name: config
-            mountPath: /etc/config.yaml
+            mountPath: /etc/agent-stack-k8s/config.yaml
             subPath: config.yaml
+          - name: config
+            mountPath: /etc/agent-stack-k8s/pre-schedule
+            subPath: pre-schedule
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
         securityContext:
@@ -49,3 +52,9 @@ spec:
         - name: config
           configMap:
             name: {{ .Release.Name }}-config
+            items:
+              - key: config.yaml
+                path: config.yaml
+              - key: pre-schedule
+                path: pre-schedule
+                mode: 0755

--- a/charts/agent-stack-k8s/templates/deployment.yaml.tpl
+++ b/charts/agent-stack-k8s/templates/deployment.yaml.tpl
@@ -31,10 +31,12 @@ spec:
           - secretRef:
               name: {{ if .Values.agentStackSecret }}{{ .Values.agentStackSecret }}{{ else }}{{ .Release.Name }}-secrets{{ end }}
         volumeMounts:
-          - name: config
+          - name: tmp-volume
+            mountPath: /tmp
+          - name: config-volume
             mountPath: /etc/agent-stack-k8s/config.yaml
             subPath: config.yaml
-          - name: config
+          - name: config-volume
             mountPath: /etc/agent-stack-k8s/pre-schedule
             subPath: pre-schedule
         resources:
@@ -49,7 +51,11 @@ spec:
           seccompProfile:
             type: RuntimeDefault
       volumes:
-        - name: config
+        - name: tmp-volume
+          emptyDir:
+            medium: Memory
+            sizeLimit: 100Mi
+        - name: config-volume
           configMap:
             name: {{ .Release.Name }}-config
             items:

--- a/charts/agent-stack-k8s/values.schema.json
+++ b/charts/agent-stack-k8s/values.schema.json
@@ -153,6 +153,12 @@
         }
       ]
     },
+    "pre-schedule": {
+      "type": "string",
+      "default": "",
+      "title": "The pre-schedule hook",
+      "examples": [""]
+    },
     "config": {
       "type": "object",
       "default": {},
@@ -216,6 +222,12 @@
         },
         "pod-spec-patch": {
           "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.PodSpec"
+        },
+        "pre-schedule-hook-path": {
+          "type": "string",
+          "default": "/etc/agent-stack-k8s/pre-schedule",
+          "title": "Path to a pre-schedule hook within the controller container",
+          "examples": ["/etc/agent-stack-k8s/pre-schedule"]
         }
       },
       "examples": [

--- a/charts/agent-stack-k8s/values.yaml
+++ b/charts/agent-stack-k8s/values.yaml
@@ -17,3 +17,5 @@ labels: {}
 secretsMetadata: {}
 
 serviceAccountMetadata: {}
+
+pre-schedule: ""

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -77,6 +77,11 @@ func AddConfigFlags(cmd *cobra.Command) {
 		"",
 		"Bind address to expose the pprof profiler (e.g. localhost:6060)",
 	)
+	cmd.Flags().String(
+		"pre-schedule-hook-path",
+		config.DefaultPreScheduleHookPath,
+		"Path to a script that is executed prior to scheduling containers",
+	)
 }
 
 // ReadConfigFromFileArgsAndEnv reads the config from the file, env and args in that order.

--- a/cmd/controller/controller_test.go
+++ b/cmd/controller/controller_test.go
@@ -18,16 +18,17 @@ func ptr[T any](v T) *T {
 
 func TestReadAndParseConfig(t *testing.T) {
 	expected := config.Config{
-		Debug:            true,
-		AgentTokenSecret: "my-kubernetes-secret",
-		BuildkiteToken:   "my-graphql-enabled-token",
-		Image:            "my.registry.dev/buildkite-agent:latest",
-		JobTTL:           300 * time.Second,
-		MaxInFlight:      100,
-		Namespace:        "my-buildkite-ns",
-		Org:              "my-buildkite-org",
-		Tags:             []string{"queue=my-queue", "priority=high"},
-		ClusterUUID:      "beefcafe-abbe-baba-abba-deedcedecade",
+		Debug:               true,
+		AgentTokenSecret:    "my-kubernetes-secret",
+		BuildkiteToken:      "my-graphql-enabled-token",
+		Image:               "my.registry.dev/buildkite-agent:latest",
+		JobTTL:              300 * time.Second,
+		MaxInFlight:         100,
+		Namespace:           "my-buildkite-ns",
+		Org:                 "my-buildkite-org",
+		Tags:                []string{"queue=my-queue", "priority=high"},
+		ClusterUUID:         "beefcafe-abbe-baba-abba-deedcedecade",
+		PreScheduleHookPath: "/etc/agent-stack-k8s/pre-schedule",
 		PodSpecPatch: &corev1.PodSpec{
 			ServiceAccountName:           "buildkite-agent-sa",
 			AutomountServiceAccountToken: ptr(true),

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -9,10 +9,11 @@ import (
 )
 
 const (
-	UUIDLabel          = "buildkite.com/job-uuid"
-	BuildURLAnnotation = "buildkite.com/build-url"
-	JobURLAnnotation   = "buildkite.com/job-url"
-	DefaultNamespace   = "default"
+	UUIDLabel                  = "buildkite.com/job-uuid"
+	BuildURLAnnotation         = "buildkite.com/build-url"
+	JobURLAnnotation           = "buildkite.com/job-url"
+	DefaultNamespace           = "default"
+	DefaultPreScheduleHookPath = "/etc/agent-stack-k8s/pre-schedule"
 )
 
 var DefaultAgentImage = "ghcr.io/buildkite/agent:" + version.Version()
@@ -34,6 +35,7 @@ type Config struct {
 	ClusterUUID            string          `json:"cluster-uuid"             validate:"omitempty"`
 	AdditionalRedactedVars stringSlice     `json:"additional-redacted-vars" validate:"omitempty"`
 	PodSpecPatch           *corev1.PodSpec `json:"pod-spec-patch"           validate:"omitempty"`
+	PreScheduleHookPath    string          `json:"pre-schedule-hook-path"   validate:"omitempty"`
 }
 
 type stringSlice []string
@@ -55,6 +57,7 @@ func (c Config) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	enc.AddString("org", c.Org)
 	enc.AddString("profiler-address", c.ProfilerAddress)
 	enc.AddString("cluster-uuid", c.ClusterUUID)
+	enc.AddString("pre-schedule-hook-path", c.PreScheduleHookPath)
 	if err := enc.AddArray("additional-redacted-vars", c.AdditionalRedactedVars); err != nil {
 		return err
 	}

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -55,6 +55,7 @@ func Run(
 		JobTTL:                 cfg.JobTTL,
 		AdditionalRedactedVars: cfg.AdditionalRedactedVars,
 		PodSpecPatch:           cfg.PodSpecPatch,
+		PreScheduleHookPath:    cfg.PreScheduleHookPath,
 	})
 	limiter := scheduler.NewLimiter(logger.Named("limiter"), sched, cfg.MaxInFlight)
 

--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -718,7 +718,7 @@ func (w *worker) runPreScheduleHook(ctx context.Context, logger *zap.Logger, job
 	logger.Debug("runPreScheduleHook")
 	hookPath := w.cfg.PreScheduleHookPath
 	if hookPath == "" {
-		w.logger.Debug("no pre-schedule hook configured, skipping")
+		logger.Debug("no pre-schedule hook configured, skipping")
 		return nil
 	}
 
@@ -726,6 +726,8 @@ func (w *worker) runPreScheduleHook(ctx context.Context, logger *zap.Logger, job
 	if err != nil {
 		return fmt.Errorf("reading pre-schedule hook: %w", err)
 	}
+	logger.Debug("pre-schedule hook content", zap.ByteString("hookContent", hookContent))
+
 	if len(bytes.TrimSpace(hookContent)) == 0 {
 		// The hook is empty - skip running it.
 		logger.Debug("pre-schedule hook is empty, skipping")

--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -86,10 +86,12 @@ func (w *worker) Create(ctx context.Context, job *api.CommandJob) error {
 	jobWrapper := NewJobWrapper(w.logger, job, w.cfg)
 
 	if err := w.runPreScheduleHook(ctx, logger, job); err != nil {
+		logger.Warn("Pre-schedule hook failed, creating failure job instead", zap.Error(err))
 		return w.buildAndCreateFallbackJob(ctx, jobWrapper, err)
 	}
 
 	if err := jobWrapper.ParsePlugins(); err != nil {
+		logger.Warn("Plugin parsing failed, creating failure job instead", zap.Error(err))
 		return w.buildAndCreateFallbackJob(ctx, jobWrapper, err)
 	}
 
@@ -101,6 +103,7 @@ func (w *worker) Create(ctx context.Context, job *api.CommandJob) error {
 
 	err = w.createJob(ctx, kjob)
 	if kerrors.IsInvalid(err) {
+		logger.Warn("Job creation failed, creating failure job instead", zap.Error(err))
 		return w.buildAndCreateFallbackJob(ctx, jobWrapper, err)
 	}
 	return err

--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -757,5 +757,6 @@ func (w *worker) runPreScheduleHook(ctx context.Context, logger *zap.Logger, job
 	if len(out) > 0 {
 		logger.Info("pre-schedule hook output", zap.ByteString("combinedOutput", out))
 	}
+	logger.Debug("pre-schedule hook succeeded")
 	return nil
 }

--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -284,10 +284,6 @@ func (w *jobWrapper) Build(skipCheckout bool) (*batchv1.Job, error) {
 			Value: "buildkite",
 		},
 		{
-			Name:  "BUILDKITE_PLUGINS_PATH",
-			Value: "/tmp",
-		},
-		{
 			Name:  clicommand.RedactedVars.EnvVar,
 			Value: strings.Join(redactedVars, ","),
 		},

--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -737,6 +737,7 @@ func (w *worker) runPreScheduleHook(ctx context.Context, logger *zap.Logger, job
 	if err != nil {
 		return fmt.Errorf("creating temp job definition file: %w", err)
 	}
+	logger.Debug("created temp file", zap.String("path", jobOut.Name()))
 	defer os.Remove(jobOut.Name())
 	defer jobOut.Close()
 
@@ -746,6 +747,7 @@ func (w *worker) runPreScheduleHook(ctx context.Context, logger *zap.Logger, job
 	if err := jobOut.Close(); err != nil {
 		return fmt.Errorf("closing temp job definition file: %w", err)
 	}
+	logger.Debug("wrote temp file successfully", zap.String("path", jobOut.Name()))
 
 	// Execute the hook directly.
 	cmd := exec.CommandContext(ctx, hookPath, jobOut.Name())

--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -721,9 +721,17 @@ func (w *worker) runPreScheduleHook(ctx context.Context, logger *zap.Logger, job
 		return nil
 	}
 
+	hookInfo, err := os.Stat(hookPath)
+	if err != nil {
+		logger.Debug("failed to stat pre-schedule hook", zap.Error(err))
+		return fmt.Errorf("stat pre-schedule hook: %w", err)
+	}
+
+	logger.Debug("pre-schedule hook file mode", zap.String("mode", strconv.FormatUint(uint64(hookInfo.Mode()), 8)))
+
 	hookContent, err := os.ReadFile(hookPath)
 	if err != nil {
-		logger.Debug("reading pre-schedule hook", zap.String("hookPath", hookPath), zap.Error(err))
+		logger.Debug("failed to read pre-schedule hook", zap.String("hookPath", hookPath), zap.Error(err))
 		return fmt.Errorf("reading pre-schedule hook: %w", err)
 	}
 	logger.Debug("pre-schedule hook content", zap.ByteString("hookContent", hookContent))

--- a/internal/controller/scheduler/scheduler_test.go
+++ b/internal/controller/scheduler/scheduler_test.go
@@ -158,7 +158,9 @@ func TestJobPluginConversion(t *testing.T) {
 		input,
 		scheduler.Config{AgentToken: "token-secret"},
 	)
-	result, err := wrapper.ParsePlugins().Build(false)
+	err = wrapper.ParsePlugins()
+	require.NoError(t, err)
+	result, err := wrapper.Build(false)
 	require.NoError(t, err)
 
 	assert.Len(t, result.Spec.Template.Spec.Containers, 3)
@@ -217,7 +219,9 @@ func TestTagEnv(t *testing.T) {
 		AgentQueryRules: []string{"queue=kubernetes"},
 	}
 	wrapper := scheduler.NewJobWrapper(logger, input, scheduler.Config{AgentToken: "token-secret"})
-	result, err := wrapper.ParsePlugins().Build(false)
+	err = wrapper.ParsePlugins()
+	require.NoError(t, err)
+	result, err := wrapper.Build(false)
 	require.NoError(t, err)
 
 	container := findContainer(t, result.Spec.Template.Spec.Containers, "agent")
@@ -247,7 +251,9 @@ func TestJobWithNoKubernetesPlugin(t *testing.T) {
 		AgentQueryRules: []string{},
 	}
 	wrapper := scheduler.NewJobWrapper(zaptest.NewLogger(t), input, scheduler.Config{})
-	result, err := wrapper.ParsePlugins().Build(false)
+	err := wrapper.ParsePlugins()
+	require.NoError(t, err)
+	result, err := wrapper.Build(false)
 	require.NoError(t, err)
 
 	require.Len(t, result.Spec.Template.Spec.Containers, 3)
@@ -300,8 +306,9 @@ func TestBuild(t *testing.T) {
 				},
 			},
 		},
-	).ParsePlugins()
-
+	)
+	err = wrapper.ParsePlugins()
+	require.NoError(t, err)
 	job, err := wrapper.Build(false)
 	require.NoError(t, err)
 
@@ -349,8 +356,9 @@ func TestBuildSkipCheckout(t *testing.T) {
 			Image:      "buildkite/agent:latest",
 			AgentToken: "bkcq_1234567890",
 		},
-	).ParsePlugins()
-
+	)
+	err = wrapper.ParsePlugins()
+	require.NoError(t, err)
 	job, err := wrapper.Build(false)
 	require.NoError(t, err)
 
@@ -383,7 +391,7 @@ func TestFailureJobs(t *testing.T) {
 		AgentQueryRules: []string{"queue=kubernetes"},
 	}
 	wrapper := scheduler.NewJobWrapper(zaptest.NewLogger(t), input, scheduler.Config{})
-	_, err = wrapper.ParsePlugins().Build(false)
+	err = wrapper.ParsePlugins()
 	require.Error(t, err)
 
 	result, err := wrapper.BuildFailureJob(err)

--- a/internal/integration/fixtures/pre-schedule
+++ b/internal/integration/fixtures/pre-schedule
@@ -1,0 +1,8 @@
+#!/bin/sh
+echo "This is a pre-schedule hook."
+echo "Here's the job definition:"
+cat "${BUILDKITE_JOB_DEFINITION}"
+echo "Any job containing a particular test string will be rejected."
+EICAR_FP='EICAR-STANDARD-ANTIVIRUS-TEST-FILE'
+grep -q "${EICAR_FP}" "${BUILDKITE_JOB_DEFINITION}" && exit 1
+exit 0

--- a/internal/integration/fixtures/pre-schedule-reject.yaml
+++ b/internal/integration/fixtures/pre-schedule-reject.yaml
@@ -1,0 +1,12 @@
+steps:
+  - label: ":skull_and_crossbones:"
+    agents:
+      queue: {{.queue}}
+    plugins:
+      - kubernetes:
+          podSpec:
+            containers:
+              # This container is harmless, but should be rejected by the pre-schedule hook.
+              - image: alpine:latest
+                command: [echo]
+                args: ['X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*']

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -221,6 +221,23 @@ func TestPluginCloneFailsTests(t *testing.T) {
 	tc.AssertFail(ctx, build)
 }
 
+func TestPreScheduleHookRejectsJob(t *testing.T) {
+	tc := testcase{
+		T:       t,
+		Fixture: "pre-schedule-reject.yaml",
+		Repo:    repoHTTP,
+		GraphQL: api.NewClient(cfg.BuildkiteToken),
+	}.Init()
+
+	ctx := context.Background()
+
+	pipelineID, cleanup := tc.CreatePipeline(ctx)
+	t.Cleanup(cleanup)
+	tc.StartController(ctx, cfg)
+	build := tc.TriggerBuild(ctx, pipelineID)
+	tc.AssertFail(ctx, build)
+}
+
 func TestMaxInFlightLimited(t *testing.T) {
 	tc := testcase{
 		T:       t,

--- a/internal/integration/testcase_test.go
+++ b/internal/integration/testcase_test.go
@@ -105,6 +105,7 @@ func (t testcase) StartController(ctx context.Context, cfg config.Config) {
 	runCtx, cancel := context.WithCancel(ctx)
 	EnsureCleanup(t.T, cancel)
 
+	cfg.PreScheduleHookPath = "fixtures/pre-schedule"
 	cfg.Tags = []string{fmt.Sprintf("queue=%s", t.ShortPipelineName())}
 	cfg.Debug = true
 


### PR DESCRIPTION
**WIP**: This currently doesn't work. The controller container simply doesn't have permissions to execute a script. (That sounds sensible actually?) So it will have to go in another container.

---

The stack can configure the agent to run hooks easily. In fact the agent container ships with a config file that sets the hook path to `/buildkite/hooks`, so one merely need mount some hooks at that path and the agent will run them, including `pre-bootstrap`.

However, with `podSpecPatch`, a pipeline can trivially override the hooks path (e.g. setting a `BUILDKITE_HOOKS_PATH` env var) which would disable `pre-bootstrap` being run. So `pre-bootstrap` no longer works as a mechanism to check jobs before running.

This PR adds a new special hook for the k8s controller: `pre-schedule`. Similar to `pre-bootstrap` it has the ability to inspect the job the controller is about to schedule a pod for. Rather than "env var" form, I've opted to dump the whole job as JSON.

Since this happens in the scheduler, I've gone ahead with a long-desired refactor of some of the scheduler methods to eliminate the `err` struct field.