### PR TITLE
Fix parsing configs with dots in mapping keys

### DIFF
--- a/cmd/controller/controller_test.go
+++ b/cmd/controller/controller_test.go
@@ -75,6 +75,9 @@ func TestReadAndParseConfig(t *testing.T) {
 		PodSpecPatch: &corev1.PodSpec{
 			ServiceAccountName:           "buildkite-agent-sa",
 			AutomountServiceAccountToken: ptr(true),
+			NodeSelector: map[string]string{
+				"selectors.example.com/my-selector": "example-value",
+			},
 			Containers: []corev1.Container{
 				{
 					Name: "container-0",

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -61,6 +61,8 @@ default-sidecar-params:
 pod-spec-patch:
   serviceAccountName: buildkite-agent-sa
   automountServiceAccountToken: true
+  nodeSelector:
+    selectors.example.com/my-selector: example-value
   containers:
     - name: container-0
       env:


### PR DESCRIPTION
### What
Change viper's key delimiter to something other than `.`.

### Why
Viper unmarshals keys with `.`s as a series of nested maps, instead of as a single string key. Which is frustrating when the Kubernetes convention is to use domain names within keys.