### PR TITLE
Ensure controller agent tags match job tags 100%

### DIFF
--- a/internal/controller/agenttags/tags.go
+++ b/internal/controller/agenttags/tags.go
@@ -82,7 +82,7 @@ func LabelsFromTags(tags []string) (map[string]string, []error) {
 	return labels, append(errs1, errs2...)
 }
 
-// AgentTagsMatchJobTags reports whether each tag key in `agentTags` is also
+// MatchJobTags reports whether each tag key in `agentTags` is also
 // present in `jobTags`, and the tag value in `jobTags` is either "*" or the
 // same as the tag value in `agentTags`.
 //

--- a/internal/controller/agenttags/tags.go
+++ b/internal/controller/agenttags/tags.go
@@ -82,20 +82,24 @@ func LabelsFromTags(tags []string) (map[string]string, []error) {
 	return labels, append(errs1, errs2...)
 }
 
-// JobTagsMatchAgentTags reports whether each tag key in `jobTags` is also
-// present in `agentTags`, and the tag value in `jobTags` is either "*" or the
+// AgentTagsMatchJobTags reports whether each tag key in `agentTags` is also
+// present in `jobTags`, and the tag value in `jobTags` is either "*" or the
 // same as the tag value in `agentTags`.
 //
 // In the future, this may be expanded to: if the tag value `agentTags` is in some
 // set of strings defined by the tag value in `jobTags` (eg a glob or regex)
 // See https://buildkite.com/docs/agent/v3/cli-start#agent-targeting
-func JobTagsMatchAgentTags(jobTags, agentTags map[string]string) bool {
-	for k, v := range jobTags {
-		agentTagValue, exists := agentTags[k]
+
+func AgentTagsMatchJobTags(agentTags, jobTags map[string]string) bool {
+	if len(agentTags) != len(jobTags) {
+		return false
+	}
+	for k, v := range agentTags {
+		jobTagValue, exists := jobTags[k]
 		if !exists {
 			return false
 		}
-		if v != "*" && v != agentTagValue {
+		if jobTagValue != "*" && jobTagValue != v {
 			return false
 		}
 	}

--- a/internal/controller/agenttags/tags.go
+++ b/internal/controller/agenttags/tags.go
@@ -90,7 +90,7 @@ func LabelsFromTags(tags []string) (map[string]string, []error) {
 // set of strings defined by the tag value in `jobTags` (eg a glob or regex)
 // See https://buildkite.com/docs/agent/v3/cli-start#agent-targeting
 
-func AgentTagsMatchJobTags(agentTags, jobTags map[string]string) bool {
+func MatchJobTags(agentTags, jobTags map[string]string) bool {
 	if len(agentTags) != len(jobTags) {
 		return false
 	}

--- a/internal/controller/agenttags/tags_test.go
+++ b/internal/controller/agenttags/tags_test.go
@@ -158,7 +158,7 @@ func TestAgentTagsMatchJobTags(t *testing.T) {
 		{
 			jobTags:        map[string]string{},
 			agentTags:      map[string]string{"a": "x"},
-			expectedResult: true,
+			expectedResult: false,
 		},
 		{
 			jobTags:        map[string]string{"a": "x"},
@@ -173,7 +173,7 @@ func TestAgentTagsMatchJobTags(t *testing.T) {
 		{
 			jobTags:        map[string]string{"a": "x"},
 			agentTags:      map[string]string{"a": "x", "b": "y"},
-			expectedResult: true,
+			expectedResult: false,
 		},
 		{
 			jobTags:        map[string]string{"a": "x", "b": "y"},

--- a/internal/controller/agenttags/tags_test.go
+++ b/internal/controller/agenttags/tags_test.go
@@ -137,7 +137,7 @@ func TestLabelsFromTags(t *testing.T) {
 	}
 }
 
-func TestJobTagsMatchAgentTags(t *testing.T) {
+func TestAgentTagsMatchJobTags(t *testing.T) {
 	t.Parallel()
 
 	for i, test := range []struct {
@@ -205,7 +205,7 @@ func TestJobTagsMatchAgentTags(t *testing.T) {
 
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			t.Parallel()
-			actualResult := agenttags.JobTagsMatchAgentTags(test.jobTags, test.agentTags)
+			actualResult := agenttags.AgentTagsMatchJobTags(test.agentTags, test.jobTags)
 			assert.Equal(
 				t,
 				test.expectedResult,

--- a/internal/controller/agenttags/tags_test.go
+++ b/internal/controller/agenttags/tags_test.go
@@ -137,7 +137,7 @@ func TestLabelsFromTags(t *testing.T) {
 	}
 }
 
-func TestAgentTagsMatchJobTags(t *testing.T) {
+func TestMatchJobTags(t *testing.T) {
 	t.Parallel()
 
 	for i, test := range []struct {
@@ -205,7 +205,7 @@ func TestAgentTagsMatchJobTags(t *testing.T) {
 
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			t.Parallel()
-			actualResult := agenttags.AgentTagsMatchJobTags(test.agentTags, test.jobTags)
+			actualResult := agenttags.MatchJobTags(test.agentTags, test.jobTags)
 			assert.Equal(
 				t,
 				test.expectedResult,

--- a/internal/controller/monitor/monitor.go
+++ b/internal/controller/monitor/monitor.go
@@ -192,7 +192,7 @@ func (m *Monitor) passJobsToNextHandler(
 		// The API returns jobs that match ANY agent tags (the agent query rules)
 		// (howevber we do know it is specific to the configured queue).
 		// However, we can only acquire jobs that match ALL agent tags
-		if !agenttags.JobTagsMatchAgentTags(jobTags, m.cfg.TagMap) {
+		if !agenttags.AgentTagsMatchJobTags(m.cfg.TagMap, jobTags) {
 			jobsFilteredOutCounter.Inc()
 			m.logger.Info("job tags do not match expected tags in configuration, skipping...",
 				zap.String("job-uuid", job.ID),

--- a/internal/controller/monitor/monitor.go
+++ b/internal/controller/monitor/monitor.go
@@ -192,7 +192,7 @@ func (m *Monitor) passJobsToNextHandler(
 		// The API returns jobs that match ANY agent tags (the agent query rules)
 		// (howevber we do know it is specific to the configured queue).
 		// However, we can only acquire jobs that match ALL agent tags
-		if !agenttags.AgentTagsMatchJobTags(m.cfg.TagMap, jobTags) {
+		if !agenttags.MatchJobTags(m.cfg.TagMap, jobTags) {
 			jobsFilteredOutCounter.Inc()
 			m.logger.Info("job tags do not match expected tags in configuration, skipping...",
 				zap.String("job-uuid", job.ID),


### PR DESCRIPTION
The shared informer watches Jobs matching [Labels created from tags](https://github.com/buildkite/agent-stack-k8s/blob/d36d4288f17bd1e2dcdec4302ec15b7335d3904b/internal/controller/controller.go#L230) in the controller's config. When a scheduled job was retrieved from the API the controller was previously checking if all job tags (`agentQueryRules`) were present as agent tags (and not the other way around). This was allowing scheduled jobs with only a matching `queue` tag to be created as a K8s Job. This then prevented the informer from matching the Labels of these Jobs and the controller was left with an infinitely increasing number of running jobs. The only remediation was to set `max-in-flight: 0` or periodically restart the controller.

Now the controller will only create K8s Jobs when tags match 100%. If tags do not match, the following `INFO` log is emitted:
```
2025-05-13T15:47:38.375-0400    INFO    monitor monitor/monitor.go:197  job tags do not match expected tags in configuration, skipping...       {"org": "my-org", "job-uuid": "0196cb30-235f-4ded-926a-d5a3aaad04a4", "controller-tags": {"foo":"bar","hello":"world","queue":"kubernetes"}, "buildkite-job-tags": {"queue":"kubernetes"}}
```