### PR TITLE
Fix note alert gfm syntax in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 
 The Buildkite Agent Stack for Kubernetes (also known as `agent-stack-k8s`) is a Kubernetes [controller](https://kubernetes.io/docs/concepts/architecture/controller/) that uses the Buildkite [Agent API](https://buildkite.com/docs/apis/agent-api) to watch for scheduled jobs assigned to the controller's queue.
 
-> [!NOTE] Starting with v0.28.0, the Buildkite GraphQL API is no longer used. If you are upgrading from an older version, your GraphQL-enabled token can be safely removed from your configuration or Kubernetes secret. Only the Agent token is required.
+> [!NOTE]
+> Starting with v0.28.0, the Buildkite GraphQL API is no longer used. If you are upgrading from an older version, your GraphQL-enabled token can be safely removed from your configuration or Kubernetes secret. Only the Agent token is required.
 
 ## Requirements
 


### PR DESCRIPTION
The tag needs to be on a separate line

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts

### Before

<img width="866" alt="image" src="https://github.com/user-attachments/assets/ac0d9016-3d2c-4f2a-ae89-7c5ede006391" />

### After

<img width="861" alt="image" src="https://github.com/user-attachments/assets/5ad33868-4209-472c-a662-067d148ff0ae" />

Fixes PIPE-1112.