### PR TITLE
PS-67: stop image pull backoff error handling for sidecars

### DIFF
--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -29,6 +29,8 @@ const (
 	defaultTermGracePeriodSeconds = 60
 	agentTokenKey                 = "BUILDKITE_AGENT_TOKEN"
 	AgentContainerName            = "agent"
+	CopyAgentContainerName        = "copy-agent"
+	CheckoutContainerName         = "checkout"
 )
 
 type Config struct {
@@ -435,7 +437,7 @@ func (w *jobWrapper) Build(skipCheckout bool) (*batchv1.Job, error) {
 	}
 
 	podSpec.InitContainers = append(podSpec.InitContainers, corev1.Container{
-		Name:            "copy-agent",
+		Name:            CopyAgentContainerName,
 		Image:           w.cfg.Image,
 		ImagePullPolicy: corev1.PullAlways,
 		Command:         []string{"cp"},
@@ -523,7 +525,7 @@ func (w *jobWrapper) createCheckoutContainer(
 	volumeMounts []corev1.VolumeMount,
 ) corev1.Container {
 	checkoutContainer := corev1.Container{
-		Name:            "checkout",
+		Name:            CheckoutContainerName,
 		Image:           w.cfg.Image,
 		WorkingDir:      "/workspace",
 		VolumeMounts:    volumeMounts,

--- a/internal/integration/fixtures/image-pull-back-off-sidecar.yaml
+++ b/internal/integration/fixtures/image-pull-back-off-sidecar.yaml
@@ -1,0 +1,14 @@
+steps:
+  - label: ":white_check_mark:"
+    agents:
+      queue: {{.queue}}
+    commands:
+      # This needs to be longer than the image pull backoff grace period to be effective.
+      - sleep 60
+    plugins:
+      - kubernetes:
+          # This side car will not run, but it won't sure our CI job status.
+          sidecars:
+            - image: buildkite/non-existant-image:latest
+              command:
+                - "true"

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -390,6 +390,21 @@ func TestImagePullBackOffCancelled(t *testing.T) {
 	tc.AssertLogsContain(build, "other job has run")
 }
 
+// Asserting that we only kill jobs for image pullbackoff on our system containers.
+func TestImagePullBackOffOnSidecar(t *testing.T) {
+	tc := testcase{
+		T:       t,
+		Fixture: "image-pull-back-off-sidecar.yaml",
+		Repo:    repoHTTP,
+		GraphQL: api.NewClient(cfg.BuildkiteToken),
+	}.Init()
+	ctx := context.Background()
+	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)
+	tc.StartController(ctx, cfg)
+	build := tc.TriggerBuild(ctx, pipelineID)
+	tc.AssertSuccess(ctx, build)
+}
+
 func TestArtifactsUploadFailedJobs(t *testing.T) {
 	tc := testcase{
 		T:       t,


### PR DESCRIPTION
Currently, our backoff error watcher monitors all containers in a pod, which is problematic for customers who heavily rely on sidecars.

Since sidecar errors theoretically do not impact the health of pipeline jobs, canceling an entire job based on the status of a sidecar only adds unnecessary trouble.

At the moment, we don't provide governance support for sidecars, meaning customers can't see logs from sidecars. When we kill a job due to a sidecar problem, customers aren't given a proper reason. Sometimes, their CI workload is functioning correctly, but some sidecars have a delayed start, leading to the job being killed. From the customers' perspective, everything appears to be working fine until something randomly terminates the job, which is frustrating.

Customers can debug sidecar issues themselves through their Kubernetes platform.

This PR reduces the scope of the image pull backoff error watcher so it only monitors containers that we actively govern.

NOTE: A longer-term solution is being planned to address the observability issues comprehensively, so this PR is a temporary solution.  