### PR TITLE
Fix release.sh

### DIFF
--- a/.buildkite/steps/release.sh
+++ b/.buildkite/steps/release.sh
@@ -16,7 +16,7 @@ GHCH_VERSION="0.11.0"
 GHCH_URL="https://github.com/buildkite/ghch/releases/download/v${GHCH_VERSION}/ghch-$(go env GOARCH)"
 
 echo --- :hammer: Installing packages
-apk add --no-progress aws-cli crane git
+apk add --no-progress aws-cli crane git jq
 wget -q "${GORELEASER_URL}/v${GORELEASER_VERSION}/${GORELEASER_FILE}"
 apk add --no-progress --allow-untrusted "${GORELEASER_FILE}"
 rm "${GORELEASER_FILE}"


### PR DESCRIPTION
Also forgotten in #450: `assume-role.sh` needs `jq` here too.

https://buildkite.com/buildkite-kubernetes-stack/kubernetes-agent-stack/builds/1981/canvas/0193cdb2-fbcd-4056-a7db-1756861485e3#0193cdb2-fc07-4db5-959b-e4cdc30237f2/167-168