### PR TITLE
Fix regression preventing evicting pods for cancelled jobs

### DIFF
--- a/api/agent_client.go
+++ b/api/agent_client.go
@@ -159,8 +159,8 @@ func (c *AgentClient) GetJobToRun(ctx context.Context, id string) (result *Agent
 
 // AgentJobState describes the current state of a job.
 type AgentJobState struct {
-	ID    string `json:"id"`
-	State string `json:"state"`
+	ID    string   `json:"id"`
+	State JobState `json:"state"`
 }
 
 // GetJobState gets the state of a specific job.

--- a/api/job_states.go
+++ b/api/job_states.go
@@ -1,49 +1,49 @@
 package api
 
 // All the possible states a job can be in
-type JobStates string
+type JobState string
 
 const (
 	// The job was accepted by the agent, and now it's waiting to start running
-	JobStatesAccepted JobStates = "ACCEPTED"
+	JobStateAccepted JobState = "accepted"
 	// The job has been assigned to an agent, and it's waiting for it to accept
-	JobStatesAssigned JobStates = "ASSIGNED"
+	JobStateAssigned JobState = "assigned"
 	// The job is waiting on a `block` step to finish
-	JobStatesBlocked JobStates = "BLOCKED"
-	// The job was in a `BLOCKED` state when the build failed
-	JobStatesBlockedFailed JobStates = "BLOCKED_FAILED"
+	JobStateBlocked JobState = "blocked"
+	// The job was in a `blocked` state when the build failed
+	JobStateBlockedFailed JobState = "blocked_failed"
 	// The jobs configuration means that it can't be run
-	JobStatesBroken JobStates = "BROKEN"
+	JobStateBroken JobState = "broken"
 	// The job was canceled
-	JobStatesCanceled JobStates = "CANCELED"
+	JobStateCanceled JobState = "canceled"
 	// The job is currently canceling
-	JobStatesCanceling JobStates = "CANCELING"
+	JobStateCanceling JobState = "canceling"
 	// The job expired before it was started on an agent
-	JobStatesExpired JobStates = "EXPIRED"
+	JobStateExpired JobState = "expired"
 	// The job has finished
-	JobStatesFinished JobStates = "FINISHED"
+	JobStateFinished JobState = "finished"
 	// The job is waiting for jobs with the same concurrency group to finish
-	JobStatesLimited JobStates = "LIMITED"
-	// The job is waiting on a concurrency group check before becoming either `LIMITED` or `SCHEDULED`
-	JobStatesLimiting JobStates = "LIMITING"
+	JobStateLimited JobState = "limited"
+	// The job is waiting on a concurrency group check before becoming either `limited` or `scheduled`
+	JobStateLimiting JobState = "limiting"
 	// The job has just been created and doesn't have a state yet
-	JobStatesPending JobStates = "PENDING"
+	JobStatePending JobState = "pending"
 	// The job is running
-	JobStatesRunning JobStates = "RUNNING"
+	JobStateRunning JobState = "running"
 	// The job is scheduled and waiting for an agent
-	JobStatesScheduled JobStates = "SCHEDULED"
+	JobStateScheduled JobState = "scheduled"
 	// The job was skipped
-	JobStatesSkipped JobStates = "SKIPPED"
+	JobStateSkipped JobState = "skipped"
 	// The job timed out
-	JobStatesTimedOut JobStates = "TIMED_OUT"
+	JobStateTimedOut JobState = "timed_out"
 	// The job is timing out for taking too long
-	JobStatesTimingOut JobStates = "TIMING_OUT"
+	JobStateTimingOut JobState = "timing_out"
 	// This `block` job has been manually unblocked
-	JobStatesUnblocked JobStates = "UNBLOCKED"
-	// This `block` job was in an `UNBLOCKED` state when the build failed
-	JobStatesUnblockedFailed JobStates = "UNBLOCKED_FAILED"
+	JobStateUnblocked JobState = "unblocked"
+	// This `block` job was in an `unblocked` state when the build failed
+	JobStateUnblockedFailed JobState = "unblocked_failed"
 	// The job is waiting on a `wait` step to finish
-	JobStatesWaiting JobStates = "WAITING"
-	// The job was in a `WAITING` state when the build failed
-	JobStatesWaitingFailed JobStates = "WAITING_FAILED"
+	JobStateWaiting JobState = "waiting"
+	// The job was in a `waiting` state when the build failed
+	JobStateWaitingFailed JobState = "waiting_failed"
 )

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/jedib0t/go-pretty/v6 v6.6.7
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
+	github.com/kylelemons/godebug v1.1.0
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.20.1
 	github.com/xeipuuv/gojsonschema v1.2.0
@@ -88,7 +89,6 @@ require (
 	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.7 // indirect
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2 // indirect
 	github.com/hashicorp/go-sockaddr v1.0.2 // indirect
-	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lestrrat-go/blackmagic v1.0.2 // indirect
 	github.com/lestrrat-go/httpcc v1.0.1 // indirect
 	github.com/lestrrat-go/httprc v1.0.6 // indirect


### PR DESCRIPTION
### What

Fix a bug where jobs with state 'canceled' or 'canceling' were not evicted early.
Fix the integration test to prevent this in future.

### How

The enum had upper-case strings, but the API returns lower-case strings. This was handled adequately in `failForImageFailure` by calling `strings.ToUpper`, but this was missing from `jobCancelChecker`. 

This PR takes the time to fix a few nits around the enum:

- All the values are now lower-case, so no case conversion is necessary
- The enum type and values are renamed to `JobState` instead of `JobStates`
- The enum type is used in the result struct so that no casting from string is needed (except for `zap.String`)

The integration test didn't catch the regression because the integration test was testing the wrong thing - absence of a string in the log output. If the job is cancelled before the pod starts, and the pod isn't evicted, then the agent won't be able to acquire the job in the first place, so it won't start - let alone log a message about receiving cancellation. The integration test should instead be inspecting the k8s cluster for existence of a pod.