### PR TITLE
Fix submodule checkout failure when checkout configuration is provided

### DIFF
--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -151,6 +151,9 @@ func appendNegatedToEnvOpt(ctr *corev1.Container, name string, value *bool) {
 }
 
 func appendCommaSepToEnv(ctr *corev1.Container, name string, values []string) {
+	if len(values) == 0 {
+		return
+	}
 	ctr.Env = append(ctr.Env, corev1.EnvVar{
 		Name:  name,
 		Value: strings.Join(values, ","),


### PR DESCRIPTION
If the repository has submodules, and a checkout configuration is provided (even if it's empty):
```
steps:
- label: Hello World!
  agents:
    queue: kubernetes
  plugins:
  - kubernetes:
      checkout: {}
      podSpec:
        containers:
        - image: alpine:latest
          command:
          - echo Hello World!
```

An empty `-c` argument is given to `git submodule update`, and checkout fails:
```
# Git submodules detected
$ git submodule sync --recursive
$ git -c  submodule update --init --recursive --force
error: empty config key
fatal: unable to parse command-line config
```

If there are no items in the `submoduleCloneConfig`, we should skip setting the env var:
https://github.com/buildkite/agent-stack-k8s/blob/c85d91193ce27fbe6ad0a91fe9689d13443840bc/internal/controller/config/checkout_params.go#L31

So the agent doesn't generate an empty `-c` argument here:
https://github.com/buildkite/agent/blob/e9482328696c5b3b1ec5aa757dd6049277ec4b0d/internal/job/checkout.go#L643-L645

We've also hardened this on the agent side: https://github.com/buildkite/agent/pull/3122

This fixes a regression introduced in agent-stack-k8s 0.16.0.