### PR TITLE
Make all new bool options optional

### DIFF
--- a/internal/controller/config/checkout_params.go
+++ b/internal/controller/config/checkout_params.go
@@ -13,7 +13,7 @@ type CheckoutParams struct {
 	CleanFlags           *string                    `json:"cleanFlags,omitempty"`
 	CloneFlags           *string                    `json:"cloneFlags,omitempty"`
 	FetchFlags           *string                    `json:"fetchFlags,omitempty"`
-	NoSubmodules         bool                       `json:"noSubmodules,omitempty"`
+	NoSubmodules         *bool                      `json:"noSubmodules,omitempty"`
 	SubmoduleCloneConfig []string                   `json:"submoduleCloneConfig,omitempty"`
 	GitMirrors           *GitMirrorsParams          `json:"gitMirrors,omitempty"`
 	GitCredentialsSecret *corev1.SecretVolumeSource `json:"gitCredentialsSecret,omitempty"`
@@ -27,7 +27,7 @@ func (co *CheckoutParams) ApplyTo(podSpec *corev1.PodSpec, ctr *corev1.Container
 	appendToEnvOpt(ctr, "BUILDKITE_GIT_CLEAN_FLAGS", co.CleanFlags)
 	appendToEnvOpt(ctr, "BUILDKITE_GIT_CLONE_FLAGS", co.CloneFlags)
 	appendToEnvOpt(ctr, "BUILDKITE_GIT_FETCH_FLAGS", co.FetchFlags)
-	appendBoolToEnv(ctr, "BUILDKITE_GIT_SUBMODULES", co.NoSubmodules)
+	appendBoolToEnvOpt(ctr, "BUILDKITE_GIT_SUBMODULES", co.NoSubmodules)
 	appendCommaSepToEnv(ctr, "BUILDKITE_GIT_SUBMODULE_CLONE_CONFIG", co.SubmoduleCloneConfig)
 	co.GitMirrors.ApplyTo(podSpec, ctr)
 	ctr.EnvFrom = append(ctr.EnvFrom, co.EnvFrom...)
@@ -46,7 +46,7 @@ type GitMirrorsParams struct {
 	Volume      *corev1.Volume `json:"volume,omitempty"`
 	CloneFlags  *string        `json:"cloneFlags,omitempty"`
 	LockTimeout int            `json:"lockTimeout,omitempty"`
-	SkipUpdate  bool           `json:"skipUpdate,omitempty"`
+	SkipUpdate  *bool          `json:"skipUpdate,omitempty"`
 }
 
 func (gm *GitMirrorsParams) ApplyTo(podSpec *corev1.PodSpec, ctr *corev1.Container) {
@@ -70,5 +70,5 @@ func (gm *GitMirrorsParams) ApplyTo(podSpec *corev1.PodSpec, ctr *corev1.Contain
 	if gm.LockTimeout > 0 {
 		appendToEnv(ctr, "BUILDKITE_GIT_MIRRORS_LOCK_TIMEOUT", strconv.Itoa(gm.LockTimeout))
 	}
-	appendBoolToEnv(ctr, "BUILDKITE_GIT_MIRRORS_SKIP_UPDATE", gm.SkipUpdate)
+	appendBoolToEnvOpt(ctr, "BUILDKITE_GIT_MIRRORS_SKIP_UPDATE", gm.SkipUpdate)
 }

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -112,8 +112,18 @@ func appendToEnvOpt(ctr *corev1.Container, name string, value *string) {
 	ctr.Env = append(ctr.Env, corev1.EnvVar{Name: name, Value: *value})
 }
 
-func appendBoolToEnv(ctr *corev1.Container, name string, value bool) {
-	ctr.Env = append(ctr.Env, corev1.EnvVar{Name: name, Value: strconv.FormatBool(value)})
+func appendBoolToEnvOpt(ctr *corev1.Container, name string, value *bool) {
+	if value == nil {
+		return
+	}
+	ctr.Env = append(ctr.Env, corev1.EnvVar{Name: name, Value: strconv.FormatBool(*value)})
+}
+
+func appendNegatedToEnvOpt(ctr *corev1.Container, name string, value *bool) {
+	if value == nil {
+		return
+	}
+	ctr.Env = append(ctr.Env, corev1.EnvVar{Name: name, Value: strconv.FormatBool(!*value)})
 }
 
 func appendCommaSepToEnv(ctr *corev1.Container, name string, values []string) {


### PR DESCRIPTION
### What
Instead of setting boolean options on the containers whether or not they are set, only set them if the option is configured in the config, similar to all the string options.

### Why
I slept on it, and realised that unconditionally setting bools in the env makes incrementally adopting the new config path harder, if a user has built a custom agent image with their own config or have been setting the env var themselves through the pipeline.