### PR TITLE
Make imagePullBackOffWatcher grace period configurable

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -78,9 +78,9 @@ func AddConfigFlags(cmd *cobra.Command) {
 		"Bind address to expose the pprof profiler (e.g. localhost:6060)",
 	)
 	cmd.Flags().Duration(
-		"startup-grace-period",
-		config.DefaultStartupGracePeriod,
-		"Duration after starting a pod that the controller will wait before considering cancelling a job (e.g. when the podSpec specifies container images that cannot be pulled)",
+		"image-pull-backoff-grace-period",
+		config.DefaultImagePullBackOffGracePeriod,
+		"Duration after starting a pod that the controller will wait before considering cancelling a job due to ImagePullBackOff (e.g. when the podSpec specifies container images that cannot be pulled)",
 	)
 }
 

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -77,6 +77,11 @@ func AddConfigFlags(cmd *cobra.Command) {
 		"",
 		"Bind address to expose the pprof profiler (e.g. localhost:6060)",
 	)
+	cmd.Flags().Duration(
+		"startup-grace-period",
+		config.DefaultStartupGracePeriod,
+		"Duration after starting a pod that the controller will wait before considering cancelling a job (e.g. when the podSpec specifies container images that cannot be pulled)",
+	)
 }
 
 // ReadConfigFromFileArgsAndEnv reads the config from the file, env and args in that order.

--- a/cmd/controller/controller_test.go
+++ b/cmd/controller/controller_test.go
@@ -18,17 +18,17 @@ func ptr[T any](v T) *T {
 
 func TestReadAndParseConfig(t *testing.T) {
 	expected := config.Config{
-		Debug:              true,
-		AgentTokenSecret:   "my-kubernetes-secret",
-		BuildkiteToken:     "my-graphql-enabled-token",
-		Image:              "my.registry.dev/buildkite-agent:latest",
-		JobTTL:             300 * time.Second,
-		StartupGracePeriod: 60 * time.Second,
-		MaxInFlight:        100,
-		Namespace:          "my-buildkite-ns",
-		Org:                "my-buildkite-org",
-		Tags:               []string{"queue=my-queue", "priority=high"},
-		ClusterUUID:        "beefcafe-abbe-baba-abba-deedcedecade",
+		Debug:                       true,
+		AgentTokenSecret:            "my-kubernetes-secret",
+		BuildkiteToken:              "my-graphql-enabled-token",
+		Image:                       "my.registry.dev/buildkite-agent:latest",
+		JobTTL:                      300 * time.Second,
+		ImagePullBackOffGradePeriod: 60 * time.Second,
+		MaxInFlight:                 100,
+		Namespace:                   "my-buildkite-ns",
+		Org:                         "my-buildkite-org",
+		Tags:                        []string{"queue=my-queue", "priority=high"},
+		ClusterUUID:                 "beefcafe-abbe-baba-abba-deedcedecade",
 		PodSpecPatch: &corev1.PodSpec{
 			ServiceAccountName:           "buildkite-agent-sa",
 			AutomountServiceAccountToken: ptr(true),

--- a/cmd/controller/controller_test.go
+++ b/cmd/controller/controller_test.go
@@ -18,16 +18,17 @@ func ptr[T any](v T) *T {
 
 func TestReadAndParseConfig(t *testing.T) {
 	expected := config.Config{
-		Debug:            true,
-		AgentTokenSecret: "my-kubernetes-secret",
-		BuildkiteToken:   "my-graphql-enabled-token",
-		Image:            "my.registry.dev/buildkite-agent:latest",
-		JobTTL:           300 * time.Second,
-		MaxInFlight:      100,
-		Namespace:        "my-buildkite-ns",
-		Org:              "my-buildkite-org",
-		Tags:             []string{"queue=my-queue", "priority=high"},
-		ClusterUUID:      "beefcafe-abbe-baba-abba-deedcedecade",
+		Debug:              true,
+		AgentTokenSecret:   "my-kubernetes-secret",
+		BuildkiteToken:     "my-graphql-enabled-token",
+		Image:              "my.registry.dev/buildkite-agent:latest",
+		JobTTL:             300 * time.Second,
+		StartupGracePeriod: 60 * time.Second,
+		MaxInFlight:        100,
+		Namespace:          "my-buildkite-ns",
+		Org:                "my-buildkite-org",
+		Tags:               []string{"queue=my-queue", "priority=high"},
+		ClusterUUID:        "beefcafe-abbe-baba-abba-deedcedecade",
 		PodSpecPatch: &corev1.PodSpec{
 			ServiceAccountName:           "buildkite-agent-sa",
 			AutomountServiceAccountToken: ptr(true),

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -2,6 +2,7 @@ agent-token-secret: my-kubernetes-secret
 debug: true
 image: my.registry.dev/buildkite-agent:latest
 job-ttl: 5m
+startup-grace-period: 60s
 max-in-flight: 100
 namespace: my-buildkite-ns
 org: my-buildkite-org

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -2,7 +2,7 @@ agent-token-secret: my-kubernetes-secret
 debug: true
 image: my.registry.dev/buildkite-agent:latest
 job-ttl: 5m
-startup-grace-period: 60s
+image-pull-backoff-grace-period: 60s
 max-in-flight: 100
 namespace: my-buildkite-ns
 org: my-buildkite-org

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -9,11 +9,11 @@ import (
 )
 
 const (
-	UUIDLabel                 = "buildkite.com/job-uuid"
-	BuildURLAnnotation        = "buildkite.com/build-url"
-	JobURLAnnotation          = "buildkite.com/job-url"
-	DefaultNamespace          = "default"
-	DefaultStartupGracePeriod = 30 * time.Second
+	UUIDLabel                          = "buildkite.com/job-uuid"
+	BuildURLAnnotation                 = "buildkite.com/build-url"
+	JobURLAnnotation                   = "buildkite.com/job-url"
+	DefaultNamespace                   = "default"
+	DefaultImagePullBackOffGracePeriod = 30 * time.Second
 )
 
 var DefaultAgentImage = "ghcr.io/buildkite/agent:" + version.Version()
@@ -22,20 +22,20 @@ var DefaultAgentImage = "ghcr.io/buildkite/agent:" + version.Version()
 // mapstructure (the module) supports switching the struct tag to "json", viper does not. So we have
 // to have the `mapstructure` tag for viper and the `json` tag is used by the mapstructure!
 type Config struct {
-	Debug                  bool            `json:"debug"`
-	JobTTL                 time.Duration   `json:"job-ttl"`
-	AgentTokenSecret       string          `json:"agent-token-secret"       validate:"required"`
-	BuildkiteToken         string          `json:"buildkite-token"          validate:"required"`
-	Image                  string          `json:"image"                    validate:"required"`
-	MaxInFlight            int             `json:"max-in-flight"            validate:"min=0"`
-	Namespace              string          `json:"namespace"                validate:"required"`
-	Org                    string          `json:"org"                      validate:"required"`
-	Tags                   stringSlice     `json:"tags"                     validate:"min=1"`
-	ProfilerAddress        string          `json:"profiler-address"         validate:"omitempty,hostname_port"`
-	ClusterUUID            string          `json:"cluster-uuid"             validate:"omitempty"`
-	AdditionalRedactedVars stringSlice     `json:"additional-redacted-vars" validate:"omitempty"`
-	PodSpecPatch           *corev1.PodSpec `json:"pod-spec-patch"           validate:"omitempty"`
-	StartupGracePeriod     time.Duration   `json:"startup-grace-period" validate:"omitempty"`
+	Debug                       bool            `json:"debug"`
+	JobTTL                      time.Duration   `json:"job-ttl"`
+	AgentTokenSecret            string          `json:"agent-token-secret"              validate:"required"`
+	BuildkiteToken              string          `json:"buildkite-token"                 validate:"required"`
+	Image                       string          `json:"image"                           validate:"required"`
+	MaxInFlight                 int             `json:"max-in-flight"                   validate:"min=0"`
+	Namespace                   string          `json:"namespace"                       validate:"required"`
+	Org                         string          `json:"org"                             validate:"required"`
+	Tags                        stringSlice     `json:"tags"                            validate:"min=1"`
+	ProfilerAddress             string          `json:"profiler-address"                validate:"omitempty,hostname_port"`
+	ClusterUUID                 string          `json:"cluster-uuid"                    validate:"omitempty"`
+	AdditionalRedactedVars      stringSlice     `json:"additional-redacted-vars"        validate:"omitempty"`
+	PodSpecPatch                *corev1.PodSpec `json:"pod-spec-patch"                  validate:"omitempty"`
+	ImagePullBackOffGradePeriod time.Duration   `json:"image-pull-backoff-grace-period" validate:"omitempty"`
 }
 
 type stringSlice []string
@@ -63,6 +63,6 @@ func (c Config) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	if err := enc.AddReflected("pod-spec-patch", c.PodSpecPatch); err != nil {
 		return err
 	}
-	enc.AddDuration("startup-grace-period", c.StartupGracePeriod)
+	enc.AddDuration("image-pull-backoff-grace-period", c.ImagePullBackOffGradePeriod)
 	return enc.AddArray("tags", c.Tags)
 }

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -9,10 +9,11 @@ import (
 )
 
 const (
-	UUIDLabel          = "buildkite.com/job-uuid"
-	BuildURLAnnotation = "buildkite.com/build-url"
-	JobURLAnnotation   = "buildkite.com/job-url"
-	DefaultNamespace   = "default"
+	UUIDLabel                 = "buildkite.com/job-uuid"
+	BuildURLAnnotation        = "buildkite.com/build-url"
+	JobURLAnnotation          = "buildkite.com/job-url"
+	DefaultNamespace          = "default"
+	DefaultStartupGracePeriod = 30 * time.Second
 )
 
 var DefaultAgentImage = "ghcr.io/buildkite/agent:" + version.Version()
@@ -34,6 +35,7 @@ type Config struct {
 	ClusterUUID            string          `json:"cluster-uuid"             validate:"omitempty"`
 	AdditionalRedactedVars stringSlice     `json:"additional-redacted-vars" validate:"omitempty"`
 	PodSpecPatch           *corev1.PodSpec `json:"pod-spec-patch"           validate:"omitempty"`
+	StartupGracePeriod     time.Duration   `json:"startup-grace-period" validate:"omitempty"`
 }
 
 type stringSlice []string
@@ -61,5 +63,6 @@ func (c Config) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	if err := enc.AddReflected("pod-spec-patch", c.PodSpecPatch); err != nil {
 		return err
 	}
+	enc.AddDuration("startup-grace-period", c.StartupGracePeriod)
 	return enc.AddArray("tags", c.Tags)
 }

--- a/internal/controller/scheduler/imagePullBackOffWatcher.go
+++ b/internal/controller/scheduler/imagePullBackOffWatcher.go
@@ -22,7 +22,7 @@ type imagePullBackOffWatcher struct {
 
 	// The imagePullBackOffWatcher waits at least this duration after pod
 	// creation before it cancels the job.
-	startupGracePeriod time.Duration
+	gracePeriod time.Duration
 }
 
 // NewImagePullBackOffWatcher creates an informer that will use the Buildkite
@@ -34,10 +34,10 @@ func NewImagePullBackOffWatcher(
 	cfg *config.Config,
 ) *imagePullBackOffWatcher {
 	return &imagePullBackOffWatcher{
-		logger:             logger,
-		k8s:                k8s,
-		gql:                api.NewClient(cfg.BuildkiteToken),
-		startupGracePeriod: cfg.StartupGracePeriod,
+		logger:      logger,
+		k8s:         k8s,
+		gql:         api.NewClient(cfg.BuildkiteToken),
+		gracePeriod: cfg.ImagePullBackOffGradePeriod,
 	}
 }
 
@@ -87,7 +87,7 @@ func (w *imagePullBackOffWatcher) cancelImagePullBackOff(ctx context.Context, po
 		return
 	}
 	startedAt := pod.Status.StartTime.Time
-	if startedAt.IsZero() || time.Since(startedAt) < w.startupGracePeriod {
+	if startedAt.IsZero() || time.Since(startedAt) < w.gracePeriod {
 		// Not started yet, or started recently
 		return
 	}

--- a/internal/controller/scheduler/imagePullBackOffWatcher.go
+++ b/internal/controller/scheduler/imagePullBackOffWatcher.go
@@ -82,8 +82,13 @@ func (w *imagePullBackOffWatcher) cancelImagePullBackOff(ctx context.Context, po
 	log := w.logger.With(zap.String("namespace", pod.Namespace), zap.String("podName", pod.Name))
 	log.Debug("Checking pod for ImagePullBackOff")
 
-	startedAt := pod.GetCreationTimestamp().Time
-	if time.Since(startedAt) < w.startupGracePeriod {
+	if pod.Status.StartTime == nil {
+		// Status could be unpopulated, or it hasn't started yet.
+		return
+	}
+	startedAt := pod.Status.StartTime.Time
+	if startedAt.IsZero() || time.Since(startedAt) < w.startupGracePeriod {
+		// Not started yet, or started recently
 		return
 	}
 


### PR DESCRIPTION
30 seconds may be too short for some customers. It should at least be configurable.

Also, as pointed out, pod creation time isn't a good moment to base the grace period - there could be a long period between creating the pod and the kubelet actually starting it. Pod start time is more useful.