### PR TITLE
SUP-3496: Ensure token is returned to bucket when BK jobs are acquired and failed

### DIFF
--- a/internal/controller/limiter/limiter.go
+++ b/internal/controller/limiter/limiter.go
@@ -114,6 +114,7 @@ func (l *MaxInFlight) Handle(ctx context.Context, job model.Job) error {
 		l.logger.Debug("next handler failed",
 			zap.String("job-uuid", job.Uuid),
 			zap.Int("available-tokens", len(l.tokenBucket)),
+			zap.Error(err),
 		)
 		return err
 	}

--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -1230,7 +1230,7 @@ func (w *worker) failJob(ctx context.Context, inputs buildInputs, message string
 		return err
 	}
 	schedulerBuildkiteJobFailsCounter.Inc()
-	return nil
+	return fmt.Errorf("%s", message)
 }
 
 func (w *worker) jobURL(jobUUID string, buildURL string) (string, error) {


### PR DESCRIPTION
While performing testing for https://github.com/buildkite/agent-stack-k8s/pull/534, I uncovered a scenario where `tryReturnToken()` was not being called when `failJob()` was invoked to acquire and fail a job. This created a situation where there were no more `available-tokens` and `num-in-flight` would be capped out at `max-in-flight`. No Kubernetes jobs would be running and the controller would be unable to create any new Kubernetes jobs. Restarting the controller was the only way to resolve this situation, as the token bucket is initialized (filled) with `max-in-flight` tokens at `Start()`.

Fixes https://github.com/buildkite/agent-stack-k8s/issues/302