### PR TITLE
Dedupe extraVolumeMounts for checkout, command, sidecar params

### DIFF
--- a/internal/controller/config/checkout_params.go
+++ b/internal/controller/config/checkout_params.go
@@ -32,7 +32,7 @@ func (co *CheckoutParams) ApplyTo(podSpec *corev1.PodSpec, ctr *corev1.Container
 	appendCommaSepToEnv(ctr, "BUILDKITE_GIT_SUBMODULE_CLONE_CONFIG", co.SubmoduleCloneConfig)
 	co.GitMirrors.ApplyTo(podSpec, ctr)
 	ctr.EnvFrom = append(ctr.EnvFrom, co.EnvFrom...)
-	ctr.VolumeMounts = append(ctr.VolumeMounts, co.ExtraVolumeMounts...)
+	ctr.VolumeMounts = appendUniqueVolumeMounts(ctr.VolumeMounts, co.ExtraVolumeMounts)
 }
 
 func (co *CheckoutParams) GitCredsSecret() *corev1.SecretVolumeSource {

--- a/internal/controller/config/command_params.go
+++ b/internal/controller/config/command_params.go
@@ -23,7 +23,7 @@ func (cmd *CommandParams) ApplyTo(ctr *corev1.Container) {
 		return
 	}
 	ctr.EnvFrom = append(ctr.EnvFrom, cmd.EnvFrom...)
-	ctr.VolumeMounts = append(ctr.VolumeMounts, cmd.ExtraVolumeMounts...)
+	ctr.VolumeMounts = appendUniqueVolumeMounts(ctr.VolumeMounts, cmd.ExtraVolumeMounts)
 }
 
 // Command interprets the command and args fields of the container into a

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -187,3 +187,20 @@ func appendCommaSepToEnv(ctr *corev1.Container, name string, values []string) {
 		Value: strings.Join(values, ","),
 	})
 }
+
+// adding multiple mounts with the same path will cause a validation error, so just drop any duplicates
+func appendUniqueVolumeMounts(original []corev1.VolumeMount, toAppend []corev1.VolumeMount) []corev1.VolumeMount {
+	for _, appendMount := range toAppend {
+		found := false
+		for _, originalMount := range original {
+			if originalMount.MountPath == appendMount.MountPath {
+				found = true
+				break
+			}
+		}
+		if !found {
+			original = append(original, appendMount)
+		}
+	}
+	return original
+}

--- a/internal/controller/config/sidecar_params.go
+++ b/internal/controller/config/sidecar_params.go
@@ -14,5 +14,5 @@ func (sc *SidecarParams) ApplyTo(ctr *corev1.Container) {
 		return
 	}
 	ctr.EnvFrom = append(ctr.EnvFrom, sc.EnvFrom...)
-	ctr.VolumeMounts = append(ctr.VolumeMounts, sc.ExtraVolumeMounts...)
+	ctr.VolumeMounts = appendUniqueVolumeMounts(ctr.VolumeMounts, sc.ExtraVolumeMounts)
 }

--- a/internal/integration/fixtures/extra-volume-mounts-command.yaml
+++ b/internal/integration/fixtures/extra-volume-mounts-command.yaml
@@ -39,3 +39,6 @@ steps:
               - name: host-volume
                 mountPath: /tmp/extra-volume-mount-command
                 subPath: extra-volume-mount-command
+              - name: host-volume-duplicate
+                mountPath: /tmp/extra-volume-mount-command
+                subPath: extra-volume-mount-command

--- a/internal/integration/fixtures/extra-volume-mounts-sidecar.yaml
+++ b/internal/integration/fixtures/extra-volume-mounts-sidecar.yaml
@@ -45,6 +45,9 @@ steps:
               - name: host-volume
                 mountPath: /tmp/extra-volume-mount-sidecar
                 subPath: extra-volume-mount-sidecar
+              - name: host-volume-duplicate
+                mountPath: /tmp/extra-volume-mount-sidecar
+                subPath: extra-volume-mount-sidecar
           extraVolumeMounts:
             - name: host-volume
               mountPath: /tmp/extra-volume-mount


### PR DESCRIPTION
Inspired by https://github.com/buildkite/agent-stack-k8s/pull/544, dedupes `extraVolumeMounts` from both controller config and `kubernetes` plugin against the `VolumeMounts` of the `corev1.Container` being created for each of the `checkout`, `command` and `sidecar` containers.