### PR TITLE
Fix VolumeSource in JSON Schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -703,8 +703,6 @@ The `agent-config` block within `values.yaml` accepts most of the
 
 Additionally, volume sources for signing and verification keys can be specified,
 and automatically attached to the right containers.
-If used, the corresponding volumes are named `buildkite-signing-jwks` and
-`buildkite-verification-jwks`.
 
 Any volume source can be specified for keys, but a common choice is to use a
 `secret` source. Keys are generally small, distributed across the cluster,
@@ -726,13 +724,15 @@ and ideally are never shown in plain text.
         # used by 'buildkite-agent pipeline upload'.
         signing-jwks-file: key # optional if the file within the volume is called "key"
         signing-jwks-key-id: llamas # optional
-        signing-jwks-volume-source:
+        signingJWKSVolume:
+          name: buildkite-signing-jwks
           secret:
             secretName: my-signing-key
         # The verification key will be attached to the 'agent start' container.
         verification-jwks-file: key # optional if the file within the volume is called "key"
-        verification-failure-behavior: warn # for testing, 'block' to enforce
-        verification-jwks-volume-source:
+        verification-failure-behavior: warn # for testing/incremental rollout, use 'block' to enforce
+        verificationJWKSVolume:
+          name: buildkite-verification-jwks
           secret:
             secretName: my-verification-key
     ```
@@ -741,6 +741,8 @@ and ideally are never shown in plain text.
 Note that `signing-jwks-file` and `verification-jwks-file` agent config options
 can be used to either change the mount point of the corresponding volume (with
 an absolute path) or specify a file within the volume (with a relative path).
+The default mount points are `/buildkite/signing-jwks` and
+`/buildkite/verification-jwks`.
 
 ## How to set up agent hooks and plugins (v0.16.0 and later)
 
@@ -763,7 +765,8 @@ config maps are made available across the cluster.
     # values.yaml
     config:
       agent-config:
-        hooksVolumeSource:
+        hooksVolume:
+          name: buildkite-hooks
           configMap:
             defaultMode: 493
             name: buildkite-agent-hooks
@@ -776,14 +779,16 @@ config maps are made available across the cluster.
     # values.yaml
     config:
       agent-config:
-        pluginsVolumeSource:
+        pluginsVolume:
+          name: buildkite-plugins
           hostPath:
             type: Directory
             path: /etc/buildkite-agent/plugins
     ```
 
 Note that `hooks-path` and `plugins-path` agent config options can be used to
-change the mount point of the corresponding volume.
+change the mount point of the corresponding volume. The default mount points are
+`/buildkite/hooks` and `/buildkite/plugins`.
 
 ## How to set up agent hooks (v0.15.0 and earlier)
 

--- a/charts/agent-stack-k8s/values.schema.json
+++ b/charts/agent-stack-k8s/values.schema.json
@@ -306,11 +306,11 @@
             "plugins-path": {
               "type": "string"
             },
-            "hooksVolumeSource": {
-              "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.VolumeSource"
+            "hooksVolume": {
+              "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.Volume"
             },
-            "pluginsVolumeSource": {
-              "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.VolumeSource"
+            "pluginsVolume": {
+              "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.Volume"
             },
             "debug-signing": {
               "type": "boolean"
@@ -321,8 +321,8 @@
             "signing-jwks-key-id": {
               "type": "string"
             },
-            "signingJWKSVolumeSource": {
-              "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.VolumeSource"
+            "signingJWKSVolume": {
+              "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.Volume"
             },
             "verification-jwks-file": {
               "type": "string"
@@ -330,8 +330,8 @@
             "verification-failure-behavior": {
               "type": "string"
             },
-            "verificationJWKSVolumeSource": {
-              "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.VolumeSource"
+            "verificationJWKSVolume": {
+              "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.Volume"
             }
           }
         },


### PR DESCRIPTION
Turns out `VolumeSource` is just an artefact of the Go library implementation - the JSON Schema has no concept of `VolumeSource`, only `Volume`. (And "name" is required, per the schema.)

I suppose the user should be able to change the volume name if they want, anyway.

I tested it and it works:

<img width="429" alt="Screenshot 2024-10-08 at 5 39 10 PM" src="https://github.com/user-attachments/assets/3282a330-2c36-4466-874f-f2bf62ef8099">
