### PR TITLE
SUP-3616 - Fix duplicate calculation/application of `podSpecPatch`

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -72,7 +72,7 @@ steps:
       - kubernetes:
           podSpec:
             containers:
-              - image: golangci/golangci-lint:latest
+              - image: golangci/golangci-lint:v1.64.8
                 command:
                   - golangci-lint run -v ./...
                 resources:


### PR DESCRIPTION
Fixes https://github.com/buildkite/agent-stack-k8s/issues/554

Also pins `golangci-lint` image to the latest `v1`, due to config changes required for `v2`. Will make config `v2` [friendly](https://golangci-lint.run/product/migration-guide/) at a later time.