### PR TITLE
Fix custom namespace deploy Role errors in RBAC

### DIFF
--- a/charts/agent-stack-k8s/templates/rbac.yaml.tpl
+++ b/charts/agent-stack-k8s/templates/rbac.yaml.tpl
@@ -2,6 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   {{- include "agent-stack-k8s.serviceAccountMetadata" . | nindent 2 }}
+  namespace: {{ .Release.Namespace }}
 rules:
   - apiGroups:
       - batch


### PR DESCRIPTION
Deploying v0.11.0 to custom namespace results in an error:

```js
W0516 23:52:47.169746       1 reflector.go:539] k8s.io/client-go@v0.29.3/tools/cache/reflector.go:229: 
failed to list *v1.Job: jobs.batch is forbidden: User "system:serviceaccount:my-namespace:my-deploy-name-v1-controller" cannot list resource "jobs" in API group "batch" in the namespace "my-namespace"
```

The Role in RBAC [should be bound to a namespace](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole), however declaring `namespace` via `serviceAccountMetadata` (which gets [injected into the Role](https://github.com/buildkite/agent-stack-k8s/blob/666b59ed07a3cc2416305fbffbde7b03e4f2e265/charts/agent-stack-k8s/templates/rbac.yaml.tpl#L4)) is [specifically not allowed](https://github.com/buildkite/agent-stack-k8s/blob/fc79e8036ea425b2f3f1bf1ba0eeb5ff03833ba8/charts/agent-stack-k8s/values.schema.json#L98).

To be honest I'm baffled at how is deploy was supposed to work for users with custom namespace, does everyone deploy to a default namespace or am I missing something? 🤔 