### PR TITLE
SUP-3349: Apply sane resource requests to imagecheck containers

### DIFF
--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -27,6 +27,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/client-go/kubernetes"
@@ -755,6 +756,13 @@ func (w *worker) Build(podSpec *corev1.PodSpec, skipCheckout bool, inputs buildI
 				Name:      workspaceVolume.Name,
 				MountPath: "/workspace",
 			}},
+			// Apply container resource requests to imagecheck containers
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("64Mi"),
+				},
+			},
 		})
 		i++
 	}


### PR DESCRIPTION
Apply the following resource requests to `imagecheck-#` containers:
```
spec:
  containers:
  - name: imagecheck-#
    resources:
      requests:
        cpu: "100m"
        memory: "64Mi"
```
Partially addresses https://github.com/buildkite/agent-stack-k8s/issues/503