### PR TITLE
Update CODEOWNERS - remove obsolete team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-* @buildkite/pipelines-enterprise
 * @buildkite/support-engineering


### PR DESCRIPTION
As per the discussion in https://github.com/buildkite/agent-stack-k8s/pull/494 - discussed this further with @tomowatt and yes, it's OK to remove the obslete team.