### PR TITLE
Fix leftover pods from test

### DIFF
--- a/.buildkite/rbac.yaml
+++ b/.buildkite/rbac.yaml
@@ -3,31 +3,37 @@ kind: ClusterRole
 metadata:
   name: integration-tests
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-- apiGroups:
-  - batch
-  resources:
-  - jobs
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - delete
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - get
-  - list
-  - watch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods/eviction
+    verbs:
+      - create
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -44,9 +50,9 @@ roleRef:
   kind: ClusterRole
   name: integration-tests
 subjects:
-- kind: ServiceAccount
-  name: integration-tests
-  namespace: buildkite
+  - kind: ServiceAccount
+    name: integration-tests
+    namespace: buildkite
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -54,26 +60,26 @@ metadata:
   name: docker
   namespace: buildkite
 rules:
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  verbs:
-  - get
-  - create
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - list
-- apiGroups:
-  - ""
-  resources:
-  - pods/exec
-  verbs:
-  - create
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - get
+      - create
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - list
+  - apiGroups:
+      - ""
+    resources:
+      - pods/exec
+    verbs:
+      - create
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -91,9 +97,9 @@ roleRef:
   kind: Role
   name: docker
 subjects:
-- kind: ServiceAccount
-  name: docker
-  namespace: buildkite
+  - kind: ServiceAccount
+    name: docker
+    namespace: buildkite
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -111,34 +117,34 @@ roleRef:
   kind: ClusterRole
   name: cluster-admin
 subjects:
-- kind: ServiceAccount
-  name: deploy
+  - kind: ServiceAccount
+    name: deploy
+    namespace: buildkite
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: read-release-secret
   namespace: buildkite
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["release-secrets"]
+    verbs: ["get", "watch", "list"]
 ---
- apiVersion: rbac.authorization.k8s.io/v1
- kind: Role
- metadata:
-   name: read-release-secret
-   namespace: buildkite
- rules:
- - apiGroups: [""]
-   resources: ["secrets"]
-   resourceNames: ["release-secrets"]
-   verbs: ["get", "watch", "list"]
----
- apiVersion: rbac.authorization.k8s.io/v1
- kind: RoleBinding
- metadata:
-   name: read-release-secret
-   namespace: buildkite
- subjects:
- - kind: ServiceAccount
-   name: release
-   namespace: buildkite
- roleRef:
-   kind: Role
-   name: read-release-secret
-   apiGroup: rbac.authorization.k8s.io
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: read-release-secret
+  namespace: buildkite
+subjects:
+  - kind: ServiceAccount
+    name: release
+    namespace: buildkite
+roleRef:
+  kind: Role
+  name: read-release-secret
+  apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
`TestImagePullBackOffWatcher` seems to leave a pending pod lying around. The role didn't have the permissions to create evictions. That rule was added to the template, but not to our own rbac.yaml.