### PR TITLE
Move Go cache hostpaths to /var/cache

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -17,27 +17,27 @@ x-anchors:
 
   go-cache-env: &go-cache-env
     name: GOCACHE
-    value: /tmp/cache/go-build
+    value: /var/cache/go-build
   go-mod-cache-env: &go-mod-cache-env
     name: GOMODCACHE
-    value: /tmp/cache/go-mod
+    value: /var/cache/go-mod
 
   go-cache-mount: &go-cache-mount
     name: go-build
-    mountPath: /tmp/cache/go-build
+    mountPath: /var/cache/go-build
   go-mod-cache-mount: &go-mod-cache-mount
     name: go-mod
-    mountPath: /tmp/cache/go-mod
+    mountPath: /var/cache/go-mod
 
   go-cache-volume: &go-cache-volume
     name: go-build
     hostPath:
-      path: /tmp/cache/go-build
+      path: /var/cache/buildkite/agent-stack-k8s-ci/go-build
       type: DirectoryOrCreate
   go-mod-cache-volume: &go-mod-cache-volume
     name: go-mod
     hostPath:
-      path: /tmp/cache/go-mod
+      path: /var/cache/buildkite/agent-stack-k8s-ci/go-mod
       type: DirectoryOrCreate
 
   go-env: &go-env
@@ -81,18 +81,18 @@ steps:
                     memory: 1Gi
                 env:
                   - name: GOLANGCI_LINT_CACHE
-                    value: /tmp/cache/golangci-lint
+                    value: /var/cache/golangci-lint
                   - *go-cache-env
                   - *go-mod-cache-env
                 volumeMounts:
                   - name: golangci-lint-cache
-                    mountPath: /tmp/cache/golangci-lint
+                    mountPath: /var/cache/golangci-lint
                   - *go-cache-mount
                   - *go-mod-cache-mount
             volumes:
               - name: golangci-lint-cache
                 hostPath:
-                  path: /tmp/cache/golangci-lint
+                  path: /var/cache/buildkite/agent-stack-k8s-ci/golangci-lint
                   type: DirectoryOrCreate
               - *go-cache-volume
               - *go-mod-cache-volume


### PR DESCRIPTION
Every so often, `/tmp` runs out of space, then k8s starts killing pods.

The instances should have more space available in `/var`.