### PR TITLE
Allow configurable job name prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Flags:
       --stale-job-data-timeout duration             Duration after querying jobs in Buildkite that the data is considered valid (default 10s)
       --tags strings                                A comma-separated list of agent tags. The "queue" tag must be unique (e.g. "queue=kubernetes,os=linux") (default [queue=kubernetes])
       --enable-queue-pause bool                     Allow the controller to pause processing the jobs when the queue is paused on Buildkite. (default false)
+      --job-prefix string                           The prefix to use when creating Kubernetes job names (default "buildkite-")
 
 
 Use "agent-stack-k8s [command] --help" for more information about a command.

--- a/charts/agent-stack-k8s/values.schema.json
+++ b/charts/agent-stack-k8s/values.schema.json
@@ -203,6 +203,12 @@
           "title": "The job-ttl Schema",
           "examples": [""]
         },
+        "job-prefix": {
+          "type": "string",
+          "default": "buildkite-",
+          "title": "The prefix to use when creating Kubernetes job names",
+          "examples": ["kubekite-","buildkube-"]
+        },
         "job-active-deadline-seconds": {
           "type": "integer",
           "default": 21600,

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -53,6 +53,11 @@ func AddConfigFlags(cmd *cobra.Command) {
 		config.DefaultAgentImage,
 		"The image to use for the Buildkite agent",
 	)
+	cmd.Flags().String(
+		"job-prefix",
+		"buildkite-",
+		"The prefix to use when creating Kubernetes job names",
+	)
 	cmd.Flags().StringSlice(
 		"tags",
 		[]string{"queue=kubernetes"},

--- a/cmd/controller/controller_test.go
+++ b/cmd/controller/controller_test.go
@@ -25,6 +25,7 @@ func TestReadAndParseConfig(t *testing.T) {
 		Image:                        "my.registry.dev/buildkite-agent:latest",
 		JobTTL:                       300 * time.Second,
 		JobActiveDeadlineSeconds:     21600,
+		JobPrefix:                    "testkite-",
 		ImagePullBackOffGracePeriod:  60 * time.Second,
 		JobCancelCheckerPollInterval: 10 * time.Second,
 		EmptyJobGracePeriod:          50 * time.Second,
@@ -43,7 +44,7 @@ func TestReadAndParseConfig(t *testing.T) {
 		GraphQLResultsLimit:          200,
 		DefaultImagePullPolicy:       "Never",
 		DefaultImageCheckPullPolicy:  "IfNotPresent",
-                EnableQueuePause:             true,
+		EnableQueuePause:             true,
 
 		WorkspaceVolume: &corev1.Volume{
 			Name: "workspace-2-the-reckoning",

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -2,6 +2,7 @@ agent-token-secret: my-kubernetes-secret
 debug: true
 image: my.registry.dev/buildkite-agent:latest
 job-ttl: 5m
+job-prefix: testkite-
 job-active-deadline-seconds: 21600
 image-pull-backoff-grace-period: 60s
 job-cancel-checker-poll-interval: 10s

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -41,6 +41,7 @@ type Config struct {
 	AgentTokenSecret         string        `json:"agent-token-secret"       validate:"required"`
 	BuildkiteToken           string        `json:"buildkite-token"          validate:"required"`
 	Image                    string        `json:"image"                    validate:"required"`
+	JobPrefix                string        `json:"job-prefix"               validate:"required"`
 	MaxInFlight              int           `json:"max-in-flight"            validate:"min=0"`
 	Namespace                string        `json:"namespace"                validate:"required"`
 	Org                      string        `json:"org"                      validate:"required"`
@@ -102,6 +103,7 @@ func (c Config) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	enc.AddString("agent-token-secret", c.AgentTokenSecret)
 	enc.AddBool("debug", c.Debug)
 	enc.AddString("image", c.Image)
+	enc.AddString("job-prefix", c.JobPrefix)
 	enc.AddDuration("job-ttl", c.JobTTL)
 	enc.AddInt("job-active-deadline-seconds", c.JobActiveDeadlineSeconds)
 	enc.AddDuration("poll-interval", c.PollInterval)

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -93,6 +93,7 @@ func Run(
 		Image:                         cfg.Image,
 		AgentTokenSecretName:          cfg.AgentTokenSecret,
 		JobTTL:                        cfg.JobTTL,
+		JobPrefix:                     cfg.JobPrefix,
 		JobActiveDeadlineSeconds:      cfg.JobActiveDeadlineSeconds,
 		AdditionalRedactedVars:        cfg.AdditionalRedactedVars,
 		WorkspaceVolume:               cfg.WorkspaceVolume,

--- a/internal/controller/scheduler/fail_job.go
+++ b/internal/controller/scheduler/fail_job.go
@@ -44,7 +44,7 @@ func acquireAndFailForObject(
 	tags := agenttags.TagsFromLabels(labels)
 	opts := cfg.AgentConfig.ControllerOptions()
 
-	if err := acquireAndFail(ctx, logger, agentToken, jobUUID, tags, message, opts...); err != nil {
+	if err := acquireAndFail(ctx, logger, agentToken, cfg.JobPrefix, jobUUID, tags, message, opts...); err != nil {
 		logger.Error("failed to acquire and fail the job on Buildkite", zap.Error(err))
 		return err
 	}
@@ -57,6 +57,7 @@ func acquireAndFail(
 	ctx context.Context,
 	zapLogger *zap.Logger,
 	agentToken string,
+	jobPrefix string,
 	jobUUID string,
 	tags []string,
 	message string,
@@ -68,7 +69,7 @@ func acquireAndFail(
 	}, options...)
 
 	// queue is required for acquire! maybe more
-	ctr, err := agentcore.NewController(ctx, agentToken, k8sJobName(jobUUID), tags, opts...)
+	ctr, err := agentcore.NewController(ctx, agentToken, k8sJobName(jobPrefix, jobUUID), tags, opts...)
 	if err != nil {
 		zapLogger.Error("registering or connecting ephemeral agent", zap.Error(err))
 		return fmt.Errorf("registering or connecting ephemeral agent: %w", err)

--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -52,6 +52,7 @@ var (
 type Config struct {
 	Namespace                     string
 	Image                         string
+	JobPrefix                     string
 	AgentTokenSecretName          string
 	JobTTL                        time.Duration
 	JobActiveDeadlineSeconds      int
@@ -239,7 +240,7 @@ func (w *worker) Build(podSpec *corev1.PodSpec, skipCheckout bool, inputs buildI
 
 	kjob := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        k8sJobName(inputs.uuid),
+			Name:        k8sJobName(w.cfg.JobPrefix, inputs.uuid),
 			Labels:      make(map[string]string),
 			Annotations: make(map[string]string),
 		},
@@ -1220,7 +1221,7 @@ func (w *worker) failJob(ctx context.Context, inputs buildInputs, message string
 	}
 
 	opts := w.cfg.AgentConfig.ControllerOptions()
-	if err := acquireAndFail(ctx, w.logger, agentToken, inputs.uuid, inputs.agentQueryRules, message, opts...); err != nil {
+	if err := acquireAndFail(ctx, w.logger, agentToken, w.cfg.JobPrefix, inputs.uuid, inputs.agentQueryRules, message, opts...); err != nil {
 		w.logger.Error("failed to acquire and fail the job on Buildkite", zap.Error(err))
 		schedulerBuildkiteJobFailErrorsCounter.Inc()
 		return err
@@ -1238,8 +1239,8 @@ func (w *worker) jobURL(jobUUID string, buildURL string) (string, error) {
 	return u.String(), nil
 }
 
-func k8sJobName(jobUUID string) string {
-	return fmt.Sprintf("buildkite-%s", jobUUID)
+func k8sJobName(jobPrefix string, jobUUID string) string {
+	return fmt.Sprintf("%s%s", jobPrefix, jobUUID)
 }
 
 // Format each agentTag as key=value and join with ,


### PR DESCRIPTION
Allows configuration of the prefix used when generating Kubernetes job names. Previously, this prefix was hardcoded to `buildkite-`. The existing structure for generating Kubernetes job names remains the same, at `<job-prefix><buildkite-job-uuid>`. If not provided, configuration will default to `buildkite-`. This prefix will also be reflected in the UI as used for the agent's `Name` and `Hostname`.

Fixes https://github.com/buildkite/agent-stack-k8s/issues/166