### PR TITLE
Fix custom namespace deploy errors in RBAC RoleBinding

### DIFF
--- a/charts/agent-stack-k8s/templates/rbac.yaml.tpl
+++ b/charts/agent-stack-k8s/templates/rbac.yaml.tpl
@@ -26,6 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role


### PR DESCRIPTION
Deploying v0.11.0 to custom namespace results in an error:

```js
W0516 23:52:47.169746       1 reflector.go:539] k8s.io/client-go@v0.29.3/tools/cache/reflector.go:229: 
failed to list *v1.Job: jobs.batch is forbidden: User "system:serviceaccount:my-namespace:my-deploy-name-v1-controller" cannot list resource "jobs" in API group "batch" in the namespace "my-namespace"
```

The RoleBinding in RBAC [should be bound to a namespace](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#rolebinding-and-clusterrolebinding).

To be honest I'm baffled at how is deploy was supposed to work for users with custom namespace, does everyone deploy to a default namespace or am I missing something? 🤔 