### PR TITLE
Allow extra EnvVar on controller container

### DIFF
--- a/charts/agent-stack-k8s/templates/deployment.yaml.tpl
+++ b/charts/agent-stack-k8s/templates/deployment.yaml.tpl
@@ -27,6 +27,9 @@ spec:
         env:
         - name: CONFIG
           value: /etc/config.yaml
+        {{- if .Values.controllerEnv -}}
+        {{- .Values.controllerEnv | toYaml | nindent 8 }}
+        {{- end }}
         envFrom:
           - secretRef:
               name: {{ if .Values.agentStackSecret }}{{ .Values.agentStackSecret }}{{ else }}{{ include "agent-stack-k8s.fullname" . }}-secrets{{ end }}

--- a/charts/agent-stack-k8s/values.schema.json
+++ b/charts/agent-stack-k8s/values.schema.json
@@ -47,6 +47,14 @@
       "title": "The chart's overridden full name",
       "examples": ["agent-stack-k8s-green"]
     },
+    "controllerEnv": {
+      "type": "array",
+      "default": [],
+      "title": "K8s EnvVar environment variables to add to the agent-stack-k8s controller container",
+      "items": {
+        "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.EnvVar"
+      }
+    },
     "nodeSelector": {
       "type": "object",
       "default": {},

--- a/docs/controller_configuration.md
+++ b/docs/controller_configuration.md
@@ -73,3 +73,23 @@ nodeSelector:
 config:
 ...
 ```
+
+## Additional Environment Variables for `agent-stack-k8s` Controller Container
+
+If the `agent-stack-k8s` controller container requires extra environment variables in order to correctly operate inside your Kubernetes cluster, they can be added to your values YAML file and applied during a deployment with Helm.
+
+### Configuration values YAML file
+
+The `controllerEnv` field can be used to define extra Kubernetes EnvVar environment variables that will apply to the `agent-stack-k8s` controller container:
+
+```yaml
+# values.yml
+...
+controllerEnv:
+  - name: KUBERNETES_SERVICE_HOST
+    value: "10.10.10.10"
+  - name: KUBERNETES_SERVICE_PORT
+    value: "8443"
+config:
+...
+```


### PR DESCRIPTION
Allows users to define additional Kubernetes `EnvVar` variables via their values YAML that will be applied to the `controller` container.

Fixes https://github.com/buildkite/agent-stack-k8s/issues/387