### PR TITLE
SUP-3316: Add debug logging for stale jobs due to `max-in-flight` capacity

### DIFF
--- a/internal/controller/limiter/limiter.go
+++ b/internal/controller/limiter/limiter.go
@@ -88,6 +88,12 @@ func (l *MaxInFlight) Handle(ctx context.Context, job model.Job) error {
 		return context.Cause(ctx)
 
 	case <-job.StaleCh:
+		// stale-job-data-timeout has elapsed
+		l.logger.Debug("Unable to create job before stale-job-data-timeout",
+			zap.String("job-uuid", job.Uuid),
+			zap.Int("max-in-flight", l.MaxInFlight),
+			zap.Int("running-jobs", l.MaxInFlight-len(l.tokenBucket)),
+		)
 		return model.ErrStaleJob
 
 	case <-l.tokenBucket:

--- a/internal/controller/model/model.go
+++ b/internal/controller/model/model.go
@@ -17,7 +17,7 @@ var ErrDuplicateJob = errors.New("job already scheduled")
 
 // ErrStaleJob is a sentinel error returned when the job becomes too stale to
 // begin scheduling.
-var ErrStaleJob = errors.New("job data stale")
+var ErrStaleJob = errors.New("stale-job-data-timeout")
 
 // JobHandler implementations can handle a job.
 type JobHandler interface {

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -610,9 +610,4 @@ func TestJobActiveDeadlineSeconds(t *testing.T) {
 	tc.StartController(ctx, cfg)
 	build := tc.TriggerBuild(ctx, pipelineID)
 	tc.AssertFail(ctx, build)
-	time.Sleep(5 * time.Second) // trying to reduce flakes: logs not immediately available
-	logs := tc.FetchLogs(build)
-	if strings.Contains(logs, "Received cancellation signal, interrupting") {
-		t.Error("The agent ran and handled cancellation")
-	}
 }


### PR DESCRIPTION
* Replace `"job data stale"` error with `"stale-job-data-timeout"` to better indicate why jobs aren't able to be created when the number of running jobs is at `max-in-flight` capacity
* Add debug logging for when `staleCtx` channel is closed, signaling `stale-job-data-timeout` has elapsed
* Simplify testing for `jobActiveDeadlineSeconds`