### PR TITLE
Run commands under tini-static

### DIFF
--- a/internal/controller/scheduler/scheduler_test.go
+++ b/internal/controller/scheduler/scheduler_test.go
@@ -171,14 +171,14 @@ func TestJobPluginConversion(t *testing.T) {
 
 	commandContainer := findContainer(t, gotPodSpec.Containers, "container-0")
 
-	// Command should be replaced with buildkite-agent.
-	// Args should be set to bootstrap.
+	// Command should be replaced with tini-static.
+	// Args should be set to -- buildkite-agent bootstrap.
 	// The original command should be placed in BUILDKITE_COMMAND.
-	wantCommand := []string{"/workspace/buildkite-agent"}
+	wantCommand := []string{"/workspace/tini-static"}
 	if diff := cmp.Diff(commandContainer.Command, wantCommand); diff != "" {
 		t.Errorf("kjob.Spec.Template.Spec.Containers[0].Command diff (-got +want):\n%s", diff)
 	}
-	wantArgs := []string{"bootstrap"}
+	wantArgs := []string{"--", "/workspace/buildkite-agent", "bootstrap"}
 	if diff := cmp.Diff(commandContainer.Args, wantArgs); diff != "" {
 		t.Errorf("kjob.Spec.Template.Spec.Containers[0].Args diff (-got +want):\n%s", diff)
 	}


### PR DESCRIPTION
### Why
To reap defunct processes. `buildkite-agent` doesn't do this currently, that's what an init process like `tini` is for.

Before:
<img width="779" alt="Screenshot 2024-10-28 at 1 56 22 PM" src="https://github.com/user-attachments/assets/a2763905-d898-49a4-bcf9-94fffa8ea13d">

After:
<img width="895" alt="Screenshot 2024-10-28 at 1 53 11 PM" src="https://github.com/user-attachments/assets/c97487ad-5419-4d1d-a0bc-8ffc10d8bd22">

### What
- Copy both buildkite-agent and tini-static into /workspace using the init container
- Run command containers using a command that looks like:
  ```shell
  /workspace/tini-static -- /workspace/buildkite-agent bootstrap
  ```
- Update the test