### PR TITLE
SUP-3261: Use Protobuf encoding for API responses

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -314,6 +314,11 @@ func New() *cobra.Command {
 			clientConfig := restconfig.GetConfigOrDie()
 			clientConfig.QPS = float32(cfg.K8sClientRateLimiterQPS)
 			clientConfig.Burst = cfg.K8sClientRateLimiterBurst
+
+			// Default to Protobuf encoding for API responses, support fallback to JSON
+			clientConfig.AcceptContentTypes = "application/vnd.kubernetes.protobuf,application/json"
+			clientConfig.ContentType = "application/vnd.kubernetes.protobuf"
+
 			k8sClient, err := kubernetes.NewForConfig(clientConfig)
 			if err != nil {
 				logger.Error("failed to create clientset", zap.Error(err))


### PR DESCRIPTION
Default to Protobuf for [encoding](https://kubernetes.io/docs/reference/using-api/api-concepts/#protobuf-encoding) of API responses, [fallback](https://kubernetes.io/docs/reference/using-api/api-concepts/#protobuf-encoding-compatibility) to JSON if not supported by API resource type.

Fixes https://github.com/buildkite/agent-stack-k8s/issues/400