### PR TITLE
Configurable work queue limit

### DIFF
--- a/charts/agent-stack-k8s/values.schema.json
+++ b/charts/agent-stack-k8s/values.schema.json
@@ -631,6 +631,12 @@
           "type": "string",
           "default": "10s",
           "title": "Controls the interval between pagination cursor resets. Increasing this value will increase the number of jobs to be scheduled but also delay picking up any jobs that were missed from the start of the query."
+        },
+        "work-queue-limit": {
+          "type": "integer",
+          "default": 1000000,
+          "minimum": 1,
+          "title": "Sets the maximum number of Jobs the controller will hold in the work queue."
         }
       },
       "examples": [

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -172,6 +172,11 @@ func AddConfigFlags(cmd *cobra.Command) {
 		config.DefaultQueryResetInterval,
 		"Controls the interval between pagination cursor resets. Increasing this value will increase the number of jobs to be scheduled but also delay picking up any jobs that were missed from the start of the query.",
 	)
+	cmd.Flags().Int(
+		"work-queue-limit",
+		config.DefaultWorkQueueLimit,
+		"Sets the maximum number of Jobs the controller will hold in the work queue.",
+	)
 	cmd.Flags().String(
 		"image-check-container-cpu-limit",
 		config.DefaultImageCheckContainerCPULimit,

--- a/cmd/controller/controller_test.go
+++ b/cmd/controller/controller_test.go
@@ -45,6 +45,7 @@ func TestReadAndParseConfig(t *testing.T) {
 		DefaultImagePullPolicy:         "Never",
 		DefaultImageCheckPullPolicy:    "IfNotPresent",
 		EnableQueuePause:               true,
+		WorkQueueLimit:                 2_000_000,
 		ImageCheckContainerCPULimit:    "201m",
 		ImageCheckContainerMemoryLimit: "129Mi",
 

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -20,6 +20,7 @@ enable-queue-pause: true
 pagination-page-size: 1000
 pagination-depth-limit: 5
 query-reset-interval: 10s
+work-queue-limit: 2000000
 image-check-container-cpu-limit: 201m
 image-check-container-memory-limit: 129Mi
 

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -25,6 +25,7 @@ const (
 	DefaultPaginationPageSize             = 1000
 	DefaultPaginationDepthLimit           = 2
 	DefaultQueryResetInterval             = 10 * time.Second
+	DefaultWorkQueueLimit                 = 1_000_000
 	DefaultImageCheckContainerCPULimit    = "200m"
 	DefaultImageCheckContainerMemoryLimit = "128Mi"
 )
@@ -53,6 +54,7 @@ type Config struct {
 	PaginationDepthLimit     int           `json:"pagination-depth-limit"   validate:"min=1,max=20"`
 	QueryResetInterval       time.Duration `json:"query-reset-interval"     validate:"omitempty"`
 	EnableQueuePause         bool          `json:"enable-queue-pause"       validate:"omitempty"`
+	WorkQueueLimit           int           `json:"work-queue-limit"         validate:"omitempty"`
 	// Agent endpoint is set in agent-config.
 
 	K8sClientRateLimiterQPS   int `json:"k8s-client-rate-limiter-qps" validate:"omitempty"`
@@ -158,6 +160,7 @@ func (c Config) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	enc.AddInt("pagination-page-size", c.PaginationPageSize)
 	enc.AddInt("pagination-depth-limit", c.PaginationDepthLimit)
 	enc.AddDuration("query-reset-interval", c.QueryResetInterval)
+	enc.AddInt("work-queue-limit", c.WorkQueueLimit)
 	return nil
 }
 

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -167,7 +167,11 @@ func Run(
 	// Limiter prevents scheduling more than cfg.MaxInFlight jobs at once
 	// (if configured) and is responsible for the priority queue of jobs.
 	// Once it figures out a job can be scheduled, it passes to the deduper.
-	limiter := limiter.New(ctx, logger.Named("limiter"), deduper, cfg.MaxInFlight, cfg.JobCreationConcurrency)
+	limiter := limiter.New(ctx, logger.Named("limiter"), deduper,
+		cfg.MaxInFlight,
+		cfg.JobCreationConcurrency,
+		cfg.WorkQueueLimit,
+	)
 	if err := limiter.RegisterInformer(ctx, informerFactory); err != nil {
 		logger.Fatal("failed to register limiter informer", zap.Error(err))
 	}

--- a/internal/controller/limiter/limiter_test.go
+++ b/internal/controller/limiter/limiter_test.go
@@ -20,7 +20,7 @@ func TestLimiter(t *testing.T) {
 	t.Cleanup(cancel)
 
 	fakeSched := model.NewFakeScheduler(1, nil)
-	limiter := limiter.New(ctx, zaptest.NewLogger(t), fakeSched, 1, 1)
+	limiter := limiter.New(ctx, zaptest.NewLogger(t), fakeSched, 1, 1, -1)
 	fakeSched.EventHandler = limiter
 	fakeSched.Add(50)
 
@@ -56,7 +56,7 @@ func TestLimiter_SchedulerErrors(t *testing.T) {
 	defer cancel()
 
 	fakeSched := model.NewFakeScheduler(0, errors.New("invalid"))
-	limiter := limiter.New(ctx, zaptest.NewLogger(t), fakeSched, 1, 1)
+	limiter := limiter.New(ctx, zaptest.NewLogger(t), fakeSched, 1, 1, -1)
 	fakeSched.EventHandler = limiter
 	fakeSched.Add(50)
 


### PR DESCRIPTION
### What

Apply deduplication within the work queue, and enforce a size limit.

### Why

The query reset interval combined with the delay between receiving jobs and the agents starting up means that the monitor query will receive duplicate jobs. This isn't a problem downstream of the limiter (the deduper takes care of it) but currently the duplicates will occupy memory in the limiter's work queue. They can be deduped here too.

If the rate of incoming jobs is high, and the rate of being able to create jobs is constrained (e.g. with max in flight), then the work queue could exhaust the controller's memory limit. Dropping jobs out of the queue to fit within the limit is fine, since they will be picked up again when the query cursor is reset.
