### PR TITLE
Don't schedule using stale job info

### DIFF
--- a/internal/controller/scheduler/limiter.go
+++ b/internal/controller/scheduler/limiter.go
@@ -92,8 +92,8 @@ func (l *MaxInFlightLimiter) Create(ctx context.Context, job monitor.Job) error 
 		return nil
 	}
 
-	// Block until there's a token in the bucket, or the job information becomes
-	// too stale.
+	// Block until there's a token in the bucket, or cancel if the job
+	// information becomes too stale.
 	select {
 	case <-ctx.Done():
 		return context.Cause(ctx)

--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/buildkite/agent-stack-k8s/v2/api"
 	"github.com/buildkite/agent-stack-k8s/v2/internal/controller/agenttags"
 	"github.com/buildkite/agent-stack-k8s/v2/internal/controller/config"
+	"github.com/buildkite/agent-stack-k8s/v2/internal/controller/monitor"
 	"github.com/buildkite/agent-stack-k8s/v2/internal/version"
 
 	"github.com/buildkite/agent/v3/clicommand"
@@ -85,11 +86,11 @@ type worker struct {
 	logger *zap.Logger
 }
 
-func (w *worker) Create(ctx context.Context, job *api.CommandJob) error {
+func (w *worker) Create(ctx context.Context, job monitor.Job) error {
 	logger := w.logger.With(zap.String("uuid", job.Uuid))
 	logger.Info("creating job")
 
-	inputs, err := w.ParseJob(job)
+	inputs, err := w.ParseJob(job.CommandJob)
 	if err != nil {
 		logger.Warn("Job parsing failed, failing job", zap.Error(err))
 		return w.failJob(ctx, inputs, fmt.Sprintf("agent-stack-k8s failed to parse the job: %v", err))


### PR DESCRIPTION
### Why
Fixes #382 

### What
Change the `Handler` interface to accept a new `Job` that includes a channel that is closed when the job information becomes stale. This can be used to time out in the limiter waiting for a token to become available. That way, stale jobs won't be given to the scheduler. 