### PR TITLE
Tidyups in .buildkite

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -15,6 +15,41 @@ x-anchors:
                   - secretRef:
                       name: deploy-secrets
 
+  go-cache-env: &go-cache-env
+    name: GOCACHE
+    value: /tmp/cache/go-build
+  go-mod-cache-env: &go-mod-cache-env
+    name: GOMODCACHE
+    value: /tmp/cache/go-mod
+
+  go-cache-mount: &go-cache-mount
+    name: go-build
+    mountPath: /tmp/cache/go-build
+  go-mod-cache-mount: &go-mod-cache-mount
+    name: go-mod
+    mountPath: /tmp/cache/go-mod
+
+  go-cache-volume: &go-cache-volume
+    name: go-build
+    hostPath:
+      path: /tmp/cache/go-build
+      type: DirectoryOrCreate
+  go-mod-cache-volume: &go-mod-cache-volume
+    name: go-mod
+    hostPath:
+      path: /tmp/cache/go-mod
+      type: DirectoryOrCreate
+
+  go-env: &go-env
+    - *go-cache-env
+    - *go-mod-cache-env
+  go-mounts: &go-mounts
+    - *go-cache-mount
+    - *go-mod-cache-mount
+  go-volumes: &go-volumes
+    - *go-cache-volume
+    - *go-mod-cache-volume
+
 agents:
   queue: kubernetes
 
@@ -25,27 +60,11 @@ steps:
       - kubernetes:
           podSpec:
             containers:
-              - image: golang:1.22-alpine
+              - image: golang:1.23-alpine
                 command: [.buildkite/steps/tidy.sh]
-                env:
-                  - name: GOCACHE
-                    value: /tmp/cache/go-build
-                  - name: GOMODCACHE
-                    value: /tmp/cache/go-mod
-                volumeMounts:
-                  - name: go-build
-                    mountPath: /tmp/cache/go-build
-                  - name: go-mod
-                    mountPath: /tmp/cache/go-mod
-            volumes:
-              - name: go-build
-                hostPath:
-                  path: /tmp/cache/go-build
-                  type: DirectoryOrCreate
-              - name: go-mod
-                hostPath:
-                  path: /tmp/cache/go-mod
-                  type: DirectoryOrCreate
+                env: *go-env
+                volumeMounts: *go-mounts
+            volumes: *go-volumes
 
   - label: ":go::lint-roller: lint"
     key: lint
@@ -63,30 +82,20 @@ steps:
                 env:
                   - name: GOLANGCI_LINT_CACHE
                     value: /tmp/cache/golangci-lint
-                  - name: GOCACHE
-                    value: /tmp/cache/go-build
-                  - name: GOMODCACHE
-                    value: /tmp/cache/go-mod
+                  - *go-cache-env
+                  - *go-mod-cache-env
                 volumeMounts:
                   - name: golangci-lint-cache
                     mountPath: /tmp/cache/golangci-lint
-                  - name: go-build
-                    mountPath: /tmp/cache/go-build
-                  - name: go-mod
-                    mountPath: /tmp/cache/go-mod
+                  - *go-cache-mount
+                  - *go-mod-cache-mount
             volumes:
               - name: golangci-lint-cache
                 hostPath:
                   path: /tmp/cache/golangci-lint
                   type: DirectoryOrCreate
-              - name: go-build
-                hostPath:
-                  path: /tmp/cache/go-build
-                  type: DirectoryOrCreate
-              - name: go-mod
-                hostPath:
-                  path: /tmp/cache/go-mod
-                  type: DirectoryOrCreate
+              - *go-cache-volume
+              - *go-mod-cache-volume
 
   - label: ":golang::robot_face: check code generation"
     key: check-code-generation
@@ -95,27 +104,11 @@ steps:
           podSpec:
             containers:
               - name: docker
-                image: golang:1.22-alpine
+                image: golang:1.23-alpine
                 command: [.buildkite/steps/check-code-generation.sh]
-                env:
-                  - name: GOCACHE
-                    value: /tmp/cache/go-build
-                  - name: GOMODCACHE
-                    value: /tmp/cache/go-mod
-                volumeMounts:
-                  - name: go-build
-                    mountPath: /tmp/cache/go-build
-                  - name: go-mod
-                    mountPath: /tmp/cache/go-mod
-            volumes:
-              - name: go-build
-                hostPath:
-                  path: /tmp/cache/go-build
-                  type: DirectoryOrCreate
-              - name: go-mod
-                hostPath:
-                  path: /tmp/cache/go-mod
-                  type: DirectoryOrCreate
+                env: *go-env
+                volumeMounts: *go-mounts
+            volumes: *go-volumes
 
   - label: ":docker::buildkite: choose agent image"
     key: agent
@@ -139,14 +132,8 @@ steps:
               - name: agent-stack-k8s-config
                 configMap:
                   name: agent-stack-k8s-config
-              - name: go-build
-                hostPath:
-                  path: /tmp/cache/go-build
-                  type: DirectoryOrCreate
-              - name: go-mod
-                hostPath:
-                  path: /tmp/cache/go-mod
-                  type: DirectoryOrCreate
+              - *go-cache-volume
+              - *go-mod-cache-volume
             containers:
               - name: tests
                 image: golang:latest
@@ -154,10 +141,8 @@ steps:
                 env:
                   - name: CONFIG
                     value: /etc/config.yaml
-                  - name: GOCACHE
-                    value: /tmp/cache/go-build
-                  - name: GOMODCACHE
-                    value: /tmp/cache/go-mod
+                  - *go-cache-env
+                  - *go-mod-cache-env
                 envFrom:
                   - secretRef:
                       name: test-secrets
@@ -167,10 +152,8 @@ steps:
                   - mountPath: /etc/config.yaml
                     name: agent-stack-k8s-config
                     subPath: config.yaml
-                  - name: go-build
-                    mountPath: /tmp/cache/go-build
-                  - name: go-mod
-                    mountPath: /tmp/cache/go-mod
+                  - *go-cache-mount
+                  - *go-mod-cache-mount
                 resources:
                   requests:
                     cpu: 1000m
@@ -186,30 +169,14 @@ steps:
           podSpec:
             containers:
               - name: ko
-                image: golang:1.22
+                image: golang:1.23
                 command: [.buildkite/steps/controller.sh]
                 envFrom:
                   - secretRef:
                       name: deploy-secrets
-                env:
-                  - name: GOCACHE
-                    value: /tmp/cache/go-build
-                  - name: GOMODCACHE
-                    value: /tmp/cache/go-mod
-                volumeMounts:
-                  - name: go-build
-                    mountPath: /tmp/cache/go-build
-                  - name: go-mod
-                    mountPath: /tmp/cache/go-mod
-            volumes:
-              - name: go-build
-                hostPath:
-                  path: /tmp/cache/go-build
-                  type: DirectoryOrCreate
-              - name: go-mod
-                hostPath:
-                  path: /tmp/cache/go-mod
-                  type: DirectoryOrCreate
+                env: *go-env
+                volumeMounts: *go-mounts
+            volumes: *go-volumes
 
   # On feature branches, don't wait for tests. We may want to deploy
   # to a test cluster to debug the feature branch.
@@ -270,8 +237,11 @@ steps:
             serviceAccountName: release
             containers:
               - name: release
-                image: golang:1.22-alpine # Note goreleaser shells out to go!
+                image: golang:1.23-alpine # Note goreleaser shells out to go!
                 command: [.buildkite/steps/release.sh]
                 envFrom:
                   - secretRef:
                       name: release-secrets
+                env: *go-env
+                volumeMounts: *go-mounts
+            volumes: *go-volumes

--- a/.buildkite/steps/agent.sh
+++ b/.buildkite/steps/agent.sh
@@ -13,7 +13,7 @@ echo "Using agent version ${agent_version} as image tag"
 buildkite-agent meta-data set agent-version "${agent_version}"
 
 echo --- :docker: Inspecting agent docker image manifest
-digest=$(skopeo inspect "docker://${repo}:${agent_version}" --format {{.Digest}})
+digest="$(skopeo inspect "docker://${repo}:${agent_version}" --format {{.Digest}})"
 
 agent_image="${repo}@${digest}"
 echo Choosing image "${agent_image}"
@@ -21,9 +21,9 @@ buildkite-agent meta-data set agent-image "${agent_image}"
 
 buildkite-agent annotate --style success --append <<EOF
 ### Agent
----------------------------------------------------
-| Version        | Image                          |
-|----------------|--------------------------------|
-| $agent_version | $agent_image                   |
----------------------------------------------------
+-----------------------------------------------------
+| Version          | Image                          |
+|------------------|--------------------------------|
+| ${agent_version} | ${agent_image}                 |
+-----------------------------------------------------
 EOF

--- a/.buildkite/steps/build-and-push.sh
+++ b/.buildkite/steps/build-and-push.sh
@@ -10,24 +10,23 @@ source .buildkite/steps/repo_info.sh
 
 echo --- :docker: Logging into ghcr.io
 skopeo login ghcr.io \
-  -u "$REGISTRY_USERNAME" \
-  --password "$REGISTRY_PASSWORD" \
+  -u "${REGISTRY_USERNAME}" \
+  --password "${REGISTRY_PASSWORD}" \
   --authfile ~/.docker/config.json
 
-
 echo --- :helm: Packaging helm chart
-yq -i ".image = \"$controller_image\"" charts/agent-stack-k8s/values.yaml
-yq -i ".config.image = \"$agent_image\"" charts/agent-stack-k8s/values.yaml
-helm package charts/agent-stack-k8s --app-version "$version" -d dist --version "$version"
+yq -i ".image = \"${controller_image}\"" charts/agent-stack-k8s/values.yaml
+yq -i ".config.image = \"${agent_image}\"" charts/agent-stack-k8s/values.yaml
+helm package charts/agent-stack-k8s --app-version "${version}" -d dist --version "${version}"
 
 echo --- :helm: Pushing helm chart to ghcr.io
-helm push "dist/agent-stack-k8s-${version}.tgz" "$helm_repo"
+helm push "dist/agent-stack-k8s-${version}.tgz" "${helm_repo}"
 
 buildkite-agent annotate --style success --append <<EOF
 ### Helm Chart
---------------------------------------------------
-| Version  | Image                               |
-|----------|-------------------------------------|
-| $version | $helm_image                         |
---------------------------------------------------
+----------------------------------------------------
+| Version    | Image                               |
+|------------|-------------------------------------|
+| ${version} | ${helm_image}                       |
+----------------------------------------------------
 EOF

--- a/.buildkite/steps/controller.sh
+++ b/.buildkite/steps/controller.sh
@@ -6,30 +6,30 @@ echo --- Installing packages
 apt update && apt install -y --no-install-recommends jq
 
 echo --- Installing ko
-KO_VERSION=0.13.0
-OS=$(go env GOOS)
-ARCH=$(uname -m)
+KO_VERSION="0.13.0"
+OS="$(go env GOOS)"
+ARCH="$(uname -m)"
 curl -sSfL "https://github.com/ko-build/ko/releases/download/v${KO_VERSION}/ko_${KO_VERSION}_${OS^}_${ARCH}.tar.gz" | tar -xzv -C /bin ko
 
 echo --- Logging into to docker registry
-ko login ghcr.io -u "$REGISTRY_USERNAME" --password "$REGISTRY_PASSWORD"
+ko login ghcr.io -u "${REGISTRY_USERNAME}" --password "${REGISTRY_PASSWORD}"
 
-tag=$(git describe)
-version=${tag#v}
+tag="$(git describe)"
+version="${tag#v}"
 
 echo --- Building with ko
 controller_image=$(
-  VERSION="$tag" \
-  KO_DOCKER_REPO=ghcr.io/buildkite/agent-stack-k8s/controller \
+  VERSION="${tag}" \
+  KO_DOCKER_REPO="ghcr.io/buildkite/agent-stack-k8s/controller" \
     ko build --bare --tags "$version" --platform linux/amd64,linux/arm64 \
 )
 
-buildkite-agent meta-data set controller-image "$controller_image"
+buildkite-agent meta-data set controller-image "${controller_image}"
 buildkite-agent annotate --style success --append <<EOF
 ### Controller
--------------------------------
-| Version | Image             |
-|---------|-------------------|
-|$version | $controller_image |
--------------------------------
+------------------------------------
+| Version    | Image               |
+|------------|---------------------|
+| ${version} | ${controller_image} |
+------------------------------------
 EOF

--- a/.buildkite/steps/deploy.sh
+++ b/.buildkite/steps/deploy.sh
@@ -9,14 +9,14 @@ source .buildkite/steps/repo_info.sh
 
 echo --- :helm: Helm upgrade
 helm upgrade agent-stack-k8s "${helm_repo}/agent-stack-k8s" \
-  --version "$version" \
+  --version "${version}" \
   --namespace buildkite \
   --install \
   --create-namespace \
   --wait \
-  --set config.org="$BUILDKITE_ORGANIZATION_SLUG" \
-  --set agentToken="$BUILDKITE_AGENT_TOKEN" \
-  --set graphqlToken="$BUILDKITE_TOKEN" \
-  --set config.image="$agent_image" \
+  --set config.org="${BUILDKITE_ORGANIZATION_SLUG}" \
+  --set agentToken="${BUILDKITE_AGENT_TOKEN}" \
+  --set graphqlToken="${BUILDKITE_TOKEN}" \
+  --set config.image="${agent_image}" \
   --set config.debug=true \
   --set config.profiler-address=localhost:6060

--- a/.buildkite/steps/release.sh
+++ b/.buildkite/steps/release.sh
@@ -8,38 +8,38 @@ if [[ -z "${BUILDKITE_TAG:-}" ]]; then
   exit 1
 fi
 
-ARCH=$(uname -m)
-GORELEASER_VERSION=1.19.2
-GORELEASER_URL=https://github.com/goreleaser/goreleaser/releases/download
+ARCH="$(uname -m)"
+GORELEASER_VERSION="1.19.2"
+GORELEASER_URL="https://github.com/goreleaser/goreleaser/releases/download"
 GORELEASER_FILE="goreleaser_${GORELEASER_VERSION}_${ARCH}.apk"
-GHCH_VERSION=0.11.0
+GHCH_VERSION="0.11.0"
 GHCH_URL="https://github.com/buildkite/ghch/releases/download/v${GHCH_VERSION}/ghch-$(go env GOARCH)"
 
 echo --- :hammer: Installing packages
 apk add --no-progress crane git
 wget -q "${GORELEASER_URL}/v${GORELEASER_VERSION}/${GORELEASER_FILE}"
-apk add --no-progress --allow-untrusted "$GORELEASER_FILE"
-rm "$GORELEASER_FILE"
-wget -qO- "$GHCH_URL" > /usr/bin/ghch
+apk add --no-progress --allow-untrusted "${GORELEASER_FILE}"
+rm "${GORELEASER_FILE}"
+wget -qO- "${GHCH_URL}" > /usr/bin/ghch
 chmod +x /usr/bin/ghch
 
 echo --- :git: Determining release version from tags
 # ensure we remove leading `v`
 version="${BUILDKITE_TAG#v}"
 # put it back
-tag="v$version"
-previous_tag=$(git describe --abbrev=0 --exclude "$tag")
-echo "Version: $version"
-echo "Tag: $tag"
-echo "Previous tag: $previous_tag"
+tag="v${version}"
+previous_tag="$(git describe --abbrev=0 --exclude "${tag}")"
+echo "Version: ${version}"
+echo "Tag: ${tag}"
+echo "Previous tag: ${previous_tag}"
 
 agent_version="$(buildkite-agent meta-data get agent-version)"
 echo "Agent version: ${agent_version}"
 
 echo --- :docker: Logging into ghcr.io
 crane auth login ghcr.io \
-  --username "$REGISTRY_USERNAME" \
-  --password "$REGISTRY_PASSWORD"
+  --username "${REGISTRY_USERNAME}" \
+  --password "${REGISTRY_PASSWORD}"
 
 echo --- :docker: Tagging latest images
 crane tag "ghcr.io/buildkite/helm/agent-stack-k8s:${version}" latest
@@ -58,15 +58,15 @@ footer="
 ## Images
 ### Helm chart
 Image: \`ghcr.io/buildkite/helm/agent-stack-k8s:${version}\`
-Digest: \`$chart_digest\`
+Digest: \`${chart_digest}\`
 
 ### Controller
 Image: \`ghcr.io/buildkite/agent-stack-k8s/controller:${version}\`
-Digest: \`$controller_digest\`
+Digest: \`${controller_digest}\`
 
 ### Agent
 Image: \`ghcr.io/buildkite/agent:${agent_version}\`
-Digest: \`$agent_digest\`
+Digest: \`${agent_digest}\`
 "
 
-goreleaser release --clean --release-notes <(printf "%s\n\n\n%s" "$changelog" "$footer")
+goreleaser release --clean --release-notes <(printf "%s\n\n\n%s" "${changelog}" "${footer}")

--- a/.buildkite/steps/repo_info.sh
+++ b/.buildkite/steps/repo_info.sh
@@ -3,14 +3,14 @@
 
 set -eufo pipefail
 
-tag=$(git describe)
-version=${tag#v}
-agent_image=$(buildkite-agent meta-data get agent-image)
-controller_image=$(buildkite-agent meta-data get controller-image)
+tag="$(git describe)"
+version="${tag#v}"
+agent_image="$(buildkite-agent meta-data get agent-image)"
+controller_image="$(buildkite-agent meta-data get controller-image)"
 helm_repo="oci://ghcr.io/buildkite/helm"
-helm_image="$helm_repo/agent-stack-k8s:$version"
+helm_image="${helm_repo}/agent-stack-k8s:${version}"
 
-echo version="$version"
-echo controller_image="$controller_image"
-echo agent_image="$agent_image"
-echo helm_image="$helm_image"
+echo "version=${version}"
+echo "controller_image=${controller_image}"
+echo "agent_image=${agent_image}"
+echo "helm_image=${helm_image}"

--- a/.buildkite/steps/tests.sh
+++ b/.buildkite/steps/tests.sh
@@ -8,13 +8,13 @@ go install gotest.tools/gotestsum
 echo "+++ Running integration tests :test_tube:"
 package="github.com/buildkite/agent-stack-k8s/v2/internal/integration_test"
 branch="${BUILDKITE_BRANCH:-main}"
-IMAGE=$(buildkite-agent meta-data get agent-image)
+IMAGE="$(buildkite-agent meta-data get agent-image)"
 export IMAGE
 # Do NOT allow integration test workloads in the buildkite namespace.
 # It causes confusion and complicates cleanup.
 # The buildkite namespace is reserved for CI workloads.
 # Integration tests will use their own namespace and out-of-cluster k8s controller to manage job pods.
-export NAMESPACE=buildkite-k8s-integration-test
+export NAMESPACE="buildkite-k8s-integration-test"
 
 gotestsum --junitfile "junit-${BUILDKITE_JOB_ID}.xml" -- \
   -count=1 \

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,27 +1,23 @@
-before:
-  hooks:
-  - go mod tidy
-  - go generate ./...
 builds:
-- env:
-  - CGO_ENABLED=0
-  goos:
-  - linux
-  goarch:
-  - amd64
-  - arm64
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
 archives:
-- format: tar.gz
-  # this name template makes the OS and Arch compatible with the results of uname.
-  name_template: >-
-    {{ .ProjectName }}_
-    {{- .Os }}_
-    {{- if eq .Arch "amd64" }}x86_64
-    {{- else if eq .Arch "386" }}i386
-    {{- else }}{{ .Arch }}{{ end }}
-    {{- if .Arm }}v{{ .Arm }}{{ end }}
+  - format: tar.gz
+    # this name template makes the OS and Arch compatible with the results of uname.
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
 checksum:
-  name_template: 'checksums.txt'
+  name_template: "checksums.txt"
 snapshot:
   name_template: "{{ incpatch .Version }}-next"
 changelog:
@@ -29,8 +25,8 @@ changelog:
   use: github
   filters:
     exclude:
-    - '^docs:'
-    - '^test:'
+      - "^docs:"
+      - "^test:"
 release:
   draft: true
   replace_existing_draft: true


### PR DESCRIPTION
### What

- Shell tidyups: handlebars, quotes
- Update Go to 1.23
- Refactor env, volumes, and volume mounts using YAML anchors
- Give release step access to the Go caches

### Why

The release step is slow, maybe this will help?