### PR TITLE
Fix resources and port parsing for non-strings

### DIFF
--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -105,5 +105,5 @@ pod-spec-patch:
               key: github-token
       resources:
         requests:
-          cpu: 1000m # one core
+          cpu: 1
           mem: 4Gi


### PR DESCRIPTION
resources can be specified as floats or ints; similarly, liveness checks use a port that's either a string or an int (i.e. named port from the ports: list).

Overall, this hand-coded approach is likely to continue causing issues, but this at least fixes the two issues I ran into. I think to fix this completely, you'd need to rewrite config parsing to use the same machinery as what kube uses, but that feels overkill.