### PR TITLE
Add note about DSA keys deprecation, change example to RSA

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,12 +288,14 @@ If you need to use git ssh credentials in your job containers, we recommend one 
 1. Use a container image that's based on the default `buildkite/agent` docker image and preserve the default entrypoint by not overriding the command in the job spec.
 2. Include or reproduce the functionality of the [`ssh-env-config.sh`](https://github.com/buildkite/docker-ssh-env-config/blob/-/ssh-env-config.sh) script in the entrypoint for your job container image
 
+#### NOTE: Support for DSA keys has been removed from OpenSSH as of early 2025. This removal now affects agent version `v3.88.0` and newer. Please migrate to `RSA`, `ECDSA` or `EDDSA` keys.
+
 #### Example secret creation for ssh cloning
 You most likely want to use a more secure method of managing k8s secrets. This example is illustrative only.
 
 Supposing a SSH private key has been created and its public key has been registered with the remote repository provider (e.g. [GitHub](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account)).
 ```bash
-kubectl create secret generic my-git-ssh-credentials --from-file=SSH_PRIVATE_DSA_KEY="$HOME/.ssh/id_ecdsa"
+kubectl create secret generic my-git-ssh-credentials --from-file=SSH_PRIVATE_RSA_KEY="$HOME/.ssh/id_rsa"
 ```
 
 Then the following pipeline will be able to clone a git repository that requires ssh credentials.
@@ -331,7 +333,7 @@ mount for the `git-credentials` volume, and configure Git to use the file within
 Once again, this example is illustrative only.
 
 First, create a Kubernetes secret containing the key `.git-credentials`, formatted in the manner
-expected by [the `store` Git credendial helper](https://git-scm.com/docs/git-credential-store):
+expected by [the `store` Git credential helper](https://git-scm.com/docs/git-credential-store):
 
 ```bash
 kubectl create secret generic my-git-credentials --from-file='.git-credentials'="$HOME/.git-credentials"

--- a/examples/ssh-secret.yaml
+++ b/examples/ssh-secret.yaml
@@ -1,5 +1,5 @@
 # A sample https://github.com/buildkite/docker-ssh-env-config secret
-# kubectl create secret generic agent-stack-k8s --from-file=SSH_PRIVATE_RSA_KEY=id_rsa
+# kubectl create secret generic agent-stack-k8s --from-file=SSH_PRIVATE_RSA_KEY="$HOME/.ssh/id_rsa"
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
Deprecation of DSA keys from OpenSSH can be found [here](https://www.openssh.com/txt/release-9.9). This took effect in the `buildkite/agent-base` OS images we use to build the `buildkite/agent` image as of [`v3.88.0`](https://github.com/buildkite/agent/compare/v3.87.1...v3.88.0).