### PR TITLE
Fix the max-in-flight default value in schema

### DIFF
--- a/charts/agent-stack-k8s/values.schema.json
+++ b/charts/agent-stack-k8s/values.schema.json
@@ -217,7 +217,7 @@
         },
         "max-in-flight": {
           "type": "integer",
-          "default": 0,
+          "default": 25,
           "title": "Sets an upper limit on the number of Kubernetes jobs that the controller will run",
           "examples": [100]
         },


### PR DESCRIPTION
Incorrect default value is defined in values.schema as 0. Fixed it to reflect the correct value which is 25