### PR TITLE
Adjust defaults for container0 (build container) as it is too frugal

### DIFF
--- a/cmd/controller/controller_test.go
+++ b/cmd/controller/controller_test.go
@@ -82,11 +82,8 @@ func TestReadAndParseConfig(t *testing.T) {
 					},
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
-							"cpu": resource.MustParse("100m"),
-							"mem": resource.MustParse("50Mi"),
-						},
-						Limits: corev1.ResourceList{
-							"mem": resource.MustParse("1Gi"),
+							"cpu": resource.MustParse("1000m"),
+							"mem": resource.MustParse("4Gi"),
 						},
 					},
 				},

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -57,7 +57,5 @@ pod-spec-patch:
               key: github-token
       resources:
         requests:
-          cpu: 100m
-          mem: 50Mi
-        limits:
-          mem: 1Gi
+          cpu: 1000m # one core
+          mem: 4Gi


### PR DESCRIPTION
As discovered while debugging some build issues, we could probably be a bit more generous with CPU and memory. Locally release builds are taking ~20 seconds, in this container they are taking over ~5 minutes threshold for jobs.. 

Currently the build container only has 1/10th of a CPU and 50mb of RAM.