### PR TITLE
Move integration test on CI to use a different namespace

### DIFF
--- a/.buildkite/steps/tests.sh
+++ b/.buildkite/steps/tests.sh
@@ -10,6 +10,11 @@ package="github.com/buildkite/agent-stack-k8s/v2/internal/integration_test"
 branch="${BUILDKITE_BRANCH:-main}"
 IMAGE=$(buildkite-agent meta-data get agent-image)
 export IMAGE
+# Do NOT allow integration test workloads in the buildkite namespace.
+# It causes confusion and complicates cleanup.
+# The buildkite namespace is reserved for CI workloads.
+# Integration tests will use their own namespace and out-of-cluster k8s controller to manage job pods.
+export NAMESPACE=buildkite-k8s-integration-test
 
 gotestsum --junitfile "junit-${BUILDKITE_JOB_ID}.xml" -- \
   -count=1 \

--- a/cmd/controller/controller_test.go
+++ b/cmd/controller/controller_test.go
@@ -68,8 +68,9 @@ func TestReadAndParseConfig(t *testing.T) {
 	// container. As this is required, we set it here to avoid the validation error.
 	t.Setenv("BUILDKITE_TOKEN", "my-graphql-enabled-token")
 
-	// This needs to be unset to as it is set in CI which pollutes the test environment
+	// These need to be unset to as it is set in CI which pollutes the test environment
 	t.Setenv("IMAGE", "")
+	t.Setenv("NAMESPACE", "")
 
 	cmd := &cobra.Command{}
 	controller.AddConfigFlags(cmd)

--- a/internal/integration/fixtures/secretref.yaml
+++ b/internal/integration/fixtures/secretref.yaml
@@ -6,7 +6,7 @@ steps:
   - kubernetes:
       gitEnvFrom:
       - secretRef:
-          name: agent-stack-k8s
+          name: integration-test-ssh-key
       podSpec:
         containers:
         - image: alpine:latest
@@ -21,7 +21,7 @@ steps:
   - kubernetes:
       gitEnvFrom:
       - secretRef:
-          name: agent-stack-k8s
+          name: integration-test-ssh-key
       podSpec:
         containers:
         - image: alpine:latest

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -187,7 +187,7 @@ func TestSSHRepoClone(t *testing.T) {
 	ctx := context.Background()
 	_, err := tc.Kubernetes.CoreV1().
 		Secrets(cfg.Namespace).
-		Get(ctx, "agent-stack-k8s", metav1.GetOptions{})
+		Get(ctx, "integration-test-ssh-key", metav1.GetOptions{})
 	require.NoError(t, err, "agent-stack-k8s secret must exist")
 
 	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)


### PR DESCRIPTION
Our integration test runs our k8s controller outsides of our k8s cluster. It will spin up lots of jobs/pods in a k8s namespace X. 

Right now, X = `buildkite`, it happens to be where our CI is running. It becomes a problem now if we saw a pod in `buildkite` namespace, we don't know if the pod is from CI workload or integration tests. 

This change makes sure when we run our CI, workload generated by integration will run on its own namespace, reducing confusion and hopefully easier to manage on the long run. 