### PR TITLE
Add GitCredentialSecret to checkout params

### DIFF
--- a/charts/agent-stack-k8s/values.schema.json
+++ b/charts/agent-stack-k8s/values.schema.json
@@ -252,6 +252,9 @@
               "default": null,
               "title": "If set, appends the BUILDKITE_GIT_FETCH_FLAGS variable"
             },
+            "gitCredentialsSecret": {
+              "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.SecretVolumeSource"
+            },
             "envFrom": {
               "type": "array",
               "default": [],

--- a/cmd/controller/controller_test.go
+++ b/cmd/controller/controller_test.go
@@ -42,6 +42,9 @@ func TestReadAndParseConfig(t *testing.T) {
 			}},
 		},
 		DefaultCheckoutParams: &config.CheckoutParams{
+			GitCredentialsSecret: &corev1.SecretVolumeSource{
+				SecretName: "my-git-credentials",
+			},
 			EnvFrom: []corev1.EnvFromSource{{
 				Prefix: "GITHUB_",
 				SecretRef: &corev1.SecretEnvSource{

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -23,6 +23,8 @@ prohibit-kubernetes-plugin: true
 
 # Applies to the checkout container in all spawned pods
 default-checkout-params:
+  gitCredentialsSecret:
+    secretName: "my-git-credentials"
   envFrom:
     - prefix: GITHUB_
       secretRef:

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -118,10 +118,11 @@ func (sc *SidecarParams) ApplyTo(ctr *corev1.Container) {
 // CheckoutParams contains parameters that provide additional control over the
 // checkout container.
 type CheckoutParams struct {
-	Skip       *bool                  `json:"skip,omitempty"`
-	CloneFlags *string                `json:"cloneFlags,omitempty"`
-	FetchFlags *string                `json:"fetchFlags,omitempty"`
-	EnvFrom    []corev1.EnvFromSource `json:"envFrom,omitempty"`
+	Skip                 *bool                      `json:"skip,omitempty"`
+	CloneFlags           *string                    `json:"cloneFlags,omitempty"`
+	FetchFlags           *string                    `json:"fetchFlags,omitempty"`
+	GitCredentialsSecret *corev1.SecretVolumeSource `json:"gitCredentialsSecret,omitempty"`
+	EnvFrom              []corev1.EnvFromSource     `json:"envFrom,omitempty"`
 }
 
 func (co *CheckoutParams) ApplyTo(ctr *corev1.Container) {
@@ -141,4 +142,11 @@ func (co *CheckoutParams) ApplyTo(ctr *corev1.Container) {
 		})
 	}
 	ctr.EnvFrom = append(ctr.EnvFrom, co.EnvFrom...)
+}
+
+func (co *CheckoutParams) GitCredsSecret() *corev1.SecretVolumeSource {
+	if co == nil {
+		return nil
+	}
+	return co.GitCredentialsSecret
 }


### PR DESCRIPTION
### What
Add a new checkout parameter, `gitCredentialsSecret`, that can be used to supply `.git-credentials` to the checkout container from a Kubernetes secret.

<img width="755" alt="Screenshot 2024-08-19 at 3 50 06 PM" src="https://github.com/user-attachments/assets/71ad4d9b-bdc2-4963-a561-8b0f2ee047df">

### Why
Currently, checking out code with an SSH key loaded from a k8s secret is supported and even reasonably documented. The situation for HTTPS checkouts is much more lacking. I was able to get it working with a mish-mash of `podSpecPatch` and a `pre-checkout` hook, but I think that packaging it up into a single new parameter would be nice.

### How

* Add the new field to `config.CheckoutParams` and test data
* When creating the checkout container, determine if a `gitCredentialsSecret` was set, if so, add a secret volume to the podSpec, volume mount to the container, and an extra command to the container entrypoint.