### PR TITLE
SUP-3258 - Implement .spec.job.activeDeadlineSeconds

### DIFF
--- a/charts/agent-stack-k8s/values.schema.json
+++ b/charts/agent-stack-k8s/values.schema.json
@@ -203,6 +203,12 @@
           "title": "The job-ttl Schema",
           "examples": [""]
         },
+        "job-active-deadline-seconds": {
+          "type": "integer",
+          "default": 21600,
+          "title": "The maximum number of seconds a kubernetes job is allowed to run before terminating all pods and failing the job",
+          "examples": [43200, 86400]
+        },
         "max-in-flight": {
           "type": "integer",
           "default": 0,

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -70,6 +70,11 @@ func AddConfigFlags(cmd *cobra.Command) {
 		10*time.Minute,
 		"time to retain kubernetes jobs after completion",
 	)
+	cmd.Flags().Int(
+		"job-active-deadline-seconds",
+		21600,
+		"maximum number of seconds a kubernetes job is allowed to run before terminating all pods and failing job",
+	)
 	cmd.Flags().Duration(
 		"poll-interval",
 		time.Second,

--- a/cmd/controller/controller_test.go
+++ b/cmd/controller/controller_test.go
@@ -24,6 +24,7 @@ func TestReadAndParseConfig(t *testing.T) {
 		BuildkiteToken:               "my-graphql-enabled-token",
 		Image:                        "my.registry.dev/buildkite-agent:latest",
 		JobTTL:                       300 * time.Second,
+		JobActiveDeadlineSeconds:     21600,
 		ImagePullBackOffGracePeriod:  60 * time.Second,
 		JobCancelCheckerPollInterval: 10 * time.Second,
 		EmptyJobGracePeriod:          50 * time.Second,

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -2,6 +2,7 @@ agent-token-secret: my-kubernetes-secret
 debug: true
 image: my.registry.dev/buildkite-agent:latest
 job-ttl: 5m
+job-active-deadline-seconds: 21600
 image-pull-backoff-grace-period: 60s
 job-cancel-checker-poll-interval: 10s
 empty-job-grace-period: 50s

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -31,22 +31,23 @@ var DefaultAgentImage = "ghcr.io/buildkite/agent:" + version.Version()
 // mapstructure (the module) supports switching the struct tag to "json", viper does not. So we have
 // to have the `mapstructure` tag for viper and the `json` tag is used by the mapstructure!
 type Config struct {
-	Debug                  bool          `json:"debug"`
-	JobTTL                 time.Duration `json:"job-ttl"`
-	PollInterval           time.Duration `json:"poll-interval"`
-	StaleJobDataTimeout    time.Duration `json:"stale-job-data-timeout"   validate:"omitempty"`
-	JobCreationConcurrency int           `json:"job-creation-concurrency" validate:"omitempty"`
-	AgentTokenSecret       string        `json:"agent-token-secret"       validate:"required"`
-	BuildkiteToken         string        `json:"buildkite-token"          validate:"required"`
-	Image                  string        `json:"image"                    validate:"required"`
-	MaxInFlight            int           `json:"max-in-flight"            validate:"min=0"`
-	Namespace              string        `json:"namespace"                validate:"required"`
-	Org                    string        `json:"org"                      validate:"required"`
-	Tags                   stringSlice   `json:"tags"                     validate:"min=1"`
-	PrometheusPort         uint16        `json:"prometheus-port"          validate:"omitempty"`
-	ProfilerAddress        string        `json:"profiler-address"         validate:"omitempty,hostname_port"`
-	GraphQLEndpoint        string        `json:"graphql-endpoint"         validate:"omitempty"`
-	GraphQLResultsLimit    int           `json:"graphql-results-limit"    validate:"min=1,max=500"`
+	Debug                    bool          `json:"debug"`
+	JobTTL                   time.Duration `json:"job-ttl"`
+	JobActiveDeadlineSeconds int           `json:"job-active-deadline-seconds" validate:"required"`
+	PollInterval             time.Duration `json:"poll-interval"`
+	StaleJobDataTimeout      time.Duration `json:"stale-job-data-timeout"   validate:"omitempty"`
+	JobCreationConcurrency   int           `json:"job-creation-concurrency" validate:"omitempty"`
+	AgentTokenSecret         string        `json:"agent-token-secret"       validate:"required"`
+	BuildkiteToken           string        `json:"buildkite-token"          validate:"required"`
+	Image                    string        `json:"image"                    validate:"required"`
+	MaxInFlight              int           `json:"max-in-flight"            validate:"min=0"`
+	Namespace                string        `json:"namespace"                validate:"required"`
+	Org                      string        `json:"org"                      validate:"required"`
+	Tags                     stringSlice   `json:"tags"                     validate:"min=1"`
+	PrometheusPort           uint16        `json:"prometheus-port"          validate:"omitempty"`
+	ProfilerAddress          string        `json:"profiler-address"         validate:"omitempty,hostname_port"`
+	GraphQLEndpoint          string        `json:"graphql-endpoint"         validate:"omitempty"`
+	GraphQLResultsLimit      int           `json:"graphql-results-limit"    validate:"min=1,max=500"`
 	// Agent endpoint is set in agent-config.
 
 	K8sClientRateLimiterQPS   int `json:"k8s-client-rate-limiter-qps" validate:"omitempty"`
@@ -94,6 +95,7 @@ func (c Config) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	enc.AddBool("debug", c.Debug)
 	enc.AddString("image", c.Image)
 	enc.AddDuration("job-ttl", c.JobTTL)
+	enc.AddInt("job-active-deadline-seconds", c.JobActiveDeadlineSeconds)
 	enc.AddDuration("poll-interval", c.PollInterval)
 	enc.AddDuration("stale-job-data-timeout", c.StaleJobDataTimeout)
 	enc.AddInt("job-creation-concurrency", c.JobCreationConcurrency)

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -92,6 +92,7 @@ func Run(
 		Image:                       cfg.Image,
 		AgentTokenSecretName:        cfg.AgentTokenSecret,
 		JobTTL:                      cfg.JobTTL,
+		JobActiveDeadlineSeconds:    cfg.JobActiveDeadlineSeconds,
 		AdditionalRedactedVars:      cfg.AdditionalRedactedVars,
 		WorkspaceVolume:             cfg.WorkspaceVolume,
 		AgentConfig:                 cfg.AgentConfig,

--- a/internal/integration/fixtures/jobactivedeadlineseconds.yaml
+++ b/internal/integration/fixtures/jobactivedeadlineseconds.yaml
@@ -1,0 +1,8 @@
+steps:
+  - label: ":x:"
+    agents:
+      queue: "{{.queue}}"
+    command: sleep 90
+    plugins:
+      - kubernetes:
+          jobActiveDeadlineSeconds: 60

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -597,3 +597,22 @@ func TestCancelCheckerEvictsPod(t *testing.T) {
 		t.Error("The agent ran and handled cancellation")
 	}
 }
+
+func TestJobActiveDeadlineSeconds(t *testing.T) {
+	tc := testcase{
+		T:       t,
+		Fixture: "jobactivedeadlineseconds.yaml",
+		Repo:    repoHTTP,
+		GraphQL: api.NewClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
+	}.Init()
+	ctx := context.Background()
+	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)
+	tc.StartController(ctx, cfg)
+	build := tc.TriggerBuild(ctx, pipelineID)
+	tc.AssertFail(ctx, build)
+	time.Sleep(5 * time.Second) // trying to reduce flakes: logs not immediately available
+	logs := tc.FetchLogs(build)
+	if strings.Contains(logs, "Received cancellation signal, interrupting") {
+		t.Error("The agent ran and handled cancellation")
+	}
+}


### PR DESCRIPTION
Implements `.spec.job.activeDeadlineSeconds` as a means of [setting runtime boundaries](https://kubernetes.io/docs/concepts/workloads/controllers/job/#job-termination-and-cleanup) for Kubernetes jobs that are unable to complete within a "reasonable" amount of time.

This is configured with a default value of `21600` seconds (6 hours) in the controller configuration. This value can be overridden by the user via the command line `--job-active-deadline-seconds 43200`, directly in the controller configuration `job-active-deadline-seconds: 43200`, or on a per Buildkite job basis via the `kubernetes` plugin:
```
steps:
  - label: "12 hour nap, override default 6 hour job-active-deadline-seconds config"
    command: sleep 43200
    plugins:
      - kubernetes:
          jobActiveDeadlineSeconds: 46800
```
At this time `.spec.job.activeDeadlineSeconds` will not be able to be disabled, as we [agree](https://github.com/buildkite/agent-stack-k8s/issues/480#issue-2807735870) that a job runtime boundary should be defined at all times.

Fixes https://github.com/buildkite/agent-stack-k8s/issues/480
Fixes https://github.com/buildkite/agent-stack-k8s/issues/479
Fixes https://github.com/buildkite/agent-stack-k8s/issues/463