### PR TITLE
Config to prevent podSpec alteration from plugin

### DIFF
--- a/charts/agent-stack-k8s/values.schema.json
+++ b/charts/agent-stack-k8s/values.schema.json
@@ -226,6 +226,12 @@
           },
           "examples": [["SECRET_RECIPE"]]
         },
+        "prohibit-kubernetes-plugin": {
+          "type": "boolean",
+          "default": false,
+          "title": "Causes the controller to prohibit the kubernetes plugin specified within jobs (pipeline YAML) - enabling this causes jobs with a kubernetes plugin to fail, preventing the pipeline YAML from having any influence over the podSpec",
+          "examples": [true]
+        },
         "default-checkout-params": {
           "type": "object",
           "default": null,

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -87,6 +87,11 @@ func AddConfigFlags(cmd *cobra.Command) {
 		config.DefaultImagePullBackOffGracePeriod,
 		"Duration after starting a pod that the controller will wait before considering cancelling a job due to ImagePullBackOff (e.g. when the podSpec specifies container images that cannot be pulled)",
 	)
+	cmd.Flags().Bool(
+		"prohibit-kubernetes-plugin",
+		false,
+		"Causes the controller to prohibit the kubernetes plugin specified within jobs (pipeline YAML) - enabling this causes jobs with a kubernetes plugin to fail, preventing the pipeline YAML from having any influence over the podSpec",
+	)
 }
 
 // ReadConfigFromFileArgsAndEnv reads the config from the file, env and args in that order.

--- a/cmd/controller/controller_test.go
+++ b/cmd/controller/controller_test.go
@@ -30,6 +30,7 @@ func TestReadAndParseConfig(t *testing.T) {
 		Org:                         "my-buildkite-org",
 		Tags:                        []string{"queue=my-queue", "priority=high"},
 		ClusterUUID:                 "beefcafe-abbe-baba-abba-deedcedecade",
+		ProhibitKubernetesPlugin:    true,
 		DefaultCommandParams: &config.CommandParams{
 			EnvFrom: []corev1.EnvFromSource{{
 				Prefix: "DEPLOY_",

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -16,6 +16,11 @@ tags:
   - queue=my-queue
   - priority=high
 
+# Causes the controller to prohibit the kubernetes plugin specified within jobs
+# (pipeline YAML) - enabling this causes jobs with a kubernetes plugin to fail,
+# preventing the pipeline YAML from having any influence over the podSpec
+prohibit-kubernetes-plugin: true
+
 # Applies to the checkout container in all spawned pods
 default-checkout-params:
   envFrom:

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -39,9 +39,14 @@ type Config struct {
 	AdditionalRedactedVars      stringSlice     `json:"additional-redacted-vars"        validate:"omitempty"`
 	PodSpecPatch                *corev1.PodSpec `json:"pod-spec-patch"                  validate:"omitempty"`
 	ImagePullBackOffGradePeriod time.Duration   `json:"image-pull-backoff-grace-period" validate:"omitempty"`
-	DefaultCheckoutParams       *CheckoutParams `json:"default-checkout-params"                  validate:"omitempty"`
-	DefaultCommandParams        *CommandParams  `json:"default-command-params"                   validate:"omitempty"`
-	DefaultSidecarParams        *SidecarParams  `json:"default-sidecar-params"                   validate:"omitempty"`
+	DefaultCheckoutParams       *CheckoutParams `json:"default-checkout-params"         validate:"omitempty"`
+	DefaultCommandParams        *CommandParams  `json:"default-command-params"          validate:"omitempty"`
+	DefaultSidecarParams        *SidecarParams  `json:"default-sidecar-params"          validate:"omitempty"`
+
+	// ProhibitKubernetesPlugin can be used to prevent alterations to the pod
+	// from the job (the kubernetes "plugin" in pipeline.yml). If enabled,
+	// jobs with a "kubernetes" plugin will fail.
+	ProhibitKubernetesPlugin bool `json:"prohibit-kubernetes-plugin" validate:"omitempty"`
 }
 
 type stringSlice []string
@@ -64,6 +69,7 @@ func (c Config) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	enc.AddString("org", c.Org)
 	enc.AddString("profiler-address", c.ProfilerAddress)
 	enc.AddString("cluster-uuid", c.ClusterUUID)
+	enc.AddBool("prohibit-kubernetes-plugin", c.ProhibitKubernetesPlugin)
 	if err := enc.AddArray("additional-redacted-vars", c.AdditionalRedactedVars); err != nil {
 		return err
 	}

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -59,6 +59,7 @@ func Run(
 		DefaultCommandParams:   cfg.DefaultCommandParams,
 		DefaultSidecarParams:   cfg.DefaultSidecarParams,
 		PodSpecPatch:           cfg.PodSpecPatch,
+		ProhibitK8sPlugin:      cfg.ProhibitKubernetesPlugin,
 	})
 	limiter := scheduler.NewLimiter(logger.Named("limiter"), sched, cfg.MaxInFlight)
 


### PR DESCRIPTION
### What
Add a `prohibit-kubernetes-plugin` option, usable as either a flag or config option, which causes jobs to fail if they contain `plugins: - kubernetes: ...`.

### Why
This is an easy way to lock down a k8s cluster and prevent users from doing such things as:
- using podSpec or podSpecPatch to specify undesirable container images, override the container entrypoint, etc
- using extraVolumeMounts to mount undesirable volumes
- using env, envFrom, or gitEnvFrom to map and leak unintended secrets
- disabling or enabling the checkout container, override git flags in an undesirable way, 

etc etc

### How
The main change is to introduce the `prohibit-kubernetes-plugin` flag and config value, and then use it throughout the scheduler.

Because this balances things out of favour of a `k8sPlugin`-centric interpretation of celestial mechanics, some useful refactors were in order:
* `Build` now takes a pointer to the podSpec it is supposed to be building, so that we can change which one we're building from `Create`. `BuildFailureJob` doesn't have to set `k8sPlugin.PodSpec` in order to build a special podspec.
* Labels and annotations are set on `kjob` first, instead of set in `k8sPlugin` and then moved to `kjob`.
* `jobWrapper` is now `buildInputs`. It has no methods (they're moved to `worker`) and is intended to contain only the relevant parts of `CommandJob` needed by `Build` or `BuildFailureJob`. The goal is to make the data flow (what data is need by which operation) clearer.