### PR TITLE
Add config for parallel command containers

### DIFF
--- a/internal/controller/config/checkout_params.go
+++ b/internal/controller/config/checkout_params.go
@@ -33,6 +33,13 @@ func (co *CheckoutParams) ApplyTo(podSpec *corev1.PodSpec, ctr *corev1.Container
 	ctr.EnvFrom = append(ctr.EnvFrom, co.EnvFrom...)
 }
 
+func (co *CheckoutParams) ShouldSkip() *bool {
+	if co == nil {
+		return nil
+	}
+	return co.Skip
+}
+
 func (co *CheckoutParams) GitCredsSecret() *corev1.SecretVolumeSource {
 	if co == nil {
 		return nil

--- a/internal/controller/config/command_params.go
+++ b/internal/controller/config/command_params.go
@@ -13,8 +13,17 @@ import (
 // CommandParams contains parameters that provide additional control over all
 // command container(s).
 type CommandParams struct {
-	Interposer Interposer             `json:"interposer,omitempty"`
-	EnvFrom    []corev1.EnvFromSource `json:"envFrom,omitempty"`
+	// Interposer controls how the command and args container fields are
+	// interpreted into a BUILDKITE_COMMAND.
+	Interposer Interposer `json:"interposer,omitempty"`
+
+	// Parallel controls whether command containers are allowed to start running
+	// commands in parallel with each other. By default each command container
+	// waits until the previous command container has finished its command.
+	Parallel *bool `json:"parallel,omitempty"`
+
+	// EnvFrom adds environment variables to command containers from a source.
+	EnvFrom []corev1.EnvFromSource `json:"envFrom,omitempty"`
 }
 
 func (cmd *CommandParams) ApplyTo(ctr *corev1.Container) {
@@ -22,6 +31,15 @@ func (cmd *CommandParams) ApplyTo(ctr *corev1.Container) {
 		return
 	}
 	ctr.EnvFrom = append(ctr.EnvFrom, cmd.EnvFrom...)
+}
+
+// RunInParallel returns nil if the receiver is nil, otherwise it returns
+// the Parallel field.
+func (cmd *CommandParams) RunInParallel() *bool {
+	if cmd == nil {
+		return nil
+	}
+	return cmd.Parallel
 }
 
 // Command interprets the command and args fields of the container into a

--- a/internal/controller/scheduler/plugin.go
+++ b/internal/controller/scheduler/plugin.go
@@ -1,0 +1,89 @@
+package scheduler
+
+import (
+	"github.com/buildkite/agent-stack-k8s/v2/internal/controller/config"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type KubernetesPlugin struct {
+	PodSpec           *corev1.PodSpec        `json:"podSpec,omitempty"`
+	PodSpecPatch      *corev1.PodSpec        `json:"podSpecPatch,omitempty"`
+	GitEnvFrom        []corev1.EnvFromSource `json:"gitEnvFrom,omitempty"`
+	Sidecars          []corev1.Container     `json:"sidecars,omitempty"`
+	Metadata          Metadata               `json:"metadata,omitempty"`
+	ExtraVolumeMounts []corev1.VolumeMount   `json:"extraVolumeMounts,omitempty"`
+	CheckoutParams    *config.CheckoutParams `json:"checkout,omitempty"`
+	CommandParams     *config.CommandParams  `json:"commandParams,omitempty"`
+	SidecarParams     *config.SidecarParams  `json:"sidecarParams,omitempty"`
+}
+
+type Metadata struct {
+	Annotations map[string]string
+	Labels      map[string]string
+}
+
+// The helper methods below implement "safe navigation" for config fields
+// (like &. in Ruby).
+
+// gitEnvFrom returns nil if the receiver is nil, otherwise it returns the
+// GitEnvFrom field.
+func (kp *KubernetesPlugin) gitEnvFrom() []corev1.EnvFromSource {
+	if kp == nil {
+		return nil
+	}
+	return kp.GitEnvFrom
+}
+
+// sidecars returns nil if the receiver is nil, otherwise it returns the
+// Sidecars field.
+func (kp *KubernetesPlugin) sidecars() []corev1.Container {
+	if kp == nil {
+		return nil
+	}
+	return kp.Sidecars
+}
+
+// extraVolumeMounts returns an empty Metadata if the receiver is nil, otherwise
+// it returns the Metadata field.
+func (kp *KubernetesPlugin) metadata() Metadata {
+	if kp == nil {
+		return Metadata{}
+	}
+	return kp.Metadata
+}
+
+// extraVolumeMounts returns nil if the receiver is nil, otherwise it returns
+// the ExtraVolumeMounts field.
+func (kp *KubernetesPlugin) extraVolumeMounts() []corev1.VolumeMount {
+	if kp == nil {
+		return nil
+	}
+	return kp.ExtraVolumeMounts
+}
+
+// checkoutParams returns nil if the receiver is nil, otherwise it returns the
+// CheckoutParams field.
+func (kp *KubernetesPlugin) checkoutParams() *config.CheckoutParams {
+	if kp == nil {
+		return nil
+	}
+	return kp.CheckoutParams
+}
+
+// commandParams returns nil if the receiver is nil, otherwise it returns the
+// CommandParams field.
+func (kp *KubernetesPlugin) commandParams() *config.CommandParams {
+	if kp == nil {
+		return nil
+	}
+	return kp.CommandParams
+}
+
+// sidecarParams returns nil if the receiver is nil, otherwise it returns the
+// SidecarParams field.
+func (kp *KubernetesPlugin) sidecarParams() *config.SidecarParams {
+	if kp == nil {
+		return nil
+	}
+	return kp.SidecarParams
+}


### PR DESCRIPTION
### What

Define a new env var to set on the agent-start container that controls when the commands in the command containers can run.

### Why

Each container connects to the agent-start container using a Unix domain socket, and then waits until the agent-start container tells it to start. Currently, it only starts containers serially: container with ID `N` only starts after container with ID `N-1` is finished (except for container with ID 0, which can always start), with no way to override this.

This change implements such an override. Note that a corresponding agent change is also needed.