### PR TITLE
Fix deploy.sh

### DIFF
--- a/.buildkite/steps/deploy.sh
+++ b/.buildkite/steps/deploy.sh
@@ -8,7 +8,7 @@ apk add --update-cache --no-progress helm git
 source .buildkite/steps/repo_info.sh
 
 echo --- :helm: Helm upgrade
-helm upgrade agent-stack-k8s "${helm_repo_pecr}" \
+helm upgrade agent-stack-k8s "${helm_repo_pecr}/agent-stack-k8s" \
   --version "${version}" \
   --namespace buildkite \
   --install \


### PR DESCRIPTION
While adjusting container repo paths in #450 I forgot to restore the trailing `/agent-stack-k8s` referencing the helm chart in the deploy script.