### PR TITLE
Allow patching some container commands/args

### DIFF
--- a/internal/controller/scheduler/scheduler_test.go
+++ b/internal/controller/scheduler/scheduler_test.go
@@ -1,12 +1,12 @@
-package scheduler_test
+package scheduler
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"testing"
 
 	"github.com/buildkite/agent-stack-k8s/v2/api"
-	"github.com/buildkite/agent-stack-k8s/v2/internal/controller/scheduler"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -19,14 +19,13 @@ func TestPatchPodSpec(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name      string
-		podspec   *corev1.PodSpec
-		patch     *corev1.PodSpec
-		assertion func(t *testing.T, result *corev1.PodSpec)
-		err       error
+		name    string
+		podspec *corev1.PodSpec
+		patch   *corev1.PodSpec
+		want    *corev1.PodSpec
 	}{
 		{
-			name: "patching a container",
+			name: "patching in a new unmanaged container",
 			podspec: &corev1.PodSpec{
 				Containers: []corev1.Container{
 					{
@@ -45,19 +44,57 @@ func TestPatchPodSpec(t *testing.T) {
 					},
 				},
 			},
-			assertion: func(t *testing.T, result *corev1.PodSpec) {
-				assert.Equal(t, "debian:latest", result.Containers[0].Image)
+			want: &corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name:  "my-cool-container",
+					Image: "debian:latest",
+				}, {
+					Image: "alpine:latest",
+					Command: []string{
+						"echo hello world",
+					},
+				}},
 			},
 		},
 		{
-			name: "patching container commands should fail",
+			name: "patching a sidecar container",
 			podspec: &corev1.PodSpec{
 				Containers: []corev1.Container{
 					{
-						Image: "alpine:latest",
-						Command: []string{
-							"echo hello world",
-						},
+						Name:    "sidecar-0",
+						Image:   "alpine:latest",
+						Command: []string{"echo hello world"},
+					},
+				},
+			},
+			patch: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:    "sidecar-0",
+						Command: []string{"echo goodbye world"},
+					},
+				},
+			},
+			want: &corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name:    "sidecar-0",
+					Image:   "alpine:latest",
+					Command: []string{"echo goodbye world"},
+				}},
+			},
+		},
+		{
+			name: "patching command container commands and args should work",
+			podspec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:    "my-cool-container",
+						Image:   "alpine:latest",
+						Command: commandContainerCommand,
+						Args:    commandContainerArgs,
+						Env: []corev1.EnvVar{{
+							Name: "BUILDKITE_COMMAND", Value: "echo hello world",
+						}},
 					},
 				},
 			},
@@ -65,44 +102,135 @@ func TestPatchPodSpec(t *testing.T) {
 				Containers: []corev1.Container{
 					{
 						Name:    "my-cool-container",
-						Command: []string{"this", "shouldn't", "work"},
+						Command: []string{"this should"},
+						Args:    []string{"work", "as", "expected"},
 					},
 				},
 			},
-			err: scheduler.ErrNoCommandModification,
+			want: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:    "my-cool-container",
+						Image:   "alpine:latest",
+						Command: commandContainerCommand,
+						Args:    commandContainerArgs,
+						Env: []corev1.EnvVar{{
+							Name: "BUILDKITE_COMMAND", Value: "this should work as expected",
+						}},
+					},
+				},
+			},
 		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := PatchPodSpec(test.podspec, test.patch, nil, nil)
+			if err != nil {
+				t.Fatalf("PodSpecPatch error = %v", err)
+			}
+			if diff := cmp.Diff(got, test.want); diff != "" {
+				t.Errorf("PodSpecPatch result diff (-got +want):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestPatchPodSpec_ErrNoCommandModification(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		podspec *corev1.PodSpec
+		patch   *corev1.PodSpec
+	}{
 		{
-			name: "patching container args should fail",
+			name: "patching agent command should fail",
 			podspec: &corev1.PodSpec{
 				Containers: []corev1.Container{
 					{
-						Image: "alpine:latest",
-						Command: []string{
-							"echo hello world",
-						},
+						Name:    AgentContainerName,
+						Image:   "alpine:latest",
+						Command: []string{"echo hello world"},
 					},
 				},
 			},
 			patch: &corev1.PodSpec{
 				Containers: []corev1.Container{
 					{
-						Name: "my-cool-container",
-						Args: []string{"this", "also", "shouldn't", "work"},
+						Name:    AgentContainerName,
+						Command: []string{"this shouldn't work"},
 					},
 				},
 			},
-			err: scheduler.ErrNoCommandModification,
+		},
+		{
+			name: "patching agent args should fail",
+			podspec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:    AgentContainerName,
+						Image:   "alpine:latest",
+						Command: []string{"echo hello world"},
+					},
+				},
+			},
+			patch: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: AgentContainerName,
+						Args: []string{"this", "shouldn't", "work"},
+					},
+				},
+			},
+		},
+		{
+			name: "patching checkout command should fail",
+			podspec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:    CheckoutContainerName,
+						Image:   "alpine:latest",
+						Command: []string{"echo hello world"},
+					},
+				},
+			},
+			patch: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:    CheckoutContainerName,
+						Command: []string{"this shouldn't work"},
+					},
+				},
+			},
+		},
+		{
+			name: "patching checkout args should fail",
+			podspec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:    CheckoutContainerName,
+						Image:   "alpine:latest",
+						Command: []string{"echo hello world"},
+					},
+				},
+			},
+			patch: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: CheckoutContainerName,
+						Args: []string{"this", "shouldn't", "work"},
+					},
+				},
+			},
 		},
 	}
 
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			result, err := scheduler.PatchPodSpec(c.podspec, c.patch)
-			if c.err != nil {
-				require.Error(t, err)
-				require.ErrorIs(t, c.err, err)
-			} else {
-				c.assertion(t, result)
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := PatchPodSpec(test.podspec, test.patch, nil, nil)
+			if !errors.Is(err, ErrNoCommandModification) {
+				t.Errorf("PodSpecPatch error = %v, want ErrNoCommandModification (%v)", err, ErrNoCommandModification)
 			}
 		})
 	}
@@ -110,7 +238,7 @@ func TestPatchPodSpec(t *testing.T) {
 
 func TestJobPluginConversion(t *testing.T) {
 	t.Parallel()
-	pluginConfig := scheduler.KubernetesPlugin{
+	pluginConfig := KubernetesPlugin{
 		PodSpec: &corev1.PodSpec{
 			Containers: []corev1.Container{
 				{
@@ -153,10 +281,10 @@ func TestJobPluginConversion(t *testing.T) {
 		Env:             []string{fmt.Sprintf("BUILDKITE_PLUGINS=%s", string(pluginsJSON))},
 		AgentQueryRules: []string{"queue=kubernetes"},
 	}
-	worker := scheduler.New(
+	worker := New(
 		zaptest.NewLogger(t),
 		nil,
-		scheduler.Config{
+		Config{
 			AgentTokenSecretName: "token-secret",
 			Image:                "buildkite/agent:latest",
 		},
@@ -216,7 +344,7 @@ func TestTagEnv(t *testing.T) {
 	t.Parallel()
 	logger := zaptest.NewLogger(t)
 
-	pluginConfig := scheduler.KubernetesPlugin{
+	pluginConfig := KubernetesPlugin{
 		PodSpec: &corev1.PodSpec{
 			Containers: []corev1.Container{
 				{
@@ -238,10 +366,10 @@ func TestTagEnv(t *testing.T) {
 		Env:             []string{fmt.Sprintf("BUILDKITE_PLUGINS=%s", string(pluginsJSON))},
 		AgentQueryRules: []string{"queue=kubernetes"},
 	}
-	worker := scheduler.New(
+	worker := New(
 		logger,
 		nil,
-		scheduler.Config{
+		Config{
 			AgentTokenSecretName: "token-secret",
 			Image:                "buildkite/agent:latest",
 		},
@@ -277,7 +405,7 @@ func TestJobWithNoKubernetesPlugin(t *testing.T) {
 		Command:         "echo hello world",
 		AgentQueryRules: []string{},
 	}
-	worker := scheduler.New(zaptest.NewLogger(t), nil, scheduler.Config{
+	worker := New(zaptest.NewLogger(t), nil, Config{
 		Image: "buildkite/agent:latest",
 	})
 	inputs, err := worker.ParseJob(job)
@@ -313,10 +441,10 @@ func TestBuild(t *testing.T) {
 		AgentQueryRules: []string{"queue=kubernetes"},
 	}
 
-	worker := scheduler.New(
+	worker := New(
 		zaptest.NewLogger(t),
 		nil,
-		scheduler.Config{
+		Config{
 			Namespace:            "buildkite",
 			Image:                "buildkite/agent:latest",
 			AgentTokenSecretName: "bkcq_1234567890",
@@ -381,10 +509,10 @@ func TestBuildSkipCheckout(t *testing.T) {
 		AgentQueryRules: []string{"queue=kubernetes"},
 	}
 
-	worker := scheduler.New(
+	worker := New(
 		zaptest.NewLogger(t),
 		nil,
-		scheduler.Config{
+		Config{
 			Namespace:            "buildkite",
 			Image:                "buildkite/agent:latest",
 			AgentTokenSecretName: "bkcq_1234567890",
@@ -426,10 +554,10 @@ func TestBuildCheckoutEmptyConfigEnv(t *testing.T) {
 		AgentQueryRules: []string{"queue=kubernetes"},
 	}
 
-	worker := scheduler.New(
+	worker := New(
 		zaptest.NewLogger(t),
 		nil,
-		scheduler.Config{
+		Config{
 			Namespace:            "buildkite",
 			Image:                "buildkite/agent:latest",
 			AgentTokenSecretName: "bkcq_1234567890",
@@ -465,7 +593,7 @@ func TestFailureJobs(t *testing.T) {
 		Env:             []string{fmt.Sprintf("BUILDKITE_PLUGINS=%s", pluginsJSON)},
 		AgentQueryRules: []string{"queue=kubernetes"},
 	}
-	wrapper := scheduler.New(zaptest.NewLogger(t), nil, scheduler.Config{})
+	wrapper := New(zaptest.NewLogger(t), nil, Config{})
 	_, err = wrapper.ParseJob(job)
 	require.Error(t, err)
 }
@@ -474,7 +602,7 @@ func TestProhibitKubernetesPlugin(t *testing.T) {
 	t.Parallel()
 	pluginsJSON, err := json.Marshal([]map[string]any{
 		{
-			"github.com/buildkite-plugins/kubernetes-buildkite-plugin": scheduler.KubernetesPlugin{},
+			"github.com/buildkite-plugins/kubernetes-buildkite-plugin": KubernetesPlugin{},
 		},
 	})
 	require.NoError(t, err)
@@ -484,7 +612,7 @@ func TestProhibitKubernetesPlugin(t *testing.T) {
 		Env:             []string{fmt.Sprintf("BUILDKITE_PLUGINS=%s", pluginsJSON)},
 		AgentQueryRules: []string{"queue=kubernetes"},
 	}
-	worker := scheduler.New(zaptest.NewLogger(t), nil, scheduler.Config{
+	worker := New(zaptest.NewLogger(t), nil, Config{
 		ProhibitK8sPlugin: true,
 	})
 	_, err = worker.ParseJob(job)

--- a/internal/integration/fixtures/podspecpatch-agent.yaml
+++ b/internal/integration/fixtures/podspecpatch-agent.yaml
@@ -1,0 +1,17 @@
+steps:
+  - label: ":x:"
+    agents:
+      queue: "{{.queue}}"
+    plugins:
+      - kubernetes:
+          podSpec:
+            containers:
+              - image: alpine:latest
+                name: nope
+                command:
+                  - echo "la di da di da"
+          podSpecPatch:
+            containers:
+              - name: agent
+                command:
+                  - echo "am I out of touch? no, it's buildkite-agent that is wrong!"


### PR DESCRIPTION
It came to me last night in a dream... wait, why am I dreaming about work? 🫤

### What
Allow patching some container commands and args with PodSpecPatch: sidecars and new containers added by patch are allowed to make any command/args modification, and command container patches are interposed back into `BUILDKITE_COMMAND` form as we do for non-patch containers. 

### Why
The command modification check was added to prevent breaking the pod. I wrote an explanation in #449 - if `buildkite-agent start` isn't run in the agent container, or `buildkite-agent bootstrap` isn't run in the checkout or command containers, the pod _will_ break in various ways.

However, it was always too strict: 
* sidecar containers never have `buildkite-agent` added to it, so they should be modifiable
* new containers added via PodSpecPatch also don't have the command interposition applied, so they should be allowed to have commands

What about command containers? I think if a user tried to override the command/args of a command container, they probably expect the patch to be _interpreted the same way_ as we do currently for command containers specified with `podSpec`: substitute `buildkite-agent bootstrap` for the command and interpose the supplied command into `BUILDKITE_COMMAND`.

Original command containers can be identified by having had this transform already applied, so we just need to match them against the patch by the same process that strategic merge patch uses: container name.

Patching the checkout container is more complicated - it's a container we add rather than one the user supplies anywhere else, with scripts for adjusting user and group IDs, etc. What do we do with a user supplied command? (schlep it into a checkout hook? that could work... 🤔 but what if the user supplied a checkout hook already?)