### PR TITLE
Setup SSH Keys in container-0

### DIFF
--- a/docs/git_credentials.md
+++ b/docs/git_credentials.md
@@ -102,15 +102,19 @@ After setting the SSH key to use on `container-0`, you will need to setup `conta
 
 ```bash
 #!/bin/bash
-set -ueo pipefail
+set -eufo pipefail
 
 eval $(ssh-agent -s)
-echo "$SSH_PRIVATE_RSA_KEY" | tr -d '\r' | ssh-add -
 mkdir -p ~/.ssh
+chmod 700 ~/.ssh
+
 touch ~/.ssh/config
+chmod 600 ~/.ssh/config
 touch ~/.ssh/known_hosts
-chmod -R 400 ~/.ssh
+chmod 600 ~/.ssh/known_hosts
+
 ssh-keyscan github.com >> ~/.ssh/known_hosts
+echo "$SSH_PRIVATE_RSA_KEY" | tr -d '\r' | ssh-add -
 ```
 
 In your pipeline yaml, you can now add git operations such as `git clone` in the command step.


### PR DESCRIPTION
Add an example in the docs on how to provide SSH Private key to non-`checkout` containers. The example shows how to setup an SSH key to `container-0` in a pod-spec-patch, and how to configure the command container to use that SSH key.  