### PR TITLE
Skip jobs that are missing `queue` tag, enhance `info` logs

### DIFF
--- a/internal/controller/agenttags/tags.go
+++ b/internal/controller/agenttags/tags.go
@@ -75,6 +75,7 @@ func LabelsFromTags(tags []string) (map[string]string, []error) {
 // set of strings defined by the tag value in `jobTags` (eg a glob or regex)
 // See https://buildkite.com/docs/agent/v3/cli-start#agent-targeting
 func JobTagsMatchAgentTags(jobTags iter.Seq2[string, string], agentTags map[string]string) bool {
+	queueTagFound := false
 	for k, v := range jobTags {
 		agentTagValue, exists := agentTags[k]
 		if !exists {
@@ -83,8 +84,11 @@ func JobTagsMatchAgentTags(jobTags iter.Seq2[string, string], agentTags map[stri
 		if v != "*" && v != agentTagValue {
 			return false
 		}
+		if k == "queue" {
+			queueTagFound = true
+		}
 	}
-	return true
+	return queueTagFound
 }
 
 // ScanLabels returns an iterator over all labels that are tags.

--- a/internal/controller/agenttags/tags.go
+++ b/internal/controller/agenttags/tags.go
@@ -75,7 +75,6 @@ func LabelsFromTags(tags []string) (map[string]string, []error) {
 // set of strings defined by the tag value in `jobTags` (eg a glob or regex)
 // See https://buildkite.com/docs/agent/v3/cli-start#agent-targeting
 func JobTagsMatchAgentTags(jobTags iter.Seq2[string, string], agentTags map[string]string) bool {
-	queueTagFound := false
 	for k, v := range jobTags {
 		agentTagValue, exists := agentTags[k]
 		if !exists {
@@ -84,11 +83,8 @@ func JobTagsMatchAgentTags(jobTags iter.Seq2[string, string], agentTags map[stri
 		if v != "*" && v != agentTagValue {
 			return false
 		}
-		if k == "queue" {
-			queueTagFound = true
-		}
 	}
-	return queueTagFound
+	return true
 }
 
 // ScanLabels returns an iterator over all labels that are tags.

--- a/internal/controller/limiter/limiter.go
+++ b/internal/controller/limiter/limiter.go
@@ -112,7 +112,7 @@ func (l *MaxInFlight) Handle(ctx context.Context, job model.Job) error {
 
 	case <-job.StaleCh:
 		// stale-job-data-timeout has elapsed
-		l.logger.Debug("Unable to create job before stale-job-data-timeout",
+		l.logger.Info("Unable to create job due to max-in-flight capacity",
 			zap.String("job-uuid", job.Uuid),
 			zap.Int("max-in-flight", l.MaxInFlight),
 			zap.Int("available-tokens", len(l.tokenBucket)),

--- a/internal/controller/monitor/monitor.go
+++ b/internal/controller/monitor/monitor.go
@@ -386,15 +386,16 @@ func jobHandlerWorker(
 				logger.Warn("making a map of job tags", zap.Errors("err", tagErrs))
 			}
 
+			// If the job does not return a 'queue' tag, skip
+			if jobTags["queue"] == "" {
+				logger.Info("job missing 'queue' tag, skipping...", zap.String("job-uuid", j.GetUuid()), zap.Any("buildkite-job-tags", jobTags))
+				return
+			}
+
 			// The api returns jobs that match ANY agent tags (the agent query rules)
 			// However, we can only acquire jobs that match ALL agent tags
 			if !agenttags.JobTagsMatchAgentTags(maps.All(jobTags), agentTags) {
 				jobsFilteredOutCounter.Inc()
-				// If the job does not return a 'queue' tag, skip
-				if jobTags["queue"] == "" {
-					logger.Info("job missing 'queue' tag, skipping...", zap.String("job-uuid", j.GetUuid()), zap.Any("buildkite-job-tags", jobTags))
-					return
-				}
 				logger.Info("job tags do not match expected tags in configuration, skipping...", zap.String("job-uuid", j.GetUuid()), zap.Any("controller-tags", agentTags), zap.Any("buildkite-job-tags", jobTags))
 				return
 			}

--- a/internal/controller/monitor/monitor.go
+++ b/internal/controller/monitor/monitor.go
@@ -109,8 +109,9 @@ func (r clusteredJobResp) CommandJobs() []*api.JobJobTypeCommand {
 // getScheduledCommandJobs calls either the clustered or unclustered GraphQL API
 // methods, depending on if a cluster uuid was provided in the config
 func (m *Monitor) getScheduledCommandJobs(ctx context.Context, queue string) (jobResp jobResp, err error) {
-	m.logger.Debug("getting scheduled jobs via GQL query...",
+	m.logger.Info("retrieving scheduled jobs via GraphQL API...",
 		zap.Duration("poll-interval", m.cfg.PollInterval),
+		zap.String("queue-tag", queue),
 	)
 
 	jobQueryCounter.Inc()
@@ -278,8 +279,9 @@ func (m *Monitor) Start(ctx context.Context, handler model.JobHandler) <-chan er
 			}
 
 			jobs := resp.CommandJobs()
-			m.logger.Debug("jobs in GQL query response(s)...",
-				zap.Int("jobs-processed", len(jobs)),
+			m.logger.Info("job processing of GraphQL API results completed...",
+				zap.Int("graphql-jobs-processed", len(jobs)),
+				zap.String("queue-tag", queue),
 			)
 			if len(jobs) == 0 {
 				continue
@@ -387,9 +389,14 @@ func jobHandlerWorker(
 			// The api returns jobs that match ANY agent tags (the agent query rules)
 			// However, we can only acquire jobs that match ALL agent tags
 			if !agenttags.JobTagsMatchAgentTags(maps.All(jobTags), agentTags) {
-				logger.Debug("skipping job because it did not match all tags", zap.Any("job", j))
 				jobsFilteredOutCounter.Inc()
-				continue
+				// If the job does not return a 'queue' tag, skip
+				if jobTags["queue"] == "" {
+					logger.Info("job missing 'queue' tag, skipping...", zap.String("job-uuid", j.GetUuid()), zap.Any("buildkite-job-tags", jobTags))
+					return
+				}
+				logger.Info("job tags do not match expected tags in configuration, skipping...", zap.String("job-uuid", j.GetUuid()), zap.Any("controller-tags", agentTags), zap.Any("buildkite-job-tags", jobTags))
+				return
 			}
 
 			job := model.Job{


### PR DESCRIPTION
If a controller is configured with a tag for `queue=default`, our API will also return jobs that are missing a `queue` tag (or missing tags altogether). This results in missing Labels on the created Kubernetes Jobs and will prevent the controller from being notified of Job/Pod events and subsequently cause `available-tokens` to eventually drop to `0` when `max-in-flight > 0`. When this happens no new jobs are able to be processed by the controller until it is restarted.

Example of Job with correct Labels:
```
Labels:           batch.kubernetes.io/controller-uid=bfbcbc64-d681-494f-b52f-70b498ceaf8d
                  batch.kubernetes.io/job-name=buildkite-019615d0-0af4-4719-99d3-eeb49ca5f4e4
                  buildkite.com/job-uuid=019615d0-0af4-4719-99d3-eeb49ca5f4e4
                  controller-uid=bfbcbc64-d681-494f-b52f-70b498ceaf8d
                  job-name=buildkite-019615d0-0af4-4719-99d3-eeb49ca5f4e4
                  tag.buildkite.com/queue=kubernetes
```
And when job wasn't correctly skipped:
```
Labels:                      buildkite.com/job-uuid=019620cd-3bcb-4fef-9618-b1f6c8b5e9db
```

The practice of skipping jobs should have already been occurring, but the condition of a `queue` tag missing from a job (or no job tags) allowed jobs to be processed even though the controller tags didn't match. This has been corrected. When a job is missing a `queue` tag, the following `info` log will be emitted:
```
job missing 'queue' tag, skipping...    {"org": "my-org", "job-uuid": "01962542-68b8-4970-bd9c-c17b1e23c7f3", "buildkite-job-tags": {"foo":"bar","hello":"world"}}
```

Additionally, some previous `debug` logs have been changed to `info` to provide better feedback around when/if jobs are being processed via GraphQL queries and when jobs are skipped due to job tags not matching:
```
retrieving scheduled jobs via GraphQL API...    {"poll-interval": "1s", "queue-tag": "kubernetes"}
job processing of GraphQL API results completed...      {"graphql-jobs-processed": 2, "queue-tag": "kubernetes"}
```