### PR TITLE
Add prometheus-port to schema (it was missing)

### DIFF
--- a/charts/agent-stack-k8s/values.schema.json
+++ b/charts/agent-stack-k8s/values.schema.json
@@ -322,6 +322,13 @@
           "title": "Allow controller to pause processing the jobs when queue is paused on Buildkite",
           "examples": [false]
         },
+        "prometheus-port": {
+          "type": "integer",
+          "default": 0,
+          "minimum": 0,
+          "maximum": 65535,
+          "title": "Bind port to expose Prometheus /metrics; 0 disables it"
+        },
         "allow-pod-spec-patch-unsafe-command-modification": {
           "type": "boolean",
           "default": false,

--- a/cmd/controller/controller_test.go
+++ b/cmd/controller/controller_test.go
@@ -38,6 +38,7 @@ func TestReadAndParseConfig(t *testing.T) {
 		Org:                            "my-buildkite-org",
 		Tags:                           []string{"queue=my-queue", "priority=high"},
 		ClusterUUID:                    "beefcafe-abbe-baba-abba-deedcedecade",
+		PrometheusPort:                 9216,
 		ProhibitKubernetesPlugin:       true,
 		PaginationPageSize:             1000,
 		PaginationDepthLimit:           5,

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -14,6 +14,7 @@ k8s-client-rate-limiter-qps: 20
 k8s-client-rate-limiter-burst: 30
 namespace: my-buildkite-ns
 org: my-buildkite-org
+prometheus-port: 9216
 default-image-pull-policy: Never
 default-image-check-pull-policy: IfNotPresent
 enable-queue-pause: true


### PR DESCRIPTION
In #419 `prometheus-port` was added as a controller flag and used by the Helm chart to configure a container port, but I clearly forgot to put it in the schema or example.