### PR TITLE
Match tags in pod watcher

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/buildkite/agent-stack-k8s/v2
 
-go 1.22.6
-
-toolchain go1.22.7
+go 1.23.3
 
 require (
 	github.com/Khan/genqlient v0.7.0

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -138,7 +138,7 @@ func NewInformerFactory(
 	namespace string,
 	tags []string,
 ) (informers.SharedInformerFactory, error) {
-	labelsFromTags, errs := agenttags.ToLabels(tags)
+	labelsFromTags, errs := agenttags.LabelsFromTags(tags)
 	if len(errs) != 0 {
 		return nil, errors.Join(errs...)
 	}

--- a/internal/controller/scheduler/fail_job.go
+++ b/internal/controller/scheduler/fail_job.go
@@ -33,7 +33,7 @@ func failJob(
 	}, options...)
 
 	// queue is required for acquire! maybe more
-	ctr, err := agentcore.NewController(ctx, agentToken, kjobName(jobUUID), tags, opts...)
+	ctr, err := agentcore.NewController(ctx, agentToken, k8sJobName(jobUUID), tags, opts...)
 	if err != nil {
 		zapLogger.Error("registering or connecting ephemeral agent", zap.Error(err))
 		return fmt.Errorf("registering or connecting ephemeral agent: %w", err)

--- a/internal/controller/scheduler/pod_watcher.go
+++ b/internal/controller/scheduler/pod_watcher.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/buildkite/agent-stack-k8s/v2/api"
+	"github.com/buildkite/agent-stack-k8s/v2/internal/controller/agenttags"
 	"github.com/buildkite/agent-stack-k8s/v2/internal/controller/config"
 
 	agentcore "github.com/buildkite/agent/v3/core"
@@ -283,15 +284,7 @@ func (w *podWatcher) failJob(ctx context.Context, log *zap.Logger, pod *corev1.P
 	}
 
 	// Tags are required order to connect the agent.
-	var tags []string
-	for key, value := range pod.Labels {
-		k, has := strings.CutPrefix(key, "tag.buildkite.com/")
-		if !has {
-			continue
-		}
-		tags = append(tags, fmt.Sprintf("%s=%s", k, value))
-	}
-
+	tags := agenttags.TagsFromLabels(pod.Labels)
 	opts := w.cfg.AgentConfig.ControllerOptions()
 
 	if err := failJob(ctx, w.logger, agentToken, jobUUID.String(), tags, message.String(), opts...); err != nil {


### PR DESCRIPTION
### What
The pod watcher should only take ownership of pods whose labels match the agent tags configured on the controller. 

### Why
The controller queries for jobs matching any tags, but then filters to ensure a match for all tags. So each controller only really "owns" _those_ jobs. 

Currently the pod watcher does no such filtering, so it runs cancel checkers and looks for ImagePullBackoff on _all_ pods with job UUIDs. That's fine if there's only a single controller in the cluster, but if there are multiple controllers in a cluster (with distinct tags) then there is redundant pod watcher work.

We could try to record all job UUIDs started by this controller and look for those, but such a list would become invalid on a controller restart.