### PR TITLE
Fix name of buildkite_deduper_onupdate_events_total metric

### DIFF
--- a/docs/prometheus_metrics.md
+++ b/docs/prometheus_metrics.md
@@ -60,7 +60,7 @@ Full metric name | Labels | Description
 `buildkite_deduper_jobs_unmarked_running_total` | `source` | Count of times a job was removed from inFlight
 `buildkite_deduper_onadd_events_total` | - | Count of OnAdd informer events
 `buildkite_deduper_ondelete_events_total` | - | Count of OnDelete informer events
-`buildkite_deduper_onupdate_event_total` | - | Count of OnUpdate informer events
+`buildkite_deduper_onupdate_events_total` | - | Count of OnUpdate informer events
 
 ## job_watcher
 

--- a/internal/controller/deduper/metrics.go
+++ b/internal/controller/deduper/metrics.go
@@ -43,7 +43,7 @@ var (
 	onUpdateEventCounter = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: promNamespace,
 		Subsystem: promSubsystem,
-		Name:      "onupdate_event_total",
+		Name:      "onupdate_events_total",
 		Help:      "Count of OnUpdate informer events",
 	})
 	onDeleteEventCounter = promauto.NewCounter(prometheus.CounterOpts{


### PR DESCRIPTION
For consistency it should be `events_total`, not `event_total`. This was the only instance of this mistake I could find.

This will break PromQL queries depending on the old name, but I doubt anyone considers this metric to be important, so I'm not expecting any complaints.