### PR TITLE
SUP-3556: De-dupe `VolumeMounts` in generated `PodSpec`

### DIFF
--- a/internal/controller/config/checkout_params.go
+++ b/internal/controller/config/checkout_params.go
@@ -32,7 +32,7 @@ func (co *CheckoutParams) ApplyTo(podSpec *corev1.PodSpec, ctr *corev1.Container
 	appendCommaSepToEnv(ctr, "BUILDKITE_GIT_SUBMODULE_CLONE_CONFIG", co.SubmoduleCloneConfig)
 	co.GitMirrors.ApplyTo(podSpec, ctr)
 	ctr.EnvFrom = append(ctr.EnvFrom, co.EnvFrom...)
-	ctr.VolumeMounts = appendUniqueVolumeMounts(ctr.VolumeMounts, co.ExtraVolumeMounts)
+	ctr.VolumeMounts = append(ctr.VolumeMounts, co.ExtraVolumeMounts...)
 }
 
 func (co *CheckoutParams) GitCredsSecret() *corev1.SecretVolumeSource {

--- a/internal/controller/config/command_params.go
+++ b/internal/controller/config/command_params.go
@@ -23,7 +23,7 @@ func (cmd *CommandParams) ApplyTo(ctr *corev1.Container) {
 		return
 	}
 	ctr.EnvFrom = append(ctr.EnvFrom, cmd.EnvFrom...)
-	ctr.VolumeMounts = appendUniqueVolumeMounts(ctr.VolumeMounts, cmd.ExtraVolumeMounts)
+	ctr.VolumeMounts = append(ctr.VolumeMounts, cmd.ExtraVolumeMounts...)
 }
 
 // Command interprets the command and args fields of the container into a

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -190,7 +190,7 @@ func appendCommaSepToEnv(ctr *corev1.Container, name string, values []string) {
 
 // Iterates over Containers in PodSpec to deduplicate VolumeMounts
 func PrepareVolumeMounts(ctrSpec []corev1.Container) []corev1.Container {
-	for ctr, _ := range ctrSpec {
+	for ctr := range ctrSpec {
 		var filteredMounts []corev1.VolumeMount
 
 		for _, mount := range ctrSpec[ctr].VolumeMounts {

--- a/internal/controller/config/sidecar_params.go
+++ b/internal/controller/config/sidecar_params.go
@@ -14,5 +14,5 @@ func (sc *SidecarParams) ApplyTo(ctr *corev1.Container) {
 		return
 	}
 	ctr.EnvFrom = append(ctr.EnvFrom, sc.EnvFrom...)
-	ctr.VolumeMounts = appendUniqueVolumeMounts(ctr.VolumeMounts, sc.ExtraVolumeMounts)
+	ctr.VolumeMounts = append(ctr.VolumeMounts, sc.ExtraVolumeMounts...)
 }

--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -861,6 +861,10 @@ func (w *worker) Build(podSpec *corev1.PodSpec, skipCheckout bool, inputs buildI
 		w.logger.Debug("Applied podSpec patch from k8s plugin", zap.Any("patched", patched))
 	}
 
+	// Dedupe VolumeMounts for both InitContainers and Containers
+	podSpec.InitContainers = config.PrepareVolumeMounts(podSpec.InitContainers)
+	podSpec.Containers = config.PrepareVolumeMounts(podSpec.Containers)
+
 	kjob.Spec.Template.Spec = *podSpec
 
 	return kjob, nil

--- a/internal/integration/fixtures/extra-volume-mounts-command.yaml
+++ b/internal/integration/fixtures/extra-volume-mounts-command.yaml
@@ -8,11 +8,19 @@ steps:
           podSpec:
             containers:
               - image: alpine:latest
+                volumeMounts:
+                  - name: host-volume
+                    mountPath: /tmp/extra-volume-mount-command
+                    subPath: extra-volume-mount-command
                 command: ["sh"]
                 args:
                   - "-c"
                   - "touch /tmp/extra-volume-mount-command/foo-$${BUILDKITE_JOB_ID}.txt"
               - image: alpine:latest
+                volumeMounts:
+                  - name: host-volume-duplicate
+                    mountPath: /tmp/extra-volume-mount-command
+                    subPath: extra-volume-mount-command
                 command:
                   - |-
                     COUNT=0
@@ -31,6 +39,10 @@ steps:
                     rm -f "/tmp/extra-volume-mount-command/foo-$${BUILDKITE_JOB_ID}.txt"
             volumes:
               - name: host-volume
+                hostPath:
+                  path: "/tmp/volumes/{{.queue}}"
+                  type: DirectoryOrCreate
+              - name: host-volume-duplicate
                 hostPath:
                   path: "/tmp/volumes/{{.queue}}"
                   type: DirectoryOrCreate

--- a/internal/integration/fixtures/extra-volume-mounts-sidecar.yaml
+++ b/internal/integration/fixtures/extra-volume-mounts-sidecar.yaml
@@ -7,6 +7,13 @@ steps:
       - kubernetes:
           sidecars:
             - image: alpine:latest
+              volumeMounts:
+                - name: host-volume
+                  mountPath: /tmp/extra-volume-mount
+                  subPath: extra-volume-mount
+                - name: host-volume
+                  mountPath: /tmp/extra-volume-mount-sidecar
+                  subPath: extra-volume-mount-sidecar
               command: ["sh"]
               args:
                 - "-c"
@@ -19,6 +26,13 @@ steps:
           podSpec:
             containers:
               - image: alpine:latest
+                volumeMounts:
+                  - name: host-volume-duplicate
+                    mountPath: /tmp/extra-volume-mount
+                    subPath: extra-volume-mount
+                  - name: host-volume-duplicate
+                    mountPath: /tmp/extra-volume-mount-sidecar
+                    subPath: extra-volume-mount-sidecar
                 command:
                   - |-
                     COUNT=0
@@ -40,6 +54,10 @@ steps:
                 hostPath:
                   path: "/tmp/volumes/{{.queue}}"
                   type: DirectoryOrCreate
+              - name: host-volume-duplicate
+                hostPath:
+                  path: "/tmp/volumes/{{.queue}}"
+                  type: DirectoryOrCreate
           sidecarParams:
             extraVolumeMounts:
               - name: host-volume
@@ -50,5 +68,8 @@ steps:
                 subPath: extra-volume-mount-sidecar
           extraVolumeMounts:
             - name: host-volume
+              mountPath: /tmp/extra-volume-mount
+              subPath: extra-volume-mount
+            - name: host-volume-duplicate
               mountPath: /tmp/extra-volume-mount
               subPath: extra-volume-mount

--- a/internal/integration/fixtures/extra-volume-mounts.yaml
+++ b/internal/integration/fixtures/extra-volume-mounts.yaml
@@ -34,7 +34,14 @@ steps:
                 hostPath:
                   path: "/tmp/volumes/{{.queue}}"
                   type: DirectoryOrCreate
+              - name: host-volume-duplicate
+                hostPath:
+                  path: "/tmp/volumes/{{.queue}}"
+                  type: DirectoryOrCreate
           extraVolumeMounts:
             - name: host-volume
+              mountPath: /tmp/buildkite-git-mirrors
+              subPath: buildkite-git-mirrors
+            - name: host-volume-duplicate
               mountPath: /tmp/buildkite-git-mirrors
               subPath: buildkite-git-mirrors


### PR DESCRIPTION
Continuation of https://github.com/buildkite/agent-stack-k8s/pull/545, which only de-duplicated `VolumeMounts` specific to `extraVolumeMounts` under params for `checkout`, `command` and `sidecar` containers. This now performs de-duplication of each container's `VolumeMounts`, using the generated `PodSpec`.