### PR TITLE
Fix workspace volume name on init containers

### DIFF
--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -586,7 +586,7 @@ func (w *worker) Build(podSpec *corev1.PodSpec, skipCheckout bool, inputs buildI
 				"/workspace",
 			},
 			VolumeMounts: []corev1.VolumeMount{{
-				Name:      "workspace",
+				Name:      workspaceVolume.Name,
 				MountPath: "/workspace",
 			}},
 		},
@@ -624,7 +624,7 @@ func (w *worker) Build(podSpec *corev1.PodSpec, skipCheckout bool, inputs buildI
 			Command: []string{"/workspace/tini-static"},
 			Args:    []string{"--version"},
 			VolumeMounts: []corev1.VolumeMount{{
-				Name:      "workspace",
+				Name:      workspaceVolume.Name,
 				MountPath: "/workspace",
 			}},
 		})


### PR DESCRIPTION
Once again haste makes waste. While rushing #428 I forgot a couple of instances of the previous hard-coded default workspace volume name. 

Tested manually locally with a custom `workspace-volume`.