### PR TITLE
Refer to the correct section of the UI when finding the UUID for a queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ If you are using [Buildkite Clusters](https://buildkite.com/docs/agent/clusters)
 config:
   cluster-uuid: beefcafe-abbe-baba-abba-deedcedecade
 ```
-The cluster's UUID may be obtained by navigating to the [clusters page](https://buildkite.com/organizations/-/clusters), clicking on the relevant cluster and then clicking on "Settings". It will be in a section titled "API Integration".
+The cluster's UUID may be obtained by navigating to the [clusters page](https://buildkite.com/organizations/-/clusters), clicking on the relevant cluster and then clicking on the section titled "API Integration".
 
 We're using Helm's support for [OCI-based registries](https://helm.sh/docs/topics/registries/),
 which means you'll need Helm version 3.8.0 or newer.

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ If you are using [Buildkite Clusters](https://buildkite.com/docs/agent/clusters)
 config:
   cluster-uuid: beefcafe-abbe-baba-abba-deedcedecade
 ```
-The cluster's UUID may be obtained by navigating to the [clusters page](https://buildkite.com/organizations/-/clusters), clicking on the relevant cluster and then clicking on "Settings". It will be in a section titled "GraphQL API Integration".
+The cluster's UUID may be obtained by navigating to the [clusters page](https://buildkite.com/organizations/-/clusters), clicking on the relevant cluster and then clicking on "Settings". It will be in a section titled "API Integration".
 
 We're using Helm's support for [OCI-based registries](https://helm.sh/docs/topics/registries/),
 which means you'll need Helm version 3.8.0 or newer.

--- a/README.md
+++ b/README.md
@@ -93,7 +93,10 @@ If you are using [Buildkite Clusters](https://buildkite.com/docs/agent/clusters)
 config:
   cluster-uuid: beefcafe-abbe-baba-abba-deedcedecade
 ```
-The cluster's UUID may be obtained by navigating to the [clusters page](https://buildkite.com/organizations/-/clusters), clicking on the relevant cluster and then clicking on the section titled "API Integration".
+The cluster's UUID may be obtained by navigating to the [clusters page](https://buildkite.com/organizations/-/clusters), clicking on the relevant cluster and then clicking on "Settings". It will be in a section titled "GraphQL API Integration".
+
+> [!NOTE]
+> Don't confuse the Cluster UUID with the UUID for the Queue. See [the docs](https://buildkite.com/docs/clusters/overview) for an explanation.
 
 We're using Helm's support for [OCI-based registries](https://helm.sh/docs/topics/registries/),
 which means you'll need Helm version 3.8.0 or newer.


### PR DESCRIPTION
Here is what I see in the UI when I attempt to follow these directions:

<img width="745" alt="Screenshot 2024-07-25 at 3 37 22 PM" src="https://github.com/user-attachments/assets/641fe7e4-58d5-4930-b767-d347a46999a5">

It seems like maybe the UI has changed since this document was written? I'm new to Buildkite, so it's possible that my UI is different than the norm.