### PR TITLE
Configurable checkout/command/sidecar defaults

### DIFF
--- a/charts/agent-stack-k8s/values.schema.json
+++ b/charts/agent-stack-k8s/values.schema.json
@@ -61,7 +61,9 @@
       "default": {},
       "title": "The labels Schema",
       "description": "label app is reserved, user input label app is not allowed",
-      "not": { "required": ["app"] },
+      "not": {
+        "required": ["app"]
+      },
       "additionalProperties": {
         "type": "string",
         "default": ""
@@ -78,7 +80,9 @@
       "default": {},
       "title": "The secretsmetadata Schema",
       "description": "secret name and namespace are reserved, user input secret name and namespace are not allowed",
-      "not": { "required": ["name", "namespace"] },
+      "not": {
+        "required": ["name", "namespace"]
+      },
       "additionalProperties": {
         "type": "object",
         "default": {}
@@ -96,7 +100,9 @@
       "default": {},
       "title": "The serviceaccountmetadata Schema",
       "description": "serviceaccount name and namespace are reserved, user input serviceaccount name and namespace are not allowed",
-      "not": { "required": ["name", "namespace"] },
+      "not": {
+        "required": ["name", "namespace"]
+      },
       "additionalProperties": {
         "type": "object",
         "default": {}
@@ -219,6 +225,66 @@
             "type": "string"
           },
           "examples": [["SECRET_RECIPE"]]
+        },
+        "default-checkout-params": {
+          "type": "object",
+          "default": null,
+          "title": "Default parameters for checkout containers",
+          "properties": {
+            "skip": {
+              "type": "boolean",
+              "default": null,
+              "title": "If true, skips building and running checkout containers"
+            },
+            "cloneFlags": {
+              "type": "string",
+              "default": null,
+              "title": "If set, appends the BUILDKITE_GIT_CLONE_FLAGS variable"
+            },
+            "fetchFlags": {
+              "type": "string",
+              "default": null,
+              "title": "If set, appends the BUILDKITE_GIT_FETCH_FLAGS variable"
+            },
+            "envFrom": {
+              "type": "array",
+              "default": [],
+              "title": "k8s envFrom sources to add",
+              "items": {
+                "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.EnvFromSource"
+              }
+            }
+          }
+        },
+        "default-command-params": {
+          "type": "object",
+          "default": null,
+          "title": "Default parameters for command containers",
+          "properties": {
+            "envFrom": {
+              "type": "array",
+              "default": [],
+              "title": "k8s envFrom sources to add",
+              "items": {
+                "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.EnvFromSource"
+              }
+            }
+          }
+        },
+        "default-sidecar-params": {
+          "type": "object",
+          "default": null,
+          "title": "Default parameters for sidecar containers",
+          "properties": {
+            "envFrom": {
+              "type": "array",
+              "default": [],
+              "title": "k8s envFrom sources to add",
+              "items": {
+                "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.EnvFromSource"
+              }
+            }
+          }
         },
         "pod-spec-patch": {
           "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.PodSpec"

--- a/cmd/controller/controller_test.go
+++ b/cmd/controller/controller_test.go
@@ -30,6 +30,36 @@ func TestReadAndParseConfig(t *testing.T) {
 		Org:                         "my-buildkite-org",
 		Tags:                        []string{"queue=my-queue", "priority=high"},
 		ClusterUUID:                 "beefcafe-abbe-baba-abba-deedcedecade",
+		DefaultCommandParams: &config.CommandParams{
+			EnvFrom: []corev1.EnvFromSource{{
+				Prefix: "DEPLOY_",
+				SecretRef: &corev1.SecretEnvSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "deploy-secrets",
+					},
+				},
+			}},
+		},
+		DefaultCheckoutParams: &config.CheckoutParams{
+			EnvFrom: []corev1.EnvFromSource{{
+				Prefix: "GITHUB_",
+				SecretRef: &corev1.SecretEnvSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "github-secrets",
+					},
+				},
+			}},
+		},
+		DefaultSidecarParams: &config.SidecarParams{
+			EnvFrom: []corev1.EnvFromSource{{
+				Prefix: "LOGGING_",
+				ConfigMapRef: &corev1.ConfigMapEnvSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "logging-config",
+					},
+				},
+			}},
+		},
 		PodSpecPatch: &corev1.PodSpec{
 			ServiceAccountName:           "buildkite-agent-sa",
 			AutomountServiceAccountToken: ptr(true),

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -13,8 +13,29 @@ org: my-buildkite-org
 cluster-uuid: beefcafe-abbe-baba-abba-deedcedecade
 
 tags:
-- queue=my-queue
-- priority=high
+  - queue=my-queue
+  - priority=high
+
+# Applies to the checkout container in all spawned pods
+default-checkout-params:
+  envFrom:
+    - prefix: GITHUB_
+      secretRef:
+        name: github-secrets
+
+# Applies to all command containers in all spawned pods
+default-command-params:
+  envFrom:
+    - prefix: DEPLOY_
+      secretRef:
+        name: deploy-secrets
+
+# Applies to all sidecar containers in all spawned pods
+default-sidecar-params:
+  envFrom:
+    - prefix: LOGGING_
+      configMapRef:
+        name: logging-config
 
 # This will be applied to the job's podSpec as a strategic merge patch
 # See https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch
@@ -22,16 +43,16 @@ pod-spec-patch:
   serviceAccountName: buildkite-agent-sa
   automountServiceAccountToken: true
   containers:
-  - name: container-0
-    env:
-    - name: GITHUB_TOKEN
-      valueFrom:
-        secretKeyRef:
-          name: github-secrets
-          key: github-token
-    resources:
-      requests:
-        cpu: 100m
-        mem: 50Mi
-      limits:
-        mem: 1Gi
+    - name: container-0
+      env:
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: github-secrets
+              key: github-token
+      resources:
+        requests:
+          cpu: 100m
+          mem: 50Mi
+        limits:
+          mem: 1Gi

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -112,7 +112,7 @@ func (sc *SidecarParams) ApplyTo(ctr *corev1.Container) {
 // CheckoutParams contains parameters that provide additional control over the
 // checkout container.
 type CheckoutParams struct {
-	Skip       bool                   `json:"skip,omitempty"`
+	Skip       *bool                  `json:"skip,omitempty"`
 	CloneFlags *string                `json:"cloneFlags,omitempty"`
 	FetchFlags *string                `json:"fetchFlags,omitempty"`
 	EnvFrom    []corev1.EnvFromSource `json:"envFrom,omitempty"`

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -55,6 +55,9 @@ func Run(
 		AgentToken:             cfg.AgentTokenSecret,
 		JobTTL:                 cfg.JobTTL,
 		AdditionalRedactedVars: cfg.AdditionalRedactedVars,
+		DefaultCheckoutParams:  cfg.DefaultCheckoutParams,
+		DefaultCommandParams:   cfg.DefaultCommandParams,
+		DefaultSidecarParams:   cfg.DefaultSidecarParams,
 		PodSpecPatch:           cfg.PodSpecPatch,
 	})
 	limiter := scheduler.NewLimiter(logger.Named("limiter"), sched, cfg.MaxInFlight)

--- a/internal/controller/scheduler/completions.go
+++ b/internal/controller/scheduler/completions.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/buildkite/agent-stack-k8s/v2/internal/controller/config"
+
 	"go.uber.org/zap"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -39,6 +39,9 @@ type Config struct {
 	AgentToken             string
 	JobTTL                 time.Duration
 	AdditionalRedactedVars []string
+	DefaultCheckoutParams  *config.CheckoutParams
+	DefaultCommandParams   *config.CommandParams
+	DefaultSidecarParams   *config.SidecarParams
 	PodSpecPatch           *corev1.PodSpec
 }
 
@@ -57,13 +60,9 @@ type KubernetesPlugin struct {
 	Sidecars          []corev1.Container     `json:"sidecars,omitempty"`
 	Metadata          Metadata               `json:"metadata,omitempty"`
 	ExtraVolumeMounts []corev1.VolumeMount   `json:"extraVolumeMounts,omitempty"`
-	Checkout          Checkout               `json:"checkout,omitempty"`
-}
-
-type Checkout struct {
-	Skip       bool   `json:"skip,omitempty"`
-	CloneFlags string `json:"cloneFlags,omitempty"`
-	FetchFlags string `json:"fetchFlags,omitempty"`
+	CheckoutParams    *config.CheckoutParams `json:"checkout,omitempty"`
+	CommandParams     *config.CommandParams  `json:"commandParams,omitempty"`
+	SidecarParams     *config.SidecarParams  `json:"sidecarParams,omitempty"`
 }
 
 type Metadata struct {
@@ -169,7 +168,10 @@ func (w *jobWrapper) ParsePlugins() error {
 // Build builds a job. The checkout container will be skipped either by passing
 // `true` or if the k8s plugin configuration is configured to skip it.
 func (w *jobWrapper) Build(skipCheckout bool) (*batchv1.Job, error) {
-	skipCheckout = skipCheckout || w.k8sPlugin.Checkout.Skip
+
+	skipCheckout = skipCheckout ||
+		(w.cfg.DefaultCheckoutParams != nil && w.cfg.DefaultCheckoutParams.Skip) ||
+		(w.k8sPlugin.CheckoutParams != nil && w.k8sPlugin.CheckoutParams.Skip)
 
 	kjob := &batchv1.Job{}
 	kjob.Name = kjobName(w.job)
@@ -323,6 +325,9 @@ func (w *jobWrapper) Build(skipCheckout bool) (*batchv1.Job, error) {
 			},
 		)
 
+		w.cfg.DefaultCommandParams.ApplyTo(&c)
+		w.k8sPlugin.CommandParams.ApplyTo(&c)
+
 		if c.Name == "" {
 			c.Name = fmt.Sprintf("%s-%d", "container", i)
 		}
@@ -338,7 +343,8 @@ func (w *jobWrapper) Build(skipCheckout bool) (*batchv1.Job, error) {
 	containerCount := len(podSpec.Containers) + systemContainerCount
 
 	if len(podSpec.Containers) == 0 {
-		podSpec.Containers = append(podSpec.Containers, corev1.Container{
+		// Create a default command container named "container-0".
+		c := corev1.Container{
 			Name:            "container-0",
 			Image:           w.cfg.Image,
 			Command:         []string{"/workspace/buildkite-agent"},
@@ -356,8 +362,11 @@ func (w *jobWrapper) Build(skipCheckout bool) (*batchv1.Job, error) {
 					Value: strconv.Itoa(0 + systemContainerCount),
 				},
 			),
-			EnvFrom: w.k8sPlugin.GitEnvFrom,
-		})
+		}
+		w.cfg.DefaultCommandParams.ApplyTo(&c)
+		w.k8sPlugin.CommandParams.ApplyTo(&c)
+		c.EnvFrom = append(c.EnvFrom, w.k8sPlugin.GitEnvFrom...)
+		podSpec.Containers = append(podSpec.Containers, c)
 	}
 
 	for i, c := range w.k8sPlugin.Sidecars {
@@ -365,6 +374,8 @@ func (w *jobWrapper) Build(skipCheckout bool) (*batchv1.Job, error) {
 			c.Name = fmt.Sprintf("%s-%d", "sidecar", i)
 		}
 		c.VolumeMounts = append(c.VolumeMounts, volumeMounts...)
+		w.cfg.DefaultSidecarParams.ApplyTo(&c)
+		w.k8sPlugin.SidecarParams.ApplyTo(&c)
 		c.EnvFrom = append(c.EnvFrom, w.k8sPlugin.GitEnvFrom...)
 		podSpec.Containers = append(podSpec.Containers, c)
 	}
@@ -551,17 +562,14 @@ func (w *jobWrapper) createCheckoutContainer(
 				Name:  "BUILDKITE_PLUGINS_PATH",
 				Value: "/workspace/plugins",
 			},
-			{
-				Name:  "BUILDKITE_GIT_CLONE_FLAGS",
-				Value: w.k8sPlugin.Checkout.CloneFlags,
-			},
-			{
-				Name:  "BUILDKITE_GIT_FETCH_FLAGS",
-				Value: w.k8sPlugin.Checkout.FetchFlags,
-			},
 		},
-		EnvFrom: w.k8sPlugin.GitEnvFrom,
 	}
+
+	w.cfg.DefaultCheckoutParams.ApplyTo(&checkoutContainer)
+	w.k8sPlugin.CheckoutParams.ApplyTo(&checkoutContainer)
+
+	checkoutContainer.EnvFrom = append(checkoutContainer.EnvFrom, w.k8sPlugin.GitEnvFrom...)
+
 	checkoutContainer.Env = append(checkoutContainer.Env, env...)
 
 	podUser, podGroup := int64(0), int64(0)


### PR DESCRIPTION
Particularly, the ability to set a global `envFrom` that applies to each of the three flavours of container that can be run, and also the same thing but within the plugin config.