### PR TITLE
PG-80: Replace evicePod with forcefullyDeletePod

### DIFF
--- a/.buildkite/rbac.yaml
+++ b/.buildkite/rbac.yaml
@@ -28,12 +28,7 @@ rules:
       - get
       - list
       - watch
-  - apiGroups:
-      - ""
-    resources:
-      - pods/eviction
-    verbs:
-      - create
+      - delete
   - apiGroups:
       - ""
     resources:

--- a/charts/agent-stack-k8s/templates/rbac.yaml.tpl
+++ b/charts/agent-stack-k8s/templates/rbac.yaml.tpl
@@ -21,18 +21,13 @@ rules:
       - get
       - list
       - watch
+      - delete
   - apiGroups:
       - ""
     resources:
       - secrets
     verbs:
       - get
-  - apiGroups:
-      - ""
-    resources:
-      - pods/eviction
-    verbs:
-      - create
   - apiGroups:
       - ""
     resources:

--- a/internal/controller/scheduler/metrics.go
+++ b/internal/controller/scheduler/metrics.go
@@ -189,18 +189,18 @@ var (
 		Help:      "Count of errors when podWatcher tried to acquire and fail a job on Buildkite",
 	})
 
-	podsEvictedCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+	forcefullyDeletedPodCounter = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: promNamespace,
 		Subsystem: "pod_watcher",
-		Name:      "pods_evicted_total",
-		Help:      "Count of evictions created for pods by podWatcher",
-	}, []string{"eviction_reason"})
-	podEvictionErrorsCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name:      "pods_forcefully_deleted_total",
+		Help:      "Count of forceful pods deletion by podWatcher",
+	}, []string{"delete_reason"})
+	forcefulPodDeletionErrorsCounter = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: promNamespace,
 		Subsystem: "pod_watcher",
-		Name:      "pod_eviction_errors_total",
-		Help:      "Count of failures to create pod evictions by podWatcher",
-	}, []string{"eviction_reason", "error_reason"})
+		Name:      "pods_forceful_deletion_errors_total",
+		Help:      "Count of failures to delete pod forcefully by podWatcher",
+	}, []string{"delete_reason", "error_reason"})
 )
 
 // Completion watcher metrics

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -598,7 +598,7 @@ func TestInterposerVector(t *testing.T) {
 	assert.Contains(t, logs, "Goodbye World!")
 }
 
-func TestCancelCheckerEvictsPod(t *testing.T) {
+func TestCancelCheckerDeletePod(t *testing.T) {
 	tc := testcase{
 		T:       t,
 		Fixture: "cancel-checker.yaml",
@@ -619,8 +619,8 @@ func TestCancelCheckerEvictsPod(t *testing.T) {
 	}
 	tc.AssertCancelled(ctx, build)
 
-	// Give it time to evict
-	time.Sleep(30 * time.Second)
+	// Give it time to delete
+	time.Sleep(5 * time.Second)
 
 	// TriggerBuild performs this type assertion
 	job := build.Jobs.Edges[0].Node.(*api.JobJobTypeCommand)
@@ -634,7 +634,7 @@ func TestCancelCheckerEvictsPod(t *testing.T) {
 		t.Fatalf("kubernetes.CoreV1().Pods(%q).List(ctx, %v) error = %v", cfg.Namespace, opts, err)
 	}
 	if len(pods.Items) > 0 {
-		t.Fatalf("kubernetes.CoreV1().Pods(%q).List(ctx, %v): found %d pods, there should be none (they should have been evicted). Pods:\n%s",
+		t.Fatalf("kubernetes.CoreV1().Pods(%q).List(ctx, %v): found %d pods, there should be none (they should have been deleted). Pods:\n%s",
 			cfg.Namespace, opts, len(pods.Items), pretty.Sprint(pods.Items))
 	}
 }


### PR DESCRIPTION
This change will largely reduce the latency between job cancelled event and pod removal event. This can help orgs that often does mass cancelling to avoid cluster resources saturation. 