### PR TITLE
PENT-29 update the help text to for image 

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Flags:
   -f, --config string               config file path
       --debug                       debug logs
   -h, --help                        help for agent-stack-k8s
-      --image string                The image to use for the Buildkite agent (default "ghcr.io/buildkite/agent-stack-k8s/agent:latest")
+      --image string                The image to use for the controller (default "ghcr.io/buildkite/agent-stack-k8s/agent:latest")
       --job-ttl duration            time to retain kubernetes jobs after completion (default 10m0s)
       --max-in-flight int           max jobs in flight, 0 means no max (default 25)
       --namespace string            kubernetes namespace to create resources in (default "default")

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -48,7 +48,7 @@ func AddConfigFlags(cmd *cobra.Command) {
 	cmd.Flags().String(
 		"image",
 		config.DefaultAgentImage,
-		"The image to use for the Buildkite agent",
+		"The image to use for the controller",
 	)
 	cmd.Flags().StringSlice(
 		"tags",


### PR DESCRIPTION
Description
Customer requested the `agent-stack-k8s --help image` text be clearer . The customer thought using --set image they could  add custom hooks to the agent image without updating the controller pod

Linear https://linear.app/buildkite/issue/PENT-29/clarify-help-text-in-agent-stack-k8s

@DrJosh9000 not sure if this is all that is required for this one. 