### PR TITLE
SUP-3283: Enable configuring GraphQL Result Limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,24 +122,33 @@ Available Commands:
   version     Prints the version
 
 Flags:
-      --agent-token-secret string                  name of the Buildkite agent token secret (default "buildkite-agent-token")
-      --buildkite-token string                     Buildkite API token with GraphQL scopes
-      --cluster-uuid string                        UUID of the Buildkite Cluster. The agent token must be for the Buildkite Cluster.
-  -f, --config string                              config file path
-      --debug                                      debug logs
-  -h, --help                                       help for agent-stack-k8s
-      --image string                               The image to use for the Buildkite agent (default "ghcr.io/buildkite/agent:3.78.0")
-      --image-pull-backoff-grace-period duration   Duration after starting a pod that the controller will wait before considering cancelling a job due to ImagePullBackOff (e.g. when the podSpec specifies container images that cannot be pulled) (default 30s)
-      --job-ttl duration                           time to retain kubernetes jobs after completion (default 10m0s)
-      --k8s-client-rate-limiter-qps int            number of queries per second allowed to Kubernetes API, once Burst has been exhausted (default 10)
-      --k8s-client-rate-limiter-burst int          number of queries allowed before throttling requests to Kubernetes API, before using QPS (default 20)
-      --max-in-flight int                          max jobs in flight, 0 means no max (default 25)
-      --namespace string                           kubernetes namespace to create resources in (default "default")
-      --org string                                 Buildkite organization name to watch
-      --poll-interval duration                     time to wait between polling for new jobs (minimum 1s); note that increasing this causes jobs to be slower to start (default 1s)
-      --profiler-address string                    Bind address to expose the pprof profiler (e.g. localhost:6060)
-      --prohibit-kubernetes-plugin                 Causes the controller to prohibit the kubernetes plugin specified within jobs (pipeline YAML) - enabling this causes jobs with a kubernetes plugin to fail, preventing the pipeline YAML from having any influence over the podSpec
-      --tags strings                               A comma-separated list of agent tags. The "queue" tag must be unique (e.g. "queue=kubernetes,os=linux") (default [queue=kubernetes])
+      --agent-token-secret string                   name of the Buildkite agent token secret (default "buildkite-agent-token")
+      --buildkite-token string                      Buildkite API token with GraphQL scopes
+      --cluster-uuid string                         UUID of the Buildkite Cluster. The agent token must be for the Buildkite Cluster.
+  -f, --config string                               config file path
+      --debug                                       debug logs
+      --default-image-check-pull-policy string      Sets a default PullPolicy for image-check init containers, used if an image pull policy is not set for the corresponding container in a podSpec or podSpecPatch
+      --default-image-pull-policy string            Configures a default image pull policy for containers that do not specify a pull policy and non-init containers created by the stack itself (default "IfNotPresent")
+      --empty-job-grace-period duration             Duration after starting a Kubernetes job that the controller will wait before considering failing the job due to a missing pod (e.g. when the podSpec specifies a missing service account) (default 30s)
+      --graphql-endpoint string                     Buildkite GraphQL endpoint URL
+      --graphql-results-limit int                   Sets the amount of results returned by GraphQL queries when retreiving Jobs to be Scheduled (default 100)
+  -h, --help                                        help for agent-stack-k8s
+      --image string                                The image to use for the Buildkite agent (default "ghcr.io/buildkite/agent:3.91.0")
+      --image-pull-backoff-grace-period duration    Duration after starting a pod that the controller will wait before considering cancelling a job due to ImagePullBackOff (e.g. when the podSpec specifies container images that cannot be pulled) (default 30s)
+      --job-cancel-checker-poll-interval duration   Controls the interval between job state queries while a pod is still Pending (default 5s)
+      --job-creation-concurrency int                Number of concurrent goroutines to run for converting Buildkite jobs into Kubernetes jobs (default 5)
+      --job-ttl duration                            time to retain kubernetes jobs after completion (default 10m0s)
+      --k8s-client-rate-limiter-burst int           The burst value of the K8s client rate limiter. (default 20)
+      --k8s-client-rate-limiter-qps int             The QPS value of the K8s client rate limiter. (default 10)
+      --max-in-flight int                           max jobs in flight, 0 means no max (default 25)
+      --namespace string                            kubernetes namespace to create resources in (default "default")
+      --org string                                  Buildkite organization name to watch
+      --poll-interval duration                      time to wait between polling for new jobs (minimum 1s); note that increasing this causes jobs to be slower to start (default 1s)
+      --profiler-address string                     Bind address to expose the pprof profiler (e.g. localhost:6060)
+      --prohibit-kubernetes-plugin                  Causes the controller to prohibit the kubernetes plugin specified within jobs (pipeline YAML) - enabling this causes jobs with a kubernetes plugin to fail, preventing the pipeline YAML from having any influence over the podSpec
+      --prometheus-port uint16                      Bind port to expose Prometheus /metrics; 0 disables it
+      --stale-job-data-timeout duration             Duration after querying jobs in Buildkite that the data is considered valid (default 10s)
+      --tags strings                                A comma-separated list of agent tags. The "queue" tag must be unique (e.g. "queue=kubernetes,os=linux") (default [queue=kubernetes])
 
 Use "agent-stack-k8s [command] --help" for more information about a command.
 ```

--- a/api/generated.go
+++ b/api/generated.go
@@ -1556,6 +1556,7 @@ type __GetScheduledJobsClusteredInput struct {
 	Slug            string   `json:"slug"`
 	AgentQueryRules []string `json:"agentQueryRules"`
 	Cluster         string   `json:"cluster"`
+	First           int      `json:"first"`
 }
 
 // GetSlug returns __GetScheduledJobsClusteredInput.Slug, and is useful for accessing the field via an interface.
@@ -1567,10 +1568,14 @@ func (v *__GetScheduledJobsClusteredInput) GetAgentQueryRules() []string { retur
 // GetCluster returns __GetScheduledJobsClusteredInput.Cluster, and is useful for accessing the field via an interface.
 func (v *__GetScheduledJobsClusteredInput) GetCluster() string { return v.Cluster }
 
+// GetFirst returns __GetScheduledJobsClusteredInput.First, and is useful for accessing the field via an interface.
+func (v *__GetScheduledJobsClusteredInput) GetFirst() int { return v.First }
+
 // __GetScheduledJobsInput is used internally by genqlient
 type __GetScheduledJobsInput struct {
 	Slug            string   `json:"slug"`
 	AgentQueryRules []string `json:"agentQueryRules"`
+	First           int      `json:"first"`
 }
 
 // GetSlug returns __GetScheduledJobsInput.Slug, and is useful for accessing the field via an interface.
@@ -1578,6 +1583,9 @@ func (v *__GetScheduledJobsInput) GetSlug() string { return v.Slug }
 
 // GetAgentQueryRules returns __GetScheduledJobsInput.AgentQueryRules, and is useful for accessing the field via an interface.
 func (v *__GetScheduledJobsInput) GetAgentQueryRules() []string { return v.AgentQueryRules }
+
+// GetFirst returns __GetScheduledJobsInput.First, and is useful for accessing the field via an interface.
+func (v *__GetScheduledJobsInput) GetFirst() int { return v.First }
 
 // __PipelineDeleteInput is used internally by genqlient
 type __PipelineDeleteInput struct {
@@ -1950,10 +1958,10 @@ func GetOrganization(
 
 // The query or mutation executed by GetScheduledJobs.
 const GetScheduledJobs_Operation = `
-query GetScheduledJobs ($slug: ID!, $agentQueryRules: [String!]) {
+query GetScheduledJobs ($slug: ID!, $agentQueryRules: [String!], $first: Int) {
 	organization(slug: $slug) {
 		id
-		jobs(state: [SCHEDULED], type: [COMMAND], first: 100, order: RECENTLY_ASSIGNED, agentQueryRules: $agentQueryRules, clustered: false) {
+		jobs(state: [SCHEDULED], type: [COMMAND], first: $first, order: RECENTLY_ASSIGNED, agentQueryRules: $agentQueryRules, clustered: false) {
 			count
 			edges {
 				node {
@@ -1985,6 +1993,7 @@ func GetScheduledJobs(
 	client_ graphql.Client,
 	slug string,
 	agentQueryRules []string,
+	first int,
 ) (*GetScheduledJobsResponse, error) {
 	req_ := &graphql.Request{
 		OpName: "GetScheduledJobs",
@@ -1992,6 +2001,7 @@ func GetScheduledJobs(
 		Variables: &__GetScheduledJobsInput{
 			Slug:            slug,
 			AgentQueryRules: agentQueryRules,
+			First:           first,
 		},
 	}
 	var err_ error
@@ -2010,10 +2020,10 @@ func GetScheduledJobs(
 
 // The query or mutation executed by GetScheduledJobsClustered.
 const GetScheduledJobsClustered_Operation = `
-query GetScheduledJobsClustered ($slug: ID!, $agentQueryRules: [String!], $cluster: ID!) {
+query GetScheduledJobsClustered ($slug: ID!, $agentQueryRules: [String!], $cluster: ID!, $first: Int) {
 	organization(slug: $slug) {
 		id
-		jobs(state: [SCHEDULED], type: [COMMAND], first: 100, order: RECENTLY_ASSIGNED, agentQueryRules: $agentQueryRules, cluster: $cluster) {
+		jobs(state: [SCHEDULED], type: [COMMAND], first: $first, order: RECENTLY_ASSIGNED, agentQueryRules: $agentQueryRules, cluster: $cluster) {
 			count
 			edges {
 				node {
@@ -2046,6 +2056,7 @@ func GetScheduledJobsClustered(
 	slug string,
 	agentQueryRules []string,
 	cluster string,
+	first int,
 ) (*GetScheduledJobsClusteredResponse, error) {
 	req_ := &graphql.Request{
 		OpName: "GetScheduledJobsClustered",
@@ -2054,6 +2065,7 @@ func GetScheduledJobsClustered(
 			Slug:            slug,
 			AgentQueryRules: agentQueryRules,
 			Cluster:         cluster,
+			First:           first,
 		},
 	}
 	var err_ error

--- a/api/genqlient.graphql
+++ b/api/genqlient.graphql
@@ -55,14 +55,18 @@ query GetBuild($uuid: ID!) {
     }
 }
 
-query GetScheduledJobs($slug: ID!, $agentQueryRules: [String!]) {
+query GetScheduledJobs(
+    $slug: ID!, 
+    $agentQueryRules: [String!], 
+    $first: Int
+) {
     organization(slug: $slug) {
         # @genqlient(pointer: true)
         id
         jobs(
             state: [SCHEDULED]
             type: [COMMAND]
-            first: 100
+            first: $first
             order: RECENTLY_ASSIGNED
             agentQueryRules: $agentQueryRules
             clustered: false
@@ -82,6 +86,7 @@ query GetScheduledJobsClustered(
     $slug: ID!
     $agentQueryRules: [String!]
     $cluster: ID!
+    $first: Int
 ) {
     organization(slug: $slug) {
         # @genqlient(pointer: true)
@@ -89,7 +94,7 @@ query GetScheduledJobsClustered(
         jobs(
             state: [SCHEDULED]
             type: [COMMAND]
-            first: 100
+            first: $first
             order: RECENTLY_ASSIGNED
             agentQueryRules: $agentQueryRules
             cluster: $cluster

--- a/charts/agent-stack-k8s/values.schema.json
+++ b/charts/agent-stack-k8s/values.schema.json
@@ -517,6 +517,13 @@
         },
         "pod-spec-patch": {
           "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.PodSpec"
+        },
+        "graphql-results-limit": {
+          "type": "integer",
+          "default": 100,
+          "minimum": 1,
+          "maximum": 500,
+          "title": "The maximum number of GraphQL results to return from GetScheduledJobs and GetScheduledJobsClustered queries"
         }
       },
       "examples": [

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -142,6 +142,10 @@ func AddConfigFlags(cmd *cobra.Command) {
 		false,
 		"Causes the controller to prohibit the kubernetes plugin specified within jobs (pipeline YAML) - enabling this causes jobs with a kubernetes plugin to fail, preventing the pipeline YAML from having any influence over the podSpec",
 	)
+	cmd.Flags().Int(
+		"graphql-results-limit",
+		config.DefaultGraphQLResultsLimit,
+		"Sets the amount of results returned by GraphQL queries when retreiving Jobs to be Scheduled")
 }
 
 // ReadConfigFromFileArgsAndEnv reads the config from the file, env and args in that order.

--- a/cmd/controller/controller_test.go
+++ b/cmd/controller/controller_test.go
@@ -39,6 +39,7 @@ func TestReadAndParseConfig(t *testing.T) {
 		ClusterUUID:                  "beefcafe-abbe-baba-abba-deedcedecade",
 		ProhibitKubernetesPlugin:     true,
 		GraphQLEndpoint:              "http://graphql.buildkite.localhost/v1",
+		GraphQLResultsLimit:          200,
 		DefaultImagePullPolicy:       "Never",
 		DefaultImageCheckPullPolicy:  "IfNotPresent",
 

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -15,6 +15,7 @@ namespace: my-buildkite-ns
 org: my-buildkite-org
 default-image-pull-policy: Never
 default-image-check-pull-policy: IfNotPresent
+graphql-results-limit: 200
 
 # Setting a custom GraphQL endpoint is usually only useful if you have a
 #  different instance of Buildkite itself available to run.

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -22,6 +22,7 @@ const (
 	DefaultJobCreationConcurrency       = 5
 	DefaultK8sClientRateLimiterQPS      = 10
 	DefaultK8sClientRateLimiterBurst    = 20
+	DefaultGraphQLResultsLimit          = 100
 )
 
 var DefaultAgentImage = "ghcr.io/buildkite/agent:" + version.Version()
@@ -45,6 +46,7 @@ type Config struct {
 	PrometheusPort         uint16        `json:"prometheus-port"          validate:"omitempty"`
 	ProfilerAddress        string        `json:"profiler-address"         validate:"omitempty,hostname_port"`
 	GraphQLEndpoint        string        `json:"graphql-endpoint"         validate:"omitempty"`
+	GraphQLResultsLimit    int           `json:"graphql-results-limit"    validate:"min=1,max=500"`
 	// Agent endpoint is set in agent-config.
 
 	K8sClientRateLimiterQPS   int `json:"k8s-client-rate-limiter-qps" validate:"omitempty"`

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -79,6 +79,7 @@ func Run(
 		JobCreationConcurrency: cfg.JobCreationConcurrency,
 		Tags:                   cfg.Tags,
 		Token:                  cfg.BuildkiteToken,
+		GraphQLResultsLimit:    cfg.GraphQLResultsLimit,
 	})
 	if err != nil {
 		logger.Fatal("failed to create monitor", zap.Error(err))

--- a/internal/controller/monitor/monitor.go
+++ b/internal/controller/monitor/monitor.go
@@ -40,6 +40,7 @@ type Config struct {
 	StaleJobDataTimeout    time.Duration
 	Org                    string
 	Tags                   []string
+	GraphQLResultsLimit    int
 }
 
 func New(logger *zap.Logger, k8s kubernetes.Interface, cfg Config) (*Monitor, error) {
@@ -116,7 +117,7 @@ func (m *Monitor) getScheduledCommandJobs(ctx context.Context, queue string) (jo
 	}()
 
 	if m.cfg.ClusterUUID == "" {
-		resp, err := api.GetScheduledJobs(ctx, m.gql, m.cfg.Org, []string{fmt.Sprintf("queue=%s", queue)})
+		resp, err := api.GetScheduledJobs(ctx, m.gql, m.cfg.Org, []string{fmt.Sprintf("queue=%s", queue)}, m.cfg.GraphQLResultsLimit)
 		return unclusteredJobResp(*resp), err
 	}
 
@@ -126,7 +127,7 @@ func (m *Monitor) getScheduledCommandJobs(ctx context.Context, queue string) (jo
 	}
 
 	resp, err := api.GetScheduledJobsClustered(
-		ctx, m.gql, m.cfg.Org, agentQueryRule, encodeClusterGraphQLID(m.cfg.ClusterUUID),
+		ctx, m.gql, m.cfg.Org, agentQueryRule, encodeClusterGraphQLID(m.cfg.ClusterUUID), m.cfg.GraphQLResultsLimit,
 	)
 	return clusteredJobResp(*resp), err
 }


### PR DESCRIPTION
By allowing configuring the GraphQL Result Limits the amount of Jobs being retrieived by queries can be increased/decreased for scaling the amount of Jobs the controller can retreive and then scheduled as Kubernetes Jobs