### PR TITLE
Stop using old k8s exec envvar

### DIFF
--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -273,11 +273,6 @@ func (w *jobWrapper) Build(skipCheckout bool) (*batchv1.Job, error) {
 	containerEnv := append([]corev1.EnvVar{}, env...)
 	containerEnv = append(containerEnv, []corev1.EnvVar{
 		{
-			// Deprecated: agents v3.74.0 and newer use BUILDKITE_KUBERNETES_EXEC instead
-			Name:  "BUILDKITE_AGENT_EXPERIMENT",
-			Value: "kubernetes-exec",
-		},
-		{
 			Name:  "BUILDKITE_KUBERNETES_EXEC",
 			Value: "true",
 		},
@@ -396,11 +391,6 @@ func (w *jobWrapper) Build(skipCheckout bool) (*batchv1.Job, error) {
 		VolumeMounts:    volumeMounts,
 		ImagePullPolicy: corev1.PullAlways,
 		Env: []corev1.EnvVar{
-			{
-				// Deprecated: agents v3.74.0 and newer use BUILDKITE_KUBERNETES_EXEC instead
-				Name:  "BUILDKITE_AGENT_EXPERIMENT",
-				Value: "kubernetes-exec",
-			},
 			{
 				Name:  "BUILDKITE_KUBERNETES_EXEC",
 				Value: "true",
@@ -541,11 +531,6 @@ func (w *jobWrapper) createCheckoutContainer(
 		VolumeMounts:    volumeMounts,
 		ImagePullPolicy: corev1.PullAlways,
 		Env: []corev1.EnvVar{
-			{
-				// Deprecated: agents v3.74.0 and newer use BUILDKITE_KUBERNETES_EXEC instead
-				Name:  "BUILDKITE_AGENT_EXPERIMENT",
-				Value: "kubernetes-exec",
-			},
 			{
 				Name:  "BUILDKITE_KUBERNETES_EXEC",
 				Value: "true",


### PR DESCRIPTION
This change will prevent users from being spammed with warning messages.

## Reviewer please read: 

The risk of this change is that users won't be able be downgrade agent to anything below `v3.74.0`. I don't expect users would be manually pinging agent version but if it's a risk we can do something smarter like: "if agent version > X then don't use the old experimental flag".