### PR TITLE
Update go-buildkite to v3.12.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.5
 
 require (
 	github.com/Khan/genqlient v0.7.0
-	github.com/buildkite/go-buildkite/v3 v3.11.0
+	github.com/buildkite/go-buildkite/v3 v3.12.0
 	github.com/buildkite/roko v1.2.0
 	github.com/go-playground/locales v0.14.1
 	github.com/go-playground/universal-translator v0.18.1

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,8 @@ github.com/buildkite/agent/v3 v3.77.0 h1:qcOexG1hNA5hIsqUjCgV9l0U4zoQLRUnLhGeE4f
 github.com/buildkite/agent/v3 v3.77.0/go.mod h1:eKubnp/T/TXYBqCG7SFG8ftOJZFlKznQck85Ie9xsZU=
 github.com/buildkite/bintest/v3 v3.2.0 h1:1GqUILGGni5UViGPH/PbSq0MxB9gzY3J/P7vNVqCkX4=
 github.com/buildkite/bintest/v3 v3.2.0/go.mod h1:+AdQZcVlzCiW2UyZWeG63xeH5z011XUBW6kWcRdaMtU=
-github.com/buildkite/go-buildkite/v3 v3.11.0 h1:A43KDOuNczqrY8wqlsHNtPoYbgWXYC/slkB/2JYXr5E=
-github.com/buildkite/go-buildkite/v3 v3.11.0/go.mod h1:TmZggyr5HqkOhNbTrcdOdmwuYbQqcfwr9MSyKyMQWAA=
+github.com/buildkite/go-buildkite/v3 v3.12.0 h1:VkJVwqx+5GD1434eyf2YuX3/LuCzSUlOycSvUA7YW04=
+github.com/buildkite/go-buildkite/v3 v3.12.0/go.mod h1:ux2rjcqNoE54wfFHO3Vlet+a57Tt2jqOqfc9Afs7R7g=
 github.com/buildkite/go-pipeline v0.10.0 h1:EDffu+LfMY2k5u+iEdo6Jn3obGKsrL5wicc1O/yFeRs=
 github.com/buildkite/go-pipeline v0.10.0/go.mod h1:eMH1kiav5VeiTiu0Mk2/M7nZhKyFeL4iGj7Y7rj4f3w=
 github.com/buildkite/interpolate v0.1.3 h1:OFEhqji1rNTRg0u9DsSodg63sjJQEb1uWbENq9fUOBM=

--- a/internal/integration/testcase_test.go
+++ b/internal/integration/testcase_test.go
@@ -67,9 +67,9 @@ func (t testcase) Init() testcase {
 	require.NoError(t, err)
 	t.Kubernetes = clientset
 
-	config, err := buildkite.NewTokenConfig(cfg.BuildkiteToken, false)
+	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(cfg.BuildkiteToken))
 	require.NoError(t, err)
-	t.Buildkite = buildkite.NewClient(config.Client())
+	t.Buildkite = client
 
 	return t
 }
@@ -215,10 +215,9 @@ func (t testcase) AssertSuccess(ctx context.Context, build api.Build) {
 func (t testcase) FetchLogs(build api.Build) string {
 	t.Helper()
 
-	config, err := buildkite.NewTokenConfig(cfg.BuildkiteToken, false)
+	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(cfg.BuildkiteToken))
 	require.NoError(t, err)
-
-	client := buildkite.NewClient(config.Client())
+	t.Buildkite = client
 
 	var logs strings.Builder
 	for _, edge := range build.Jobs.Edges {
@@ -252,9 +251,9 @@ func (t testcase) AssertLogsContain(build api.Build, content string) {
 
 func (t testcase) AssertArtifactsContain(build api.Build, expected ...string) {
 	t.Helper()
-	config, err := buildkite.NewTokenConfig(cfg.BuildkiteToken, false)
+	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(cfg.BuildkiteToken))
 	require.NoError(t, err)
-	client := buildkite.NewClient(config.Client())
+	t.Buildkite = client
 
 	artifacts, _, err := client.Artifacts.ListByBuild(
 		cfg.Org,


### PR DESCRIPTION
CI failed dependabot's attempt, because the old way is deprecated.

Closes #367 