### PR TITLE
Reduce MaxInFlight integration test flakes

### DIFF
--- a/internal/integration/fixtures/parallel.yaml
+++ b/internal/integration/fixtures/parallel.yaml
@@ -9,4 +9,6 @@ steps:
             containers:
               - image: alpine:latest
                 command:
-                  - sleep 1
+                  - echo ⏱️
+                  - sleep 10
+                  - echo 🔔


### PR DESCRIPTION
The MaxInFlightUnlimited integration test is flaky. This PR doesn't make it completely unflaky (I have ideas but it adds significant complication), but should reduce the chances of flakiness. While here, I tidied up some nits I had with the style, and made MaxInFlightLimited consistent with those changes.