### PR TITLE
Check that CheckoutParams.GitCredentialsSecret is not nil

### DIFF
--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -1113,9 +1113,13 @@ func (w *worker) createCheckoutContainer(
 	// If configured, set up a volume mount of a secret containing a
 	// .git-credentials file. k8sPlugin (if allowed) supersedes the default.
 	gitCredsSecret := w.cfg.DefaultCheckoutParams.GitCredsSecret()
-	if k8sPlugin != nil {
-		gitCredsSecret = k8sPlugin.CheckoutParams.GitCredsSecret()
+
+	if k8sPlugin != nil && k8sPlugin.CheckoutParams != nil {
+		if k8sPlugin.CheckoutParams.GitCredentialsSecret != nil {
+			gitCredsSecret = k8sPlugin.CheckoutParams.GitCredsSecret()
+		}
 	}
+
 	gitConfigCmd := "true"
 	if gitCredsSecret != nil {
 		podSpec.Volumes = append(podSpec.Volumes,


### PR DESCRIPTION
Addresses the configuration where `values.yaml` file has `.git-credentials`:
```
...
default-checkout-params:
  gitCredentialsSecret:
    secretName: my-git-credentials
...
```
And `pipeline.yaml` file includes `kubernetes` plugin. The presence of the `kubernetes` plugin was causing `checkout/gitCredentialsSecret` to always be used in-place of `default-checkout-params/GitCredentialsSecret`, even if `nil`.