### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @buildkite/pipelines-enterprise


### PR DESCRIPTION
self-explanatory. 

So we can get automatically assigned when there are pull requests. 

The Github complains that the codeowner file has error (team doesn't exist?), I don't know if it's working... so let's give it shot.