### PR TITLE
fix: volume mount deduplication for podSpec updates

### DIFF
--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -188,19 +188,26 @@ func appendCommaSepToEnv(ctr *corev1.Container, name string, values []string) {
 	})
 }
 
-// adding multiple mounts with the same path will cause a validation error, so just drop any duplicates
+// Adding multiple mounts with the same path will cause a validation error, so just drop any duplicates
 func appendUniqueVolumeMounts(original []corev1.VolumeMount, toAppend []corev1.VolumeMount) []corev1.VolumeMount {
-	for _, appendMount := range toAppend {
-		found := false
-		for _, originalMount := range original {
-			if originalMount.MountPath == appendMount.MountPath {
-				found = true
-				break
-			}
-		}
-		if !found {
-			original = append(original, appendMount)
+	seen := make(map[string]bool)
+	var result []corev1.VolumeMount
+
+	// Add mounts from the original list and deduplicate them
+	for _, mount := range original {
+		if !seen[mount.MountPath] {
+			seen[mount.MountPath] = true
+			result = append(result, mount)
 		}
 	}
-	return original
+
+	// Append mounts from toAppend if their mountPath isn’t already seen
+	for _, mount := range toAppend {
+		if !seen[mount.MountPath] {
+			seen[mount.MountPath] = true
+			result = append(result, mount)
+		}
+	}
+
+	return result
 }

--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -861,6 +861,7 @@ func (w *worker) Build(podSpec *corev1.PodSpec, skipCheckout bool, inputs buildI
 		w.logger.Debug("Applied podSpec patch from k8s plugin", zap.Any("patched", patched))
 	}
 
+	config.PrepareVolumeMounts(podSpec)
 	kjob.Spec.Template.Spec = *podSpec
 
 	return kjob, nil

--- a/internal/integration/fixtures/extra-volume-mounts-command.yaml
+++ b/internal/integration/fixtures/extra-volume-mounts-command.yaml
@@ -8,16 +8,19 @@ steps:
           podSpec:
             containers:
               - image: alpine:latest
-                # Pre-existing volume mount simulating a prior update
                 volumeMounts:
-                  - name: pre-existing-volume
+                  - name: host-volume
                     mountPath: /tmp/extra-volume-mount-command
-                    subPath: pre-existing-extra-volume-mount-command
+                    subPath: extra-volume-mount-command
                 command: ["sh"]
                 args:
                   - "-c"
                   - "touch /tmp/extra-volume-mount-command/foo-$${BUILDKITE_JOB_ID}.txt"
               - image: alpine:latest
+                volumeMounts:
+                  - name: host-volume-duplicate
+                    mountPath: /tmp/extra-volume-mount-command
+                    subPath: extra-volume-mount-command
                 command:
                   - |-
                     COUNT=0
@@ -39,10 +42,12 @@ steps:
                 hostPath:
                   path: "/tmp/volumes/{{.queue}}"
                   type: DirectoryOrCreate
+              - name: host-volume-duplicate
+                hostPath:
+                  path: "/tmp/volumes/{{.queue}}"
+                  type: DirectoryOrCreate
           commandParams:
             extraVolumeMounts:
-              # These two mounts have the same mountPath as the pre-existing one
-              # The appendUniqueVolumeMounts function omit them
               - name: host-volume
                 mountPath: /tmp/extra-volume-mount-command
                 subPath: extra-volume-mount-command

--- a/internal/integration/fixtures/extra-volume-mounts-command.yaml
+++ b/internal/integration/fixtures/extra-volume-mounts-command.yaml
@@ -8,6 +8,11 @@ steps:
           podSpec:
             containers:
               - image: alpine:latest
+                # Pre-existing volume mount simulating a prior update
+                volumeMounts:
+                  - name: pre-existing-volume
+                    mountPath: /tmp/extra-volume-mount-command
+                    subPath: pre-existing-extra-volume-mount-command
                 command: ["sh"]
                 args:
                   - "-c"
@@ -36,6 +41,8 @@ steps:
                   type: DirectoryOrCreate
           commandParams:
             extraVolumeMounts:
+              # These two mounts have the same mountPath as the pre-existing one
+              # The appendUniqueVolumeMounts function omit them
               - name: host-volume
                 mountPath: /tmp/extra-volume-mount-command
                 subPath: extra-volume-mount-command

--- a/internal/integration/fixtures/extra-volume-mounts-sidecar.yaml
+++ b/internal/integration/fixtures/extra-volume-mounts-sidecar.yaml
@@ -5,13 +5,34 @@ steps:
     key: write-file-to-extra-volume-mount-sidecar
     plugins:
       - kubernetes:
+          sidecars:
+            - image: alpine:latest
+              volumeMounts:
+                - name: host-volume
+                  mountPath: /tmp/extra-volume-mount
+                  subPath: extra-volume-mount
+                - name: host-volume
+                  mountPath: /tmp/extra-volume-mount-sidecar
+                  subPath: extra-volume-mount-sidecar
+              command: ["sh"]
+              args:
+                - "-c"
+                - |-
+                  touch /tmp/extra-volume-mount-sidecar/pass-the-parcel
+                  rm -f "/tmp/extra-volume-mount/pass-the-parcel"
+                  mv /tmp/extra-volume-mount-sidecar/pass-the-parcel /tmp/extra-volume-mount/pass-the-parcel
+                  ls -lah /tmp/extra-volume-mount-sidecar
+                  ls -lah /tmp/extra-volume-mount
           podSpec:
             containers:
               - image: alpine:latest
                 volumeMounts:
-                  - name: pre-existing-volume
+                  - name: host-volume-duplicate
                     mountPath: /tmp/extra-volume-mount
-                    subPath: pre-existing-extra-volume-mount
+                    subPath: extra-volume-mount
+                  - name: host-volume-duplicate
+                    mountPath: /tmp/extra-volume-mount-sidecar
+                    subPath: extra-volume-mount-sidecar
                 command:
                   - |-
                     COUNT=0
@@ -33,21 +54,10 @@ steps:
                 hostPath:
                   path: "/tmp/volumes/{{.queue}}"
                   type: DirectoryOrCreate
-          sidecars:
-            - image: alpine:latest
-              volumeMounts:
-                - name: pre-existing-sidecar-volume
-                  mountPath: /tmp/extra-volume-mount-sidecar
-                  subPath: pre-existing-sidecar
-              command: ["sh"]
-              args:
-                - "-c"
-                - |-
-                  touch /tmp/extra-volume-mount-sidecar/pass-the-parcel
-                  rm -f "/tmp/extra-volume-mount/pass-the-parcel"
-                  mv /tmp/extra-volume-mount-sidecar/pass-the-parcel /tmp/extra-volume-mount/pass-the-parcel
-                  ls -lah /tmp/extra-volume-mount-sidecar
-                  ls -lah /tmp/extra-volume-mount
+              - name: host-volume-duplicate
+                hostPath:
+                  path: "/tmp/volumes/{{.queue}}"
+                  type: DirectoryOrCreate
           sidecarParams:
             extraVolumeMounts:
               - name: host-volume
@@ -58,5 +68,8 @@ steps:
                 subPath: extra-volume-mount-sidecar
           extraVolumeMounts:
             - name: host-volume
+              mountPath: /tmp/extra-volume-mount
+              subPath: extra-volume-mount
+            - name: host-volume-duplicate
               mountPath: /tmp/extra-volume-mount
               subPath: extra-volume-mount

--- a/internal/integration/fixtures/extra-volume-mounts-sidecar.yaml
+++ b/internal/integration/fixtures/extra-volume-mounts-sidecar.yaml
@@ -5,20 +5,13 @@ steps:
     key: write-file-to-extra-volume-mount-sidecar
     plugins:
       - kubernetes:
-          sidecars:
-            - image: alpine:latest
-              command: ["sh"]
-              args:
-                - "-c"
-                - |-
-                  touch /tmp/extra-volume-mount-sidecar/pass-the-parcel
-                  rm -f "/tmp/extra-volume-mount/pass-the-parcel"
-                  mv /tmp/extra-volume-mount-sidecar/pass-the-parcel /tmp/extra-volume-mount/pass-the-parcel
-                  ls -lah /tmp/extra-volume-mount-sidecar
-                  ls -lah /tmp/extra-volume-mount
           podSpec:
             containers:
               - image: alpine:latest
+                volumeMounts:
+                  - name: pre-existing-volume
+                    mountPath: /tmp/extra-volume-mount
+                    subPath: pre-existing-extra-volume-mount
                 command:
                   - |-
                     COUNT=0
@@ -40,6 +33,21 @@ steps:
                 hostPath:
                   path: "/tmp/volumes/{{.queue}}"
                   type: DirectoryOrCreate
+          sidecars:
+            - image: alpine:latest
+              volumeMounts:
+                - name: pre-existing-sidecar-volume
+                  mountPath: /tmp/extra-volume-mount-sidecar
+                  subPath: pre-existing-sidecar
+              command: ["sh"]
+              args:
+                - "-c"
+                - |-
+                  touch /tmp/extra-volume-mount-sidecar/pass-the-parcel
+                  rm -f "/tmp/extra-volume-mount/pass-the-parcel"
+                  mv /tmp/extra-volume-mount-sidecar/pass-the-parcel /tmp/extra-volume-mount/pass-the-parcel
+                  ls -lah /tmp/extra-volume-mount-sidecar
+                  ls -lah /tmp/extra-volume-mount
           sidecarParams:
             extraVolumeMounts:
               - name: host-volume

--- a/internal/integration/fixtures/extra-volume-mounts.yaml
+++ b/internal/integration/fixtures/extra-volume-mounts.yaml
@@ -34,7 +34,14 @@ steps:
                 hostPath:
                   path: "/tmp/volumes/{{.queue}}"
                   type: DirectoryOrCreate
+              - name: host-volume-duplicate
+                hostPath:
+                  path: "/tmp/volumes/{{.queue}}"
+                  type: DirectoryOrCreate
           extraVolumeMounts:
             - name: host-volume
+              mountPath: /tmp/buildkite-git-mirrors
+              subPath: buildkite-git-mirrors
+            - name: host-volume-duplicate
               mountPath: /tmp/buildkite-git-mirrors
               subPath: buildkite-git-mirrors


### PR DESCRIPTION
- Update `appendUniqueVolumeMounts` to deduplicate both existing and new mounts based on mountPath
- Add integration tests to cover update to existing volume mounts