### PR TITLE
Configurable stale job data timeout

### DIFF
--- a/cmd/controller/controller_test.go
+++ b/cmd/controller/controller_test.go
@@ -27,6 +27,7 @@ func TestReadAndParseConfig(t *testing.T) {
 		ImagePullBackOffGracePeriod:  60 * time.Second,
 		JobCancelCheckerPollInterval: 10 * time.Second,
 		PollInterval:                 5 * time.Second,
+		StaleJobDataTimeout:          10 * time.Second,
 		MaxInFlight:                  100,
 		Namespace:                    "my-buildkite-ns",
 		Org:                          "my-buildkite-org",

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -5,6 +5,7 @@ job-ttl: 5m
 image-pull-backoff-grace-period: 60s
 job-cancel-checker-poll-interval: 10s
 poll-interval: 5s
+stale-job-data-timeout: 10s
 max-in-flight: 100
 namespace: my-buildkite-ns
 org: my-buildkite-org

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -25,18 +25,19 @@ var DefaultAgentImage = "ghcr.io/buildkite/agent:" + version.Version()
 // mapstructure (the module) supports switching the struct tag to "json", viper does not. So we have
 // to have the `mapstructure` tag for viper and the `json` tag is used by the mapstructure!
 type Config struct {
-	Debug            bool          `json:"debug"`
-	JobTTL           time.Duration `json:"job-ttl"`
-	PollInterval     time.Duration `json:"poll-interval"`
-	AgentTokenSecret string        `json:"agent-token-secret" validate:"required"`
-	BuildkiteToken   string        `json:"buildkite-token"    validate:"required"`
-	Image            string        `json:"image"              validate:"required"`
-	MaxInFlight      int           `json:"max-in-flight"      validate:"min=0"`
-	Namespace        string        `json:"namespace"          validate:"required"`
-	Org              string        `json:"org"                validate:"required"`
-	Tags             stringSlice   `json:"tags"               validate:"min=1"`
-	ProfilerAddress  string        `json:"profiler-address"   validate:"omitempty,hostname_port"`
-	GraphQLEndpoint  string        `json:"graphql-endpoint"   validate:"omitempty"`
+	Debug               bool          `json:"debug"`
+	JobTTL              time.Duration `json:"job-ttl"`
+	PollInterval        time.Duration `json:"poll-interval"`
+	StaleJobDataTimeout time.Duration `json:"stale-job-data-timeout" validate:"omitempty"`
+	AgentTokenSecret    string        `json:"agent-token-secret"     validate:"required"`
+	BuildkiteToken      string        `json:"buildkite-token"        validate:"required"`
+	Image               string        `json:"image"                  validate:"required"`
+	MaxInFlight         int           `json:"max-in-flight"          validate:"min=0"`
+	Namespace           string        `json:"namespace"              validate:"required"`
+	Org                 string        `json:"org"                    validate:"required"`
+	Tags                stringSlice   `json:"tags"                   validate:"min=1"`
+	ProfilerAddress     string        `json:"profiler-address"       validate:"omitempty,hostname_port"`
+	GraphQLEndpoint     string        `json:"graphql-endpoint"       validate:"omitempty"`
 	// Agent endpoint is set in agent-config.
 
 	// ClusterUUID field is mandatory for most new orgs.

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -38,14 +38,15 @@ func Run(
 	}
 
 	m, err := monitor.New(logger.Named("monitor"), k8sClient, monitor.Config{
-		GraphQLEndpoint: cfg.GraphQLEndpoint,
-		Namespace:       cfg.Namespace,
-		Org:             cfg.Org,
-		ClusterUUID:     cfg.ClusterUUID,
-		MaxInFlight:     cfg.MaxInFlight,
-		PollInterval:    cfg.PollInterval,
-		Tags:            cfg.Tags,
-		Token:           cfg.BuildkiteToken,
+		GraphQLEndpoint:     cfg.GraphQLEndpoint,
+		Namespace:           cfg.Namespace,
+		Org:                 cfg.Org,
+		ClusterUUID:         cfg.ClusterUUID,
+		MaxInFlight:         cfg.MaxInFlight,
+		PollInterval:        cfg.PollInterval,
+		StaleJobDataTimeout: cfg.StaleJobDataTimeout,
+		Tags:                cfg.Tags,
+		Token:               cfg.BuildkiteToken,
 	})
 	if err != nil {
 		logger.Fatal("failed to create monitor", zap.Error(err))


### PR DESCRIPTION
`poll-interval` is probably not be the ideal timeout for stale job data in many cases, so make it configurable and default it to 10s (duration chosen by guesswork). 

Increasing the timeout means more jobs from the same GraphQL query can be created before the next poll, but increases the chances of scheduling an already-cancelled job as a pod.