### PR TITLE
SUP-3216 - Remove checkout container from podSpec, if skipped

### DIFF
--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -591,11 +591,9 @@ func (w *worker) Build(podSpec *corev1.PodSpec, skipCheckout bool, inputs buildI
 			switch pod.Name {
 			case CheckoutContainerName:
 				podSpec.Containers = append(podSpec.Containers[:i], podSpec.Containers[i+1:]...)
-				break
 
 			default:
 				continue
-
 			}
 		}
 	}

--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -586,6 +586,20 @@ func (w *worker) Build(podSpec *corev1.PodSpec, skipCheckout bool, inputs buildI
 		w.logger.Debug("Applied podSpec patch from k8s plugin", zap.Any("patched", patched))
 	}
 
+	if skipCheckout {
+		for i, pod := range podSpec.Containers {
+			switch pod.Name {
+			case CheckoutContainerName:
+				podSpec.Containers = append(podSpec.Containers[:i], podSpec.Containers[i+1:]...)
+				break
+
+			default:
+				continue
+
+			}
+		}
+	}
+
 	// Use init containers to check that images can be used or pulled before
 	// any other containers run. These are added _after_ podSpecPatch is applied
 	// since podSpecPatch may freely modify each container's image ref.


### PR DESCRIPTION
If a Buildkite job is configured to skip checkout AND the `checkout` container is configured in the controller's `pod-spec-patch` or the plugin's `podSpecPatch`, remove the `checkout` container from the resulting merged `podSpec` before the controller creates the Kubernetes Job.