### PR TITLE
Parallel job creation

### DIFF
--- a/charts/agent-stack-k8s/values.schema.json
+++ b/charts/agent-stack-k8s/values.schema.json
@@ -192,26 +192,38 @@
         "max-in-flight": {
           "type": "integer",
           "default": 0,
-          "title": "The max-in-flight Schema",
+          "title": "Sets an upper limit on the number of Kubernetes jobs that the controller will run",
           "examples": [100]
         },
         "poll-interval": {
           "type": "string",
-          "default": "",
-          "title": "The poll-interval Schema",
+          "default": "1s",
+          "title": "Interval between polling Buildkite for jobs. Values below 1 second will be ignored and 1 second will be used instead",
           "examples": ["1s", "1m"]
+        },
+        "stale-job-data-timeout": {
+          "type": "string",
+          "default": "10s",
+          "title": "After polling Buildkite for jobs, the job data is considered valid up to this timeout",
+          "examples": ["1s", "1m"]
+        },
+        "job-creation-concurrency": {
+          "type": "integer",
+          "default": 5,
+          "title": "Sets a limit on the number of Kubernetes jobs that will be attempted to be created simultaneously in parallel",
+          "examples": [1, 2, 5, 10]
         },
         "org": {
           "type": "string",
           "default": "",
           "minLength": 1,
-          "title": "The org Schema",
+          "title": "Buildkite organization slug",
           "examples": [""]
         },
         "tags": {
           "type": "array",
           "default": [],
-          "title": "The tags Schema",
+          "title": "Buildkite agent tags used for acquiring jobs - 'queue' is required",
           "items": {
             "type": "string"
           },

--- a/cmd/controller/controller_test.go
+++ b/cmd/controller/controller_test.go
@@ -28,6 +28,7 @@ func TestReadAndParseConfig(t *testing.T) {
 		JobCancelCheckerPollInterval: 10 * time.Second,
 		PollInterval:                 5 * time.Second,
 		StaleJobDataTimeout:          10 * time.Second,
+		JobCreationConcurrency:       5,
 		MaxInFlight:                  100,
 		Namespace:                    "my-buildkite-ns",
 		Org:                          "my-buildkite-org",

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -6,6 +6,7 @@ image-pull-backoff-grace-period: 60s
 job-cancel-checker-poll-interval: 10s
 poll-interval: 5s
 stale-job-data-timeout: 10s
+job-creation-concurrency: 5
 max-in-flight: 100
 namespace: my-buildkite-ns
 org: my-buildkite-org

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -25,19 +25,20 @@ var DefaultAgentImage = "ghcr.io/buildkite/agent:" + version.Version()
 // mapstructure (the module) supports switching the struct tag to "json", viper does not. So we have
 // to have the `mapstructure` tag for viper and the `json` tag is used by the mapstructure!
 type Config struct {
-	Debug               bool          `json:"debug"`
-	JobTTL              time.Duration `json:"job-ttl"`
-	PollInterval        time.Duration `json:"poll-interval"`
-	StaleJobDataTimeout time.Duration `json:"stale-job-data-timeout" validate:"omitempty"`
-	AgentTokenSecret    string        `json:"agent-token-secret"     validate:"required"`
-	BuildkiteToken      string        `json:"buildkite-token"        validate:"required"`
-	Image               string        `json:"image"                  validate:"required"`
-	MaxInFlight         int           `json:"max-in-flight"          validate:"min=0"`
-	Namespace           string        `json:"namespace"              validate:"required"`
-	Org                 string        `json:"org"                    validate:"required"`
-	Tags                stringSlice   `json:"tags"                   validate:"min=1"`
-	ProfilerAddress     string        `json:"profiler-address"       validate:"omitempty,hostname_port"`
-	GraphQLEndpoint     string        `json:"graphql-endpoint"       validate:"omitempty"`
+	Debug                  bool          `json:"debug"`
+	JobTTL                 time.Duration `json:"job-ttl"`
+	PollInterval           time.Duration `json:"poll-interval"`
+	StaleJobDataTimeout    time.Duration `json:"stale-job-data-timeout"   validate:"omitempty"`
+	JobCreationConcurrency int           `json:"job-creation-concurrency" validate:"omitempty"`
+	AgentTokenSecret       string        `json:"agent-token-secret"       validate:"required"`
+	BuildkiteToken         string        `json:"buildkite-token"          validate:"required"`
+	Image                  string        `json:"image"                    validate:"required"`
+	MaxInFlight            int           `json:"max-in-flight"            validate:"min=0"`
+	Namespace              string        `json:"namespace"                validate:"required"`
+	Org                    string        `json:"org"                      validate:"required"`
+	Tags                   stringSlice   `json:"tags"                     validate:"min=1"`
+	ProfilerAddress        string        `json:"profiler-address"         validate:"omitempty,hostname_port"`
+	GraphQLEndpoint        string        `json:"graphql-endpoint"         validate:"omitempty"`
 	// Agent endpoint is set in agent-config.
 
 	// ClusterUUID field is mandatory for most new orgs.
@@ -76,6 +77,7 @@ func (c Config) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	enc.AddDuration("job-ttl", c.JobTTL)
 	enc.AddDuration("poll-interval", c.PollInterval)
 	enc.AddDuration("stale-job-data-timeout", c.StaleJobDataTimeout)
+	enc.AddInt("job-creation-concurrency", c.JobCreationConcurrency)
 	enc.AddInt("max-in-flight", c.MaxInFlight)
 	enc.AddString("namespace", c.Namespace)
 	enc.AddString("org", c.Org)

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -43,15 +43,16 @@ func Run(
 	// Monitor polls Buildkite GraphQL for jobs. It passes them to Deduper.
 	// Job flow: monitor -> deduper -> limiter -> scheduler.
 	m, err := monitor.New(logger.Named("monitor"), k8sClient, monitor.Config{
-		GraphQLEndpoint:     cfg.GraphQLEndpoint,
-		Namespace:           cfg.Namespace,
-		Org:                 cfg.Org,
-		ClusterUUID:         cfg.ClusterUUID,
-		MaxInFlight:         cfg.MaxInFlight,
-		PollInterval:        cfg.PollInterval,
-		StaleJobDataTimeout: cfg.StaleJobDataTimeout,
-		Tags:                cfg.Tags,
-		Token:               cfg.BuildkiteToken,
+		GraphQLEndpoint:        cfg.GraphQLEndpoint,
+		Namespace:              cfg.Namespace,
+		Org:                    cfg.Org,
+		ClusterUUID:            cfg.ClusterUUID,
+		MaxInFlight:            cfg.MaxInFlight,
+		PollInterval:           cfg.PollInterval,
+		StaleJobDataTimeout:    cfg.StaleJobDataTimeout,
+		JobCreationConcurrency: cfg.JobCreationConcurrency,
+		Tags:                   cfg.Tags,
+		Token:                  cfg.BuildkiteToken,
 	})
 	if err != nil {
 		logger.Fatal("failed to create monitor", zap.Error(err))


### PR DESCRIPTION
### What
For each poll of BK for jobs, run the rest of the pipeline (deduper -> limiter -> scheduler) in parallel (with a fairly conservative default concurrency of 5 goroutines).
Randomise the order in which jobs are sent.

### Why
If 100% of jobs sent to k8s successfully create, then (up to the MaxInFlight limit if it applies) the current process should always make progress even if the k8s API was slow, because `staleCtx` only interrupts waiting for limiter tokens, not the creation of jobs. (Any job that makes its way through the limiter will be sent to k8s by the scheduler.) The other bits in the middle shouldn't be so slow that `staleCtx` is cancelled first.

If some jobs successfully create and some won't, then that's most likely a property of the job (e.g. the job name collides with an existing job). If we try and fail to create the same job over and over, and creating jobs is slow enough that we don't get through enough of the broken ones before `staleCtx` expires, we won't progress.

Randomising the order of creating jobs means jobs that _could_ successfully be created get a chance. Adding parallelism to create more jobs at a time will increase load on the k8s cluster, but let more jobs be tried before staleness kicks in.