### PR TITLE
feat: pave road to custom annotations

### DIFF
--- a/charts/agent-stack-k8s/templates/_helper.tpl
+++ b/charts/agent-stack-k8s/templates/_helper.tpl
@@ -24,6 +24,11 @@ app: {{ include "agent-stack-k8s.fullname" . }}
 {{- toYaml (mustMerge (fromYaml (include "agent-stack-k8s.mandatoryLabels" .)) .Values.labels) }}
 {{- end }}
 
+{{/* Generate annotations */}}
+{{- define "agent-stack-k8s.annotations" }}
+{{- toYaml .Values.annotations }}
+{{- end }}
+
 {{/* Generate basic secrets metadata */}}
 {{- define "agent-stack-k8s.mandatorySecretsMetadata" }}
 name: {{ include "agent-stack-k8s.fullname" . }}-secrets

--- a/charts/agent-stack-k8s/templates/deployment.yaml.tpl
+++ b/charts/agent-stack-k8s/templates/deployment.yaml.tpl
@@ -14,7 +14,9 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/config.yaml.tpl") . | sha256sum }}
         checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml.tpl") . | sha256sum }}
+        {{- if .Values.annotations -}}
         {{- include "agent-stack-k8s.annotations" . | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "agent-stack-k8s.fullname" . }}-controller
       nodeSelector:

--- a/charts/agent-stack-k8s/templates/deployment.yaml.tpl
+++ b/charts/agent-stack-k8s/templates/deployment.yaml.tpl
@@ -14,6 +14,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/config.yaml.tpl") . | sha256sum }}
         checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml.tpl") . | sha256sum }}
+        {{- include "agent-stack-k8s.annotations" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "agent-stack-k8s.fullname" . }}-controller
       nodeSelector:

--- a/charts/agent-stack-k8s/values.schema.json
+++ b/charts/agent-stack-k8s/values.schema.json
@@ -96,6 +96,21 @@
         }
       ]
     },
+    "annotations": {
+      "type": "object",
+      "default": {},
+      "title": "The annotations Schema",
+      "additionalProperties": {
+        "type": "string",
+        "default": ""
+      },
+      "example": [
+        {
+          "kubernetes.io/description": "Agent Stack K8s Controller",
+          "prometheus.io/scrape": "true"
+        }
+      ]
+    },
     "secretsMetadata": {
       "type": "object",
       "default": {},

--- a/charts/agent-stack-k8s/values.yaml
+++ b/charts/agent-stack-k8s/values.yaml
@@ -13,6 +13,8 @@ resources:
 
 labels: {}
 
+annotations: {}
+
 secretsMetadata: {}
 
 serviceAccountMetadata: {}

--- a/docs/controller_configuration.md
+++ b/docs/controller_configuration.md
@@ -93,3 +93,22 @@ controllerEnv:
 config:
 ...
 ```
+
+## Custom Annotations for `agent-stack-k8s` controller
+
+If you need to add custom annotations to the `agent-stack-k8s` controller pod, they can be defined in your values YAML file and applied during a deployment with Helm. Note that the controller pod will also have the annotations `checksum/config` and `checksum/secrets` to track changes to the configuration and secrets.
+
+### Configuration
+
+The `annotations` field can be used to define custom annotations that will be applied to the `agent-stack-k8s` controller pod:
+
+```yaml
+# values.yml
+...
+annotations:
+  kubernetes.io/description: "Agent Stack K8s Controller"
+  prometheus.io/scrape: "true"
+  prometheus.io/port: "8080"
+config:
+...
+```


### PR DESCRIPTION
The `annotations` field can be used to define custom annotations that will be applied to the `agent-stack-k8s` controller pod:

```yaml
# values.yml
...
annotations:
  kubernetes.io/description: "Agent Stack K8s Controller"
  prometheus.io/scrape: "true"
  prometheus.io/port: "8080"
config:
...
```