### PR TITLE
fix(scheduler): pod-spec-patch was not working on default init containers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ Brewfile.lock.json
 
 .DS_Store
 .vscode
+.idea
 
 dist/
 

--- a/README.md
+++ b/README.md
@@ -503,11 +503,12 @@ config:
   pod-spec-patch:
     initContainers:
     - name: copy-agent
-    requests:
-      cpu: 100m
-      memory: 50Mi
-    limits:
-      memory: 100Mi
+      resources:
+        requests:
+          cpu: 100m
+          memory: 50Mi
+        limits:
+          memory: 100Mi
     containers:
     - name: agent          # this container acquires the job
       resources:

--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -560,7 +560,7 @@ func (w *worker) Build(podSpec *corev1.PodSpec, skipCheckout bool, inputs buildI
 		)
 	}
 
-	initContainers := []corev1.Container{w.createWorkspaceSetupContainer(podSpec, workspaceVolume)}
+	podSpec.InitContainers = []corev1.Container{w.createWorkspaceSetupContainer(podSpec, workspaceVolume)}
 
 	// Only attempt the job once.
 	podSpec.RestartPolicy = corev1.RestartPolicyNever
@@ -671,7 +671,6 @@ func (w *worker) Build(podSpec *corev1.PodSpec, skipCheckout bool, inputs buildI
 		}
 	}
 
-	cullCheckForExisting(initContainers[0])    // the workspace setup container
 	for _, c := range podSpec.InitContainers { // user-defined init containers
 		cullCheckForExisting(c)
 	}
@@ -726,7 +725,7 @@ func (w *worker) Build(podSpec *corev1.PodSpec, skipCheckout bool, inputs buildI
 			zap.String("image", image),
 			zap.String("policy", string(policy)),
 		)
-		initContainers = append(initContainers, corev1.Container{
+		podSpec.InitContainers = append(podSpec.InitContainers, corev1.Container{
 			Name:            name,
 			Image:           image,
 			ImagePullPolicy: policy,
@@ -743,9 +742,6 @@ func (w *worker) Build(podSpec *corev1.PodSpec, skipCheckout bool, inputs buildI
 		})
 		i++
 	}
-
-	// Prepend all the init containers defined above to the podspec.
-	podSpec.InitContainers = append(initContainers, podSpec.InitContainers...)
 
 	kjob.Spec.Template.Spec = *podSpec
 

--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -560,7 +560,7 @@ func (w *worker) Build(podSpec *corev1.PodSpec, skipCheckout bool, inputs buildI
 		)
 	}
 
-	podSpec.InitContainers = []corev1.Container{w.createWorkspaceSetupContainer(podSpec, workspaceVolume)}
+	podSpec.InitContainers = append(podSpec.InitContainers, w.createWorkspaceSetupContainer(podSpec, workspaceVolume))
 
 	// Only attempt the job once.
 	podSpec.RestartPolicy = corev1.RestartPolicyNever

--- a/internal/controller/scheduler/scheduler_test.go
+++ b/internal/controller/scheduler/scheduler_test.go
@@ -224,6 +224,46 @@ func TestPatchPodSpec_ErrNoCommandModification(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "patching init-container command should fail",
+			podspec: &corev1.PodSpec{
+				InitContainers: []corev1.Container{
+					{
+						Name:    CopyAgentContainerName,
+						Image:   "alpine:latest",
+						Command: []string{"echo hello world"},
+					},
+				},
+			},
+			patch: &corev1.PodSpec{
+				InitContainers: []corev1.Container{
+					{
+						Name:    CopyAgentContainerName,
+						Command: []string{"this shouldn't work"},
+					},
+				},
+			},
+		},
+		{
+			name: "patching init-container args should fail",
+			podspec: &corev1.PodSpec{
+				InitContainers: []corev1.Container{
+					{
+						Name:    CopyAgentContainerName,
+						Image:   "alpine:latest",
+						Command: []string{"echo hello world"},
+					},
+				},
+			},
+			patch: &corev1.PodSpec{
+				InitContainers: []corev1.Container{
+					{
+						Name: CopyAgentContainerName,
+						Args: []string{"this", "shouldn't", "work"},
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range cases {
@@ -451,9 +491,8 @@ func TestBuild(t *testing.T) {
 			PodSpecPatch: &corev1.PodSpec{
 				InitContainers: []corev1.Container{
 					{
-						Name:    "copy-agent",
-						Image:   "alpine:latest",
-						Command: []string{"ls", "-l"},
+						Name:  "copy-agent",
+						Image: "alpine:latest",
 					},
 				},
 				Containers: []corev1.Container{
@@ -485,7 +524,7 @@ func TestBuild(t *testing.T) {
 	if diff := cmp.Diff(copyAgent.Image, "alpine:latest"); diff != "" {
 		t.Errorf("unexpected init container image (-want +got):\n%s", diff)
 	}
-	if diff := cmp.Diff(copyAgent.Command, []string{"ls", "-l"}); diff != "" {
+	if diff := cmp.Diff(copyAgent.Command, []string{"ash"}); diff != "" {
 		t.Errorf("unexpected init container command (-want +got):\n%s", diff)
 	}
 


### PR DESCRIPTION
### Description
This PR resolves an issue where the `PodSpecPatch` for default `initContainers` was not functioning correctly in the scheduler.

### Changes
- Fixed duplication of init containers in `podSpecPatch` when the init-container exists.
- Update the documentation for patching resources.
- Ensure the documentation of pod-spec-patch is aligned with what the code is doing.