### PR TITLE
Add Prometheus metrics

### DIFF
--- a/charts/agent-stack-k8s/templates/deployment.yaml.tpl
+++ b/charts/agent-stack-k8s/templates/deployment.yaml.tpl
@@ -36,6 +36,11 @@ spec:
             subPath: config.yaml
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
+        {{ with index .Values.config "prometheus-port" -}}
+        ports:
+          - name: metrics
+            containerPort: {{.}}
+        {{ end -}}
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -83,6 +83,11 @@ func AddConfigFlags(cmd *cobra.Command) {
 		"",
 		"Bind address to expose the pprof profiler (e.g. localhost:6060)",
 	)
+	cmd.Flags().Uint16(
+		"prometheus-port",
+		0,
+		"Bind port to expose Prometheus /metrics; 0 disables it",
+	)
 	cmd.Flags().String("graphql-endpoint", "", "Buildkite GraphQL endpoint URL")
 
 	cmd.Flags().Duration(

--- a/go.mod
+++ b/go.mod
@@ -53,6 +53,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.28.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.32.4 // indirect
 	github.com/aws/smithy-go v1.22.0 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bitfield/gotestdox v0.2.2 // indirect
 	github.com/buildkite/go-pipeline v0.13.2 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0 // indirect
@@ -73,6 +74,7 @@ require (
 	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.7 // indirect
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2 // indirect
 	github.com/hashicorp/go-sockaddr v1.0.2 // indirect
+	github.com/klauspost/compress v1.17.9 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lestrrat-go/blackmagic v1.0.2 // indirect
 	github.com/lestrrat-go/httpcc v1.0.1 // indirect
@@ -84,6 +86,9 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/outcaste-io/ristretto v0.2.3 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
+	github.com/prometheus/client_model v0.6.1 // indirect
+	github.com/prometheus/common v0.55.0 // indirect
+	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
@@ -161,6 +166,7 @@ require (
 	github.com/philhofer/fwd v1.1.3-0.20240612014219-fbbf4953d986 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
+	github.com/prometheus/client_golang v1.20.5
 	github.com/puzpuzpuz/xsync/v2 v2.5.1 // indirect
 	github.com/qri-io/jsonpointer v0.1.1 // indirect
 	github.com/qri-io/jsonschema v0.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -91,6 +91,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.32.4 h1:yDxvkz3/uOKfxnv8YhzOi9m+2OGI
 github.com/aws/aws-sdk-go-v2/service/sts v1.32.4/go.mod h1:9XEUty5v5UAsMiFOBJrNibZgwCeOma73jgGwwhgffa8=
 github.com/aws/smithy-go v1.22.0 h1:uunKnWlcoL3zO7q+gG2Pk53joueEOsnNB28QdMsmiMM=
 github.com/aws/smithy-go v1.22.0/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxYa/cJHg=
+github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
+github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bitfield/gotestdox v0.2.2 h1:x6RcPAbBbErKLnapz1QeAlf3ospg8efBsedU93CDsnE=
 github.com/bitfield/gotestdox v0.2.2/go.mod h1:D+gwtS0urjBrzguAkTM2wodsTQYFHdpx8eqRJ3N+9pY=
@@ -290,6 +292,8 @@ github.com/keybase/go-keychain v0.0.0-20231219164618-57a3676c3af6 h1:IsMZxCuZqKu
 github.com/keybase/go-keychain v0.0.0-20231219164618-57a3676c3af6/go.mod h1:3VeWNIJaW+O5xpRQbPp0Ybqu1vJd/pm7s2F473HRrkw=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=
+github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
@@ -361,7 +365,15 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
+github.com/prometheus/client_golang v1.20.5 h1:cxppBPuYhUnsO6yo/aoRol4L7q7UFfdm+bR9r+8l63Y=
+github.com/prometheus/client_golang v1.20.5/go.mod h1:PIEt8X02hGcP8JWbeHyeZ53Y/jReSnHgO035n//V5WE=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/prometheus/client_model v0.6.1 h1:ZKSh/rekM+n3CeS952MLRAdFwIKqeY8b62p8ais2e9E=
+github.com/prometheus/client_model v0.6.1/go.mod h1:OrxVMOVHjw3lKMa8+x6HeMGkHMQyHDk9E3jmP2AmGiY=
+github.com/prometheus/common v0.55.0 h1:KEi6DK7lXW/m7Ig5i47x0vRzuBsHuvJdi5ee6Y3G1dc=
+github.com/prometheus/common v0.55.0/go.mod h1:2SECS4xJG1kd8XF9IcM1gMX6510RAEL65zxzNImwdc8=
+github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
+github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/puzpuzpuz/xsync/v2 v2.5.1 h1:mVGYAvzDSu52+zaGyNjC+24Xw2bQi3kTr4QJ6N9pIIU=
 github.com/puzpuzpuz/xsync/v2 v2.5.1/go.mod h1:gD2H2krq/w52MfPLE+Uy64TzJDVY7lP2znR9qmR35kU=
 github.com/qri-io/jsonpointer v0.1.1 h1:prVZBZLL6TW5vsSB9fFHFAMBLI4b0ri5vribQlTJiBA=

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -37,6 +37,7 @@ type Config struct {
 	Namespace              string        `json:"namespace"                validate:"required"`
 	Org                    string        `json:"org"                      validate:"required"`
 	Tags                   stringSlice   `json:"tags"                     validate:"min=1"`
+	PrometheusPort         uint16        `json:"prometheus-port"          validate:"omitempty"`
 	ProfilerAddress        string        `json:"profiler-address"         validate:"omitempty,hostname_port"`
 	GraphQLEndpoint        string        `json:"graphql-endpoint"         validate:"omitempty"`
 	// Agent endpoint is set in agent-config.
@@ -89,6 +90,7 @@ func (c Config) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 		return err
 	}
 	enc.AddString("profiler-address", c.ProfilerAddress)
+	enc.AddUint16("prometheus-port", c.PrometheusPort)
 	enc.AddString("cluster-uuid", c.ClusterUUID)
 	enc.AddBool("prohibit-kubernetes-plugin", c.ProhibitKubernetesPlugin)
 	if err := enc.AddArray("additional-redacted-vars", c.AdditionalRedactedVars); err != nil {

--- a/internal/controller/deduper/metrics.go
+++ b/internal/controller/deduper/metrics.go
@@ -1,0 +1,80 @@
+package deduper
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+const (
+	promNamespace = "buildkite"
+	promSubsystem = "deduper"
+)
+
+// Overridden by New to return len(inFlight).
+var jobsRunningGaugeFunc = func() int { return 0 }
+
+var (
+	_ = promauto.NewGaugeFunc(prometheus.GaugeOpts{
+		Namespace: promNamespace,
+		Subsystem: promSubsystem,
+		Name:      "jobs_running",
+		Help:      "Current number of running jobs according to deduper",
+	}, func() float64 { return float64(jobsRunningGaugeFunc()) })
+
+	jobHandlerCallsCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: promSubsystem,
+		Name:      "job_handler_calls_total",
+		Help:      "Count of jobs that were passed to the next handler in the chain",
+	})
+	jobHandlerErrorCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: promSubsystem,
+		Name:      "job_handler_errors_total",
+		Help:      "Count of jobs that weren't scheduled because the next handler in the chain returned an error",
+	})
+
+	onAddEventCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: promSubsystem,
+		Name:      "onadd_events_total",
+		Help:      "Count of OnAdd informer events",
+	})
+	onUpdateEventCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: promSubsystem,
+		Name:      "onupdate_event_total",
+		Help:      "Count of OnUpdate informer events",
+	})
+	onDeleteEventCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: promSubsystem,
+		Name:      "ondelete_events_total",
+		Help:      "Count of OnDelete informer events",
+	})
+
+	jobsMarkedRunningCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: promSubsystem,
+		Name:      "jobs_marked_running_total",
+		Help:      "Count of times a job was added to inFlight",
+	}, []string{"source"})
+	jobsUnmarkedRunningCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: promSubsystem,
+		Name:      "jobs_unmarked_running_total",
+		Help:      "Count of times a job was removed from inFlight",
+	}, []string{"source"})
+	jobsAlreadyRunningCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: promSubsystem,
+		Name:      "jobs_already_running_total",
+		Help:      "Count of times a job was already present in inFlight",
+	}, []string{"source"})
+	jobsAlreadyNotRunningCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: promSubsystem,
+		Name:      "jobs_already_not_running_total",
+		Help:      "Count of times a job was already missing from inFlight",
+	}, []string{"source"})
+)

--- a/internal/controller/limiter/metrics.go
+++ b/internal/controller/limiter/metrics.go
@@ -1,0 +1,82 @@
+package limiter
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+const (
+	promNamespace = "buildkite"
+	promSubsystem = "limiter"
+)
+
+// Overridden by New to return len(tokenBucket).
+var tokensAvailableFunc = func() int { return 0 }
+
+var (
+	maxInFlightGauge = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: promNamespace,
+		Subsystem: promSubsystem,
+		Name:      "max_in_flight",
+		Help:      "Configured limit on number of jobs simultaneously in flight",
+	})
+	_ = promauto.NewGaugeFunc(prometheus.GaugeOpts{
+		Namespace: promNamespace,
+		Subsystem: promSubsystem,
+		Name:      "tokens_available",
+		Help:      "Limiter tokens currently available",
+	}, func() float64 { return float64(tokensAvailableFunc()) })
+	tokenWaitDurationHistogram = promauto.NewHistogram(prometheus.HistogramOpts{
+		Namespace:                    promNamespace,
+		Subsystem:                    promSubsystem,
+		Name:                         "token_wait_duration_seconds",
+		Help:                         "Time spent waiting for a limiter token to become available",
+		NativeHistogramBucketFactor:  1.1,
+		NativeHistogramZeroThreshold: 0.01,
+	})
+
+	jobHandlerCallsCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: promSubsystem,
+		Name:      "job_handler_calls_total",
+		Help:      "Count of jobs that were passed to the next handler in the chain",
+	})
+	jobHandlerErrorCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: promSubsystem,
+		Name:      "job_handler_errors_total",
+		Help:      "Count of jobs that weren't scheduled because the next handler in the chain returned an error",
+	})
+
+	onAddEventCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: promSubsystem,
+		Name:      "onadd_events_total",
+		Help:      "Count of OnAdd informer events",
+	})
+	onUpdateEventCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: promSubsystem,
+		Name:      "onupdate_events_total",
+		Help:      "Count of OnUpdate informer events",
+	})
+	onDeleteEventCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: promSubsystem,
+		Name:      "ondelete_events_total",
+		Help:      "Count of OnDelete informer events",
+	})
+
+	tokenUnderflowCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: promSubsystem,
+		Name:      "token_underflows_total",
+		Help:      "Count of attempts to take a token when the bucket was empty",
+	}, []string{"source"})
+	tokenOverflowCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: promSubsystem,
+		Name:      "token_overflows_total",
+		Help:      "Count of attempts to return a token when the bucket was full",
+	}, []string{"source"})
+)

--- a/internal/controller/model/model.go
+++ b/internal/controller/model/model.go
@@ -4,6 +4,7 @@ package model
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/buildkite/agent-stack-k8s/v2/api"
 
@@ -30,6 +31,9 @@ type Job struct {
 
 	// Closed when the job information becomes stale.
 	StaleCh <-chan struct{}
+
+	// When we began the Buildkite GraphQL query that returned this job.
+	QueriedAt time.Time
 }
 
 // JobFinished reports if the job has a Complete or Failed status condition.

--- a/internal/controller/monitor/metrics.go
+++ b/internal/controller/monitor/metrics.go
@@ -1,0 +1,77 @@
+package monitor
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+const (
+	promNamespace = "buildkite"
+	promSubsystem = "monitor"
+)
+
+var (
+	monitorUpGauge = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: promNamespace,
+		Subsystem: promSubsystem,
+		Name:      "monitor_up",
+		Help:      "Whether the monitor loop is running (0 = stopped, 1 = running)",
+	})
+
+	jobQueryCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: promSubsystem,
+		Name:      "job_queries_total",
+		Help:      "Count of queries to Buildkite to fetch jobs",
+	})
+	jobQueryErrorCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: promSubsystem,
+		Name:      "job_query_errors_total",
+		Help:      "Count of errors from queries to Buildkite to fetch jobs",
+	})
+	jobQueryDurationHistogram = promauto.NewHistogram(prometheus.HistogramOpts{
+		Namespace:                    promNamespace,
+		Subsystem:                    promSubsystem,
+		Name:                         "job_query_seconds",
+		Help:                         "Time taken to fetch jobs from Buildkite",
+		NativeHistogramBucketFactor:  1.1,
+		NativeHistogramZeroThreshold: 0.001,
+	})
+	jobsReturnedCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: promSubsystem,
+		Name:      "jobs_returned_total",
+		Help:      "Count of jobs returned from queries to Buildkite",
+	})
+	jobsReachedWorkerCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: promSubsystem,
+		Name:      "jobs_reached_worker_total",
+		Help:      "Count of jobs received by a jobHandlerWorker",
+	})
+	jobsFilteredOutCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: promSubsystem,
+		Name:      "jobs_filtered_out_total",
+		Help:      "Count of jobs that didn't match the configured agent tags",
+	})
+	jobHandlerCallsCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: promSubsystem,
+		Name:      "jobs_handled_total",
+		Help:      "Count of jobs that were passed to the next handler in the chain",
+	})
+	jobHandlerErrorCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: promSubsystem,
+		Name:      "job_handler_errors_total",
+		Help:      "Count of jobs that weren't scheduled because the next handler in the chain returned an error",
+	}, []string{"reason"})
+	staleJobsCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: promSubsystem,
+		Name:      "stale_jobs_total",
+		Help:      "Count of jobs that weren't scheduled because their information was queried too long ago",
+	})
+)

--- a/internal/controller/scheduler/metrics.go
+++ b/internal/controller/scheduler/metrics.go
@@ -1,0 +1,155 @@
+package scheduler
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+const promNamespace = "buildkite"
+
+// General metrics
+
+var jobEndToEndDurationHistogram = promauto.NewHistogram(prometheus.HistogramOpts{
+	Namespace:                    promNamespace,
+	Name:                         "job_end_to_end_seconds",
+	Help:                         "End-to-end processing times of jobs. Specifically, for each job, the duration between starting the query that returned the job from Buildkite, and successfully creating that job in Kubernetes.",
+	NativeHistogramBucketFactor:  1.1,
+	NativeHistogramZeroThreshold: 0.01,
+})
+
+// Scheduler metrics
+
+var (
+	jobCreateCallsCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: "scheduler",
+		Name:      "job_create_calls_total",
+		Help:      "Count of jobs that were passed to Kubernetes to create",
+	})
+	jobCreateSuccessCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: "scheduler",
+		Name:      "job_create_success_total",
+		Help:      "Count of jobs that were successfully created in Kubernetes",
+	})
+	jobCreateErrorCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: "scheduler",
+		Name:      "job_create_errors_total",
+		Help:      "Count of jobs that weren't created in Kubernetes because of an error",
+	}, []string{"reason"})
+
+	schedulerBuildkiteJobFailsCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: "scheduler",
+		Name:      "jobs_failed_on_buildkite_total",
+		Help:      "Count of jobs that scheduler successfully acquired and failed on Buildkite",
+	})
+	schedulerBuildkiteJobFailErrorsCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: "scheduler",
+		Name:      "job_fail_on_buildkite_errors_total",
+		Help:      "Count of errors when scheduler tried to acquire and fail a job on Buildkite",
+	})
+)
+
+// Pod watcher metrics
+
+var (
+	// Overridden to return len(jobCancelCheckers) by podWatcher.
+	jobCancelCheckerGaugeFunc = func() int { return 0 }
+
+	_ = promauto.NewGaugeFunc(prometheus.GaugeOpts{
+		Namespace: promNamespace,
+		Subsystem: "pod_watcher",
+		Name:      "num_job_cancel_checkers",
+		Help:      "Current count of job cancellation checkers",
+	}, func() float64 { return float64(jobCancelCheckerGaugeFunc()) })
+
+	podWatcherOnAddEventCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: "pod_watcher",
+		Name:      "onadd_events_total",
+		Help:      "Count of OnAdd informer events",
+	})
+	podWatcherOnUpdateEventCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: "pod_watcher",
+		Name:      "onupdate_events_total",
+		Help:      "Count of OnUpdate informer events",
+	})
+	podWatcherOnDeleteEventCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: "pod_watcher",
+		Name:      "ondelete_events_total",
+		Help:      "Count of OnDelete informer events",
+	})
+
+	podWatcherBuildkiteJobFailsCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: "pod_watcher",
+		Name:      "jobs_failed_on_buildkite_total",
+		Help:      "Count of jobs that podWatcher successfully acquired and failed on Buildkite",
+	})
+	podWatcherBuildkiteJobFailErrorsCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: "pod_watcher",
+		Name:      "job_fail_on_buildkite_errors_total",
+		Help:      "Count of errors when podWatcher tried to acquire and fail a job on Buildkite",
+	})
+	podWatcherBuildkiteJobCancelsCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: "pod_watcher",
+		Name:      "jobs_cancelled_on_buildkite_total",
+		Help:      "Count of jobs that podWatcher successfully cancelled on Buildkite",
+	})
+	podWatcherBuildkiteJobCancelErrorsCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: "pod_watcher",
+		Name:      "job_cancel_on_buildkite_errors_total",
+		Help:      "Count of errors when podWatcher tried to cancel a job on Buildkite",
+	})
+
+	podsEvictedCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: "pod_watcher",
+		Name:      "pods_evicted_total",
+		Help:      "Count of evictions created for pods by podWatcher",
+	}, []string{"eviction_reason"})
+	podEvictionErrorsCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: "pod_watcher",
+		Name:      "pod_eviction_errors_total",
+		Help:      "Count of failures to create pod evictions by podWatcher",
+	}, []string{"eviction_reason", "error_reason"})
+)
+
+// Completion watcher metrics
+
+var (
+	completionWatcherOnAddEventCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: "completion_watcher",
+		Name:      "onadd_events_total",
+		Help:      "Count of OnAdd informer events",
+	})
+	completionWatcherOnUpdateEventCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: "completion_watcher",
+		Name:      "onupdate_events_total",
+		Help:      "Count of OnUpdate informer events",
+	})
+
+	completionWatcherJobCleanupsCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: "completion_watcher",
+		Name:      "cleanups_total",
+		Help:      "Count of jobs successfully cleaned up",
+	})
+	completionWatcherJobCleanupErrorsCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: "completion_watcher",
+		Name:      "cleanup_errors_total",
+		Help:      "Count of errors during attempts to clean up a job",
+	}, []string{"reason"})
+)


### PR DESCRIPTION
### What
Adds a Prometheus metrics endpoint, and a whole heap of metrics.

### Why
Fixes #102.

Addresses the metric part of #278.

Among other reasons, extra observability into the controller will likely be needed to keep digging into #302.

### Show me the charts
Two ways to get the number of jobs the deduper thinks is running:
<img width="712" alt="Screenshot 2024-11-27 at 1 28 01 PM" src="https://github.com/user-attachments/assets/6caea56a-5887-4229-ab62-bb38e06f7585">
<img width="706" alt="Screenshot 2024-11-27 at 1 29 36 PM" src="https://github.com/user-attachments/assets/c31c467b-d009-4e03-b573-87cfa69548b4">

Available limiter tokens:
<img width="728" alt="Screenshot 2024-11-27 at 1 30 16 PM" src="https://github.com/user-attachments/assets/b1ece8a4-7389-4ac3-9426-f57a156395f9">

Median time between querying a job and scheduling it:
<img width="710" alt="Screenshot 2024-11-27 at 1 31 15 PM" src="https://github.com/user-attachments/assets/3ef986a5-2afb-44f0-b075-a63d04d9d3c4">
