### PR TITLE
RFC: Use different exit statuses for different failures

### DIFF
--- a/internal/controller/scheduler/fail_job.go
+++ b/internal/controller/scheduler/fail_job.go
@@ -26,6 +26,7 @@ func acquireAndFailForObject(
 	k8sClient kubernetes.Interface,
 	cfg *config.Config,
 	obj metav1.Object,
+	code int,
 	message string,
 ) error {
 	agentToken, err := fetchAgentToken(ctx, logger, k8sClient, obj.GetNamespace(), cfg.AgentTokenSecret)
@@ -44,7 +45,7 @@ func acquireAndFailForObject(
 	tags := agenttags.TagsFromLabels(labels)
 	opts := cfg.AgentConfig.ControllerOptions()
 
-	if err := acquireAndFail(ctx, logger, agentToken, jobUUID, tags, message, opts...); err != nil {
+	if err := acquireAndFail(ctx, logger, agentToken, jobUUID, tags, code, message, opts...); err != nil {
 		logger.Error("failed to acquire and fail the job on Buildkite", zap.Error(err))
 		return err
 	}
@@ -59,6 +60,7 @@ func acquireAndFail(
 	agentToken string,
 	jobUUID string,
 	tags []string,
+	code int,
 	message string,
 	options ...agentcore.ControllerOption,
 ) error {
@@ -92,7 +94,7 @@ func acquireAndFail(
 		return fmt.Errorf("writing log: %w", err)
 	}
 
-	if err := jctr.Finish(ctx, agentcore.ProcessExit{Status: 1}); err != nil {
+	if err := jctr.Finish(ctx, agentcore.ProcessExit{Status: code}); err != nil {
 		zapLogger.Error("finishing job", zap.Error(err))
 		return fmt.Errorf("finishing job: %w", err)
 	}

--- a/internal/controller/scheduler/job_watcher.go
+++ b/internal/controller/scheduler/job_watcher.go
@@ -169,7 +169,7 @@ func (w *jobWatcher) checkFinishedWithoutPod(ctx context.Context, log *zap.Logge
 	log.Info("The Kubernetes job ended without starting a pod. Failing the corresponding Buildkite job")
 	message := "The Kubernetes job ended without starting a pod.\n"
 	message += w.fetchEvents(ctx, log, kjob)
-	w.failJob(ctx, log, kjob, message)
+	w.failJob(ctx, log, kjob, -1, message)
 }
 
 func (w *jobWatcher) checkStalledWithoutPod(log *zap.Logger, jobUUID uuid.UUID, kjob *batchv1.Job) {
@@ -217,8 +217,8 @@ func (w *jobWatcher) fetchEvents(ctx context.Context, log *zap.Logger, kjob *bat
 	return w.formatEvents(evlist)
 }
 
-func (w *jobWatcher) failJob(ctx context.Context, log *zap.Logger, kjob *batchv1.Job, message string) {
-	if err := acquireAndFailForObject(ctx, log, w.k8s, w.cfg, kjob, message); err != nil {
+func (w *jobWatcher) failJob(ctx context.Context, log *zap.Logger, kjob *batchv1.Job, code int, message string) {
+	if err := acquireAndFailForObject(ctx, log, w.k8s, w.cfg, kjob, code, message); err != nil {
 		// Maybe the job was cancelled in the meantime?
 		log.Error("Could not fail Buildkite job", zap.Error(err))
 		jobWatcherBuildkiteJobFailErrorsCounter.Inc()
@@ -305,7 +305,7 @@ func (w *jobWatcher) cleanupStalledJob(ctx context.Context, kjob *batchv1.Job) {
 	stallDuration := duration.HumanDuration(time.Since(kjob.Status.StartTime.Time))
 	message := fmt.Sprintf("The Kubernetes job spent %s without starting a pod.\n", stallDuration)
 	message += w.fetchEvents(ctx, log, kjob)
-	w.failJob(ctx, log, kjob, message)
+	w.failJob(ctx, log, kjob, -1, message)
 
 	// Use ActiveDeadlineSeconds to fail the job, which makes k8s delete the job
 	// in the future.

--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -99,7 +99,7 @@ func (w *worker) Handle(ctx context.Context, job model.Job) error {
 	inputs, err := w.ParseJob(job.CommandJob)
 	if err != nil {
 		logger.Warn("Job parsing failed, failing job", zap.Error(err))
-		return w.failJob(ctx, inputs, fmt.Sprintf("agent-stack-k8s failed to parse the job: %v", err))
+		return w.failJob(ctx, inputs, 1, fmt.Sprintf("agent-stack-k8s failed to parse the job: %v", err))
 	}
 
 	// Default command container using default image.
@@ -119,7 +119,7 @@ func (w *worker) Handle(ctx context.Context, job model.Job) error {
 	kjob, err := w.Build(podSpec, false, inputs)
 	if err != nil {
 		logger.Warn("Job definition error detected, failing job", zap.Error(err))
-		return w.failJob(ctx, inputs, fmt.Sprintf("agent-stack-k8s failed to build a podSpec for the job: %v", err))
+		return w.failJob(ctx, inputs, 1, fmt.Sprintf("agent-stack-k8s failed to build a podSpec for the job: %v", err))
 	}
 
 	jobCreateCallsCounter.Inc()
@@ -133,7 +133,7 @@ func (w *worker) Handle(ctx context.Context, job model.Job) error {
 
 		case kerrors.IsInvalid(err):
 			logger.Warn("Job invalid, failing job on Buildkite", zap.Error(err))
-			return w.failJob(ctx, inputs, fmt.Sprintf("Kubernetes rejected the podSpec built by agent-stack-k8s: %v", err))
+			return w.failJob(ctx, inputs, 1, fmt.Sprintf("Kubernetes rejected the podSpec built by agent-stack-k8s: %v", err))
 
 		default:
 			return err
@@ -1059,7 +1059,7 @@ buildkite-agent-entrypoint bootstrap`,
 }
 
 // failJob fails the job in Buildkite.
-func (w *worker) failJob(ctx context.Context, inputs buildInputs, message string) error {
+func (w *worker) failJob(ctx context.Context, inputs buildInputs, code int, message string) error {
 	// Need to fetch the agent token ourselves.
 	agentToken, err := fetchAgentToken(ctx, w.logger, w.client, w.cfg.Namespace, w.cfg.AgentTokenSecretName)
 	if err != nil {
@@ -1068,7 +1068,7 @@ func (w *worker) failJob(ctx context.Context, inputs buildInputs, message string
 	}
 
 	opts := w.cfg.AgentConfig.ControllerOptions()
-	if err := acquireAndFail(ctx, w.logger, agentToken, inputs.uuid, inputs.agentQueryRules, message, opts...); err != nil {
+	if err := acquireAndFail(ctx, w.logger, agentToken, inputs.uuid, inputs.agentQueryRules, code, message, opts...); err != nil {
 		w.logger.Error("failed to acquire and fail the job on Buildkite", zap.Error(err))
 		schedulerBuildkiteJobFailErrorsCounter.Inc()
 		return err


### PR DESCRIPTION
The problem that I'm having is that I get occasional image pull "failures." That is to say - these are not persistent, retrying them usually fixes things.

I'd like to automate the retries but the current retry code makes that difficult (1 is too generic). `docker run` returns 125 for a missing image. This patch makes buildkite return the same and similarly updates exit codes in other places. This isn't obviously the right approach, so feedback welcome.