### PR TITLE
Dedupe extraVolumeMounts

### DIFF
--- a/internal/controller/config/checkout_params.go
+++ b/internal/controller/config/checkout_params.go
@@ -32,7 +32,7 @@ func (co *CheckoutParams) ApplyTo(podSpec *corev1.PodSpec, ctr *corev1.Container
 	appendCommaSepToEnv(ctr, "BUILDKITE_GIT_SUBMODULE_CLONE_CONFIG", co.SubmoduleCloneConfig)
 	co.GitMirrors.ApplyTo(podSpec, ctr)
 	ctr.EnvFrom = append(ctr.EnvFrom, co.EnvFrom...)
-	ctr.VolumeMounts = append(ctr.VolumeMounts, co.ExtraVolumeMounts...)
+	ctr.VolumeMounts = appendUniqueVolumeMounts(ctr.VolumeMounts, co.ExtraVolumeMounts)
 }
 
 func (co *CheckoutParams) GitCredsSecret() *corev1.SecretVolumeSource {

--- a/internal/controller/config/command_params.go
+++ b/internal/controller/config/command_params.go
@@ -23,7 +23,7 @@ func (cmd *CommandParams) ApplyTo(ctr *corev1.Container) {
 		return
 	}
 	ctr.EnvFrom = append(ctr.EnvFrom, cmd.EnvFrom...)
-	ctr.VolumeMounts = append(ctr.VolumeMounts, cmd.ExtraVolumeMounts...)
+	ctr.VolumeMounts = appendUniqueVolumeMounts(ctr.VolumeMounts, cmd.ExtraVolumeMounts)
 }
 
 // Command interprets the command and args fields of the container into a

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -151,7 +151,7 @@ func (c Config) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	return nil
 }
 
-// Helpers for applying configs / params to container env.
+// Helpers for applying configs / params
 
 func appendToEnv(ctr *corev1.Container, name, value string) {
 	ctr.Env = append(ctr.Env, corev1.EnvVar{Name: name, Value: value})
@@ -186,4 +186,21 @@ func appendCommaSepToEnv(ctr *corev1.Container, name string, values []string) {
 		Name:  name,
 		Value: strings.Join(values, ","),
 	})
+}
+
+// adding multiple mounts with the same path will cause a validation error, so just drop any duplicates
+func appendUniqueVolumeMounts(original, toAppend []corev1.VolumeMount) []corev1.VolumeMount {
+	for _, appendMount := range toAppend {
+		found := false
+		for _, originalMount := range original {
+			if originalMount.MountPath == appendMount.MountPath {
+				found = true
+				break
+			}
+		}
+		if !found {
+			original = append(original, appendMount)
+		}
+	}
+	return original
 }

--- a/internal/controller/config/sidecar_params.go
+++ b/internal/controller/config/sidecar_params.go
@@ -14,5 +14,5 @@ func (sc *SidecarParams) ApplyTo(ctr *corev1.Container) {
 		return
 	}
 	ctr.EnvFrom = append(ctr.EnvFrom, sc.EnvFrom...)
-	ctr.VolumeMounts = append(ctr.VolumeMounts, sc.ExtraVolumeMounts...)
+	ctr.VolumeMounts = appendUniqueVolumeMounts(ctr.VolumeMounts, sc.ExtraVolumeMounts)
 }


### PR DESCRIPTION
- if a volumeMount is specified in the pipeline yaml already, don't add a duplicate which would cause a validation error
- this allows easier migration to use the functionality added in https://github.com/buildkite/agent-stack-k8s/pull/534

Note that I am not much of a go developer so please review carefully! Also not sure if a test should be added for this case?