### PR TITLE
Schedule jobs in priority order

### DIFF
--- a/api/generated.go
+++ b/api/generated.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/Khan/genqlient/graphql"
 )
@@ -395,8 +394,8 @@ type CommandJob struct {
 	Uuid string `json:"uuid"`
 	// Environment variables for this job
 	Env []string `json:"env"`
-	// The time when the job became scheduled for running
-	ScheduledAt time.Time `json:"scheduledAt"`
+	// The priority of this job
+	Priority CommandJobPriority `json:"priority"`
 	// The ruleset used to find an agent to run this job
 	AgentQueryRules []string `json:"agentQueryRules"`
 	// The command the job will run
@@ -409,14 +408,25 @@ func (v *CommandJob) GetUuid() string { return v.Uuid }
 // GetEnv returns CommandJob.Env, and is useful for accessing the field via an interface.
 func (v *CommandJob) GetEnv() []string { return v.Env }
 
-// GetScheduledAt returns CommandJob.ScheduledAt, and is useful for accessing the field via an interface.
-func (v *CommandJob) GetScheduledAt() time.Time { return v.ScheduledAt }
+// GetPriority returns CommandJob.Priority, and is useful for accessing the field via an interface.
+func (v *CommandJob) GetPriority() CommandJobPriority { return v.Priority }
 
 // GetAgentQueryRules returns CommandJob.AgentQueryRules, and is useful for accessing the field via an interface.
 func (v *CommandJob) GetAgentQueryRules() []string { return v.AgentQueryRules }
 
 // GetCommand returns CommandJob.Command, and is useful for accessing the field via an interface.
 func (v *CommandJob) GetCommand() string { return v.Command }
+
+// CommandJobPriority includes the requested fields of the GraphQL type JobPriority.
+// The GraphQL type's documentation follows.
+//
+// The priority with which a job will run
+type CommandJobPriority struct {
+	Number int `json:"number"`
+}
+
+// GetNumber returns CommandJobPriority.Number, and is useful for accessing the field via an interface.
+func (v *CommandJobPriority) GetNumber() int { return v.Number }
 
 // GetBuildBuild includes the requested fields of the GraphQL type Build.
 // The GraphQL type's documentation follows.
@@ -1234,8 +1244,8 @@ func (v *JobJobTypeCommand) GetUuid() string { return v.CommandJob.Uuid }
 // GetEnv returns JobJobTypeCommand.Env, and is useful for accessing the field via an interface.
 func (v *JobJobTypeCommand) GetEnv() []string { return v.CommandJob.Env }
 
-// GetScheduledAt returns JobJobTypeCommand.ScheduledAt, and is useful for accessing the field via an interface.
-func (v *JobJobTypeCommand) GetScheduledAt() time.Time { return v.CommandJob.ScheduledAt }
+// GetPriority returns JobJobTypeCommand.Priority, and is useful for accessing the field via an interface.
+func (v *JobJobTypeCommand) GetPriority() CommandJobPriority { return v.CommandJob.Priority }
 
 // GetAgentQueryRules returns JobJobTypeCommand.AgentQueryRules, and is useful for accessing the field via an interface.
 func (v *JobJobTypeCommand) GetAgentQueryRules() []string { return v.CommandJob.AgentQueryRules }
@@ -1273,7 +1283,7 @@ type __premarshalJobJobTypeCommand struct {
 
 	Env []string `json:"env"`
 
-	ScheduledAt time.Time `json:"scheduledAt"`
+	Priority CommandJobPriority `json:"priority"`
 
 	AgentQueryRules []string `json:"agentQueryRules"`
 
@@ -1293,7 +1303,7 @@ func (v *JobJobTypeCommand) __premarshalJSON() (*__premarshalJobJobTypeCommand, 
 
 	retval.Uuid = v.CommandJob.Uuid
 	retval.Env = v.CommandJob.Env
-	retval.ScheduledAt = v.CommandJob.ScheduledAt
+	retval.Priority = v.CommandJob.Priority
 	retval.AgentQueryRules = v.CommandJob.AgentQueryRules
 	retval.Command = v.CommandJob.Command
 	return &retval, nil
@@ -1659,7 +1669,9 @@ fragment Job on Job {
 fragment CommandJob on JobTypeCommand {
 	uuid
 	env
-	scheduledAt
+	priority {
+		number
+	}
 	agentQueryRules
 	command
 }
@@ -1755,7 +1767,9 @@ fragment Job on Job {
 fragment CommandJob on JobTypeCommand {
 	uuid
 	env
-	scheduledAt
+	priority {
+		number
+	}
 	agentQueryRules
 	command
 }
@@ -1822,7 +1836,9 @@ fragment Job on Job {
 fragment CommandJob on JobTypeCommand {
 	uuid
 	env
-	scheduledAt
+	priority {
+		number
+	}
 	agentQueryRules
 	command
 }
@@ -1956,7 +1972,9 @@ fragment Job on Job {
 fragment CommandJob on JobTypeCommand {
 	uuid
 	env
-	scheduledAt
+	priority {
+		number
+	}
 	agentQueryRules
 	command
 }
@@ -2014,7 +2032,9 @@ fragment Job on Job {
 fragment CommandJob on JobTypeCommand {
 	uuid
 	env
-	scheduledAt
+	priority {
+		number
+	}
 	agentQueryRules
 	command
 }

--- a/api/genqlient.graphql
+++ b/api/genqlient.graphql
@@ -1,148 +1,153 @@
 fragment Job on Job {
-  ... on JobTypeCommand {
-    ...CommandJob
-  }
+    ... on JobTypeCommand {
+        ...CommandJob
+    }
 }
 
 fragment CommandJob on JobTypeCommand {
-  uuid
-  env
-  scheduledAt
-  agentQueryRules
-  command
+    uuid
+    env
+    priority {
+        number
+    }
+    agentQueryRules
+    command
 }
 
 fragment Build on Build {
-  uuid
-  id
-  number
-  state
-  jobs(first: 100) {
-    edges {
-      # @genqlient(flatten: true)
-      node {
-        ...Job
-      }
+    uuid
+    id
+    number
+    state
+    jobs(first: 100) {
+        edges {
+            # @genqlient(flatten: true)
+            node {
+                ...Job
+            }
+        }
     }
-  }
 }
 
 mutation BuildCreate($input: BuildCreateInput!) {
-  buildCreate(input: $input) {
-    build {
-      ...Build
+    buildCreate(input: $input) {
+        build {
+            ...Build
+        }
     }
-  }
 }
 
 mutation BuildCancel($input: BuildCancelInput!) {
-  buildCancel(input: $input) {
-    clientMutationId
-  }
+    buildCancel(input: $input) {
+        clientMutationId
+    }
 }
 
 query GetOrganization($slug: ID!) {
-  organization(slug: $slug) {
-    id
-  }
+    organization(slug: $slug) {
+        id
+    }
 }
 
 query GetBuild($uuid: ID!) {
-  build(uuid: $uuid) {
-    ...Build
-  }
+    build(uuid: $uuid) {
+        ...Build
+    }
 }
 
 query GetScheduledJobs($slug: ID!, $agentQueryRules: [String!]) {
-  organization(slug: $slug) {
-    # @genqlient(pointer: true)
-    id
-    jobs(
-      state: [SCHEDULED]
-      type: [COMMAND]
-      first: 100
-      order: RECENTLY_ASSIGNED
-      agentQueryRules: $agentQueryRules
-      clustered: false
-    ) {
-      count
-      edges {
-        # @genqlient(flatten: true)
-        node {
-          ...Job
+    organization(slug: $slug) {
+        # @genqlient(pointer: true)
+        id
+        jobs(
+            state: [SCHEDULED]
+            type: [COMMAND]
+            first: 100
+            order: RECENTLY_ASSIGNED
+            agentQueryRules: $agentQueryRules
+            clustered: false
+        ) {
+            count
+            edges {
+                # @genqlient(flatten: true)
+                node {
+                    ...Job
+                }
+            }
         }
-      }
     }
-  }
 }
 
-query GetScheduledJobsClustered($slug: ID!, $agentQueryRules: [String!], $cluster: ID!) {
-  organization(slug: $slug) {
-    # @genqlient(pointer: true)
-    id
-    jobs(
-      state: [SCHEDULED]
-      type: [COMMAND]
-      first: 100
-      order: RECENTLY_ASSIGNED
-      agentQueryRules: $agentQueryRules
-      cluster: $cluster
-    ) {
-      count
-      edges {
-        # @genqlient(flatten: true)
-        node {
-          ...Job
+query GetScheduledJobsClustered(
+    $slug: ID!
+    $agentQueryRules: [String!]
+    $cluster: ID!
+) {
+    organization(slug: $slug) {
+        # @genqlient(pointer: true)
+        id
+        jobs(
+            state: [SCHEDULED]
+            type: [COMMAND]
+            first: 100
+            order: RECENTLY_ASSIGNED
+            agentQueryRules: $agentQueryRules
+            cluster: $cluster
+        ) {
+            count
+            edges {
+                # @genqlient(flatten: true)
+                node {
+                    ...Job
+                }
+            }
         }
-      }
     }
-  }
 }
 
 query GetBuilds($slug: ID!, $state: [BuildStates!], $first: Int) {
-  pipeline(slug: $slug) {
-    builds(state: $state, first: $first) {
-      edges {
-        node {
-          ...Build
+    pipeline(slug: $slug) {
+        builds(state: $state, first: $first) {
+            edges {
+                node {
+                    ...Build
+                }
+            }
         }
-      }
     }
-  }
 }
 
 query GetCommandJob($uuid: ID!) {
-  job(uuid: $uuid) {
-    ... on JobTypeCommand {
-        id
-        state
+    job(uuid: $uuid) {
+        ... on JobTypeCommand {
+            id
+            state
+        }
     }
-  }
 }
 
 mutation CancelCommandJob($input: JobTypeCommandCancelInput!) {
-  jobTypeCommandCancel(input: $input) {
-    clientMutationId
-  }
+    jobTypeCommandCancel(input: $input) {
+        clientMutationId
+    }
 }
-
 
 ### The following are used in the cleanup integration "test"
 mutation PipelineDelete($input: PipelineDeleteInput!) {
-  pipelineDelete(input: $input) {
-    clientMutationId
-  }
+    pipelineDelete(input: $input) {
+        clientMutationId
+    }
 }
 
 query SearchPipelines($slug: ID!, $search: String!, $first: Int!) {
-  organization(slug: $slug) {
-    pipelines(search: $search, first: $first) {
-      edges {
-        node {
-          id
-          name
+    organization(slug: $slug) {
+        pipelines(search: $search, first: $first) {
+            edges {
+                node {
+                    id
+                    name
+                }
+            }
         }
-      }
     }
-  }
 }

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -239,7 +239,7 @@ func TestMaxInFlightLimited(t *testing.T) {
 			nil,
 		)
 		if err != nil {
-			t.Fatalf("tc.Buildkite.Builds.Get(%q, %q, %d, nil) error = %v", cfg.Org, tc.PipelineName, build.Number, err)
+			t.Fatalf("tc.Buildkite.Builds.Get(%q, %q, %d, nil) error = %v", cfg.Org, tc.PipelineName, buildID, err)
 		}
 
 		switch *build.State {
@@ -277,7 +277,7 @@ func TestMaxInFlightUnlimited(t *testing.T) {
 	cfg := cfg
 	cfg.MaxInFlight = 0 // unlimited
 	tc.StartController(ctx, cfg)
-	build := tc.TriggerBuild(ctx, pipelineID)
+	buildID := tc.TriggerBuild(ctx, pipelineID).Number
 
 	maxRunningJobs := 0
 fetchBuildStateLoop:
@@ -285,11 +285,11 @@ fetchBuildStateLoop:
 		build, _, err := tc.Buildkite.Builds.Get(
 			cfg.Org,
 			tc.PipelineName,
-			strconv.Itoa(build.Number),
+			strconv.Itoa(buildID),
 			nil,
 		)
 		if err != nil {
-			t.Fatalf("tc.Buildkite.Builds.Get(%q, %q, %d, nil) error = %v", cfg.Org, tc.PipelineName, build.Number, err)
+			t.Fatalf("tc.Buildkite.Builds.Get(%q, %q, %d, nil) error = %v", cfg.Org, tc.PipelineName, buildID, err)
 		}
 
 		switch *build.State {


### PR DESCRIPTION
### What
Sort jobs by priority (descending) before sending them through to be scheduled. Highest priority jobs should be scheduled first, lowest priority jobs scheduled last.

### Why
Fixes #445

### Notes
The graphQL queries remove `scheduledAt` (since it stopped being used with #427) and adds `priority`. My text editor also reformatted the GraphQL. The integration tests also hit a nil panic (these are sometimes flaky), so I have fixed the two instances of that particular path.