### PR TITLE
pod-spec-patch without containers specified removes all containers from job pod

### DIFF
--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -122,6 +122,33 @@ func TestPodSpecPatchInController(t *testing.T) {
 	tc.AssertLogsContain(build, "value of MOUNTAIN is antisana")
 }
 
+func TestPodSpecPatchWithoutContainers(t *testing.T) {
+	tc := testcase{
+		T:       t,
+		Fixture: "mountain.yaml",
+		Repo:    repoHTTP,
+		GraphQL: api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
+	}.Init()
+	ctx := context.Background()
+	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)
+	cfg := cfg
+	cfg.PodSpecPatch = &corev1.PodSpec{
+		HostAliases: []corev1.HostAlias{
+			{
+				IP:        "127.0.0.1",
+				Hostnames: []string{"agent.buildkite.localhost"},
+			},
+		},
+	}
+
+	tc.StartController(ctx, cfg)
+	build := tc.TriggerBuild(ctx, pipelineID)
+
+	tc.AssertSuccess(ctx, build)
+	tc.AssertLogsContain(build, "value of MOUNTAIN is cotopaxi")
+	tc.AssertHostAlias(ctx, "agent.buildkite.localhost", "127.0.0.1")
+}
+
 func TestControllerPicksUpJobsWithSubsetOfAgentTags(t *testing.T) {
 	tc := testcase{
 		T:       t,


### PR DESCRIPTION
It should be possible to use a pod-spec-patch to add properties to pods scheduled by the controller. The docs says this should merge with the default pod spec. But with this valid pod spec patch that adds a host alias to the pod the controller ends up creating a pod without any containers. The job fails with the following log:

> Kubernetes rejected the podSpec built by agent-stack-k8s: failed to
> create job: Job.batch "buildkite-01973482-fa87-4008-862f-6cb79f05314c"
> is invalid: spec.template.spec.containers: Required value

The logs reveal:

> logger.go:146: 2025-06-03T16:38:10.116+1000 DEBUG   TestPodSpecPatchWithoutContainers.scheduler.worker      Applied podSpec patch from controller   {"patched": "&PodSpec{Volumes:[]Volume{Volume{Name:workspace,VolumeSource:VolumeSource{HostPath:nil,EmptyDir:&EmptyDirVolumeSource{Medium:,SizeLimit:<nil>,},GCEPersistentDisk:nil,AWSElasticBlockStore:nil,GitRepo:nil,Secret:nil,NFS:nil,ISCSI:nil,Glusterfs:nil,PersistentVolumeClaim:nil,RBD:nil,FlexVolume:nil,Cinder:nil,CephFS:nil,Flocker:nil,DownwardAPI:nil,FC:nil,AzureFile:nil,ConfigMap:nil,VsphereVolume:nil,Quobyte:nil,AzureDisk:nil,PhotonPersistentDisk:nil,PortworxVolume:nil,ScaleIO:nil,Projected:nil,StorageOS:nil,CSI:nil,Ephemeral:nil,Image:nil,},},},Containers:[]Container{},RestartPolicy:Never,TerminationGracePeriodSeconds:nil,ActiveDeadlineSeconds:nil,DNSPolicy:,NodeSelector:map[string]string{},ServiceAccountName:,DeprecatedServiceAccount:,NodeName:,HostNetwork:false,HostPID:false,HostIPC:false,SecurityContext:nil,ImagePullSecrets:[]LocalObjectReference{},Hostname:,Subdomain:,Affinity:nil,SchedulerName:,InitContainers:[]Container{Container{Name:copy-agent,Image:ghcr.io/buildkite/agent:3.98.0,Command:[ash],Args:[-cefx \nmkdir /workspace/sockets\nchmod 777 /workspace/sockets\ncp /usr/local/bin/buildkite-agent /sbin/tini-static /workspace\n],WorkingDir:,Ports:[]ContainerPort{},Env:[]EnvVar{},Resources:ResourceRequirements{Limits:ResourceList{},Requests:ResourceList{},Claims:[]ResourceClaim{},},VolumeMounts:[]VolumeMount{VolumeMount{Name:workspace,ReadOnly:false,MountPath:/workspace,SubPath:,MountPropagation:nil,SubPathExpr:,RecursiveReadOnly:nil,},},LivenessProbe:nil,ReadinessProbe:nil,Lifecycle:nil,TerminationMessagePath:,ImagePullPolicy:Always,SecurityContext:nil,Stdin:false,StdinOnce:false,TTY:false,EnvFrom:[]EnvFromSource{},TerminationMessagePolicy:,VolumeDevices:[]VolumeDevice{},StartupProbe:nil,ResizePolicy:[]ContainerResizePolicy{},RestartPolicy:nil,},Container{Name:imagecheck-0,Image:alpine:latest,Command:[/workspace/tini-static],Args:[--version],WorkingDir:,Ports:[]ContainerPort{},Env:[]EnvVar{},Resources:ResourceRequirements{Limits:ResourceList{cpu: {{200 -3} {<nil>} 200m DecimalSI},memory: {{134217728 0} {<nil>}  BinarySI},},Requests:ResourceList{cpu: {{100 -3} {<nil>} 100m DecimalSI},memory: {{67108864 0} {<nil>}  BinarySI},},Claims:[]ResourceClaim{},},VolumeMounts:[]VolumeMount{VolumeMount{Name:workspace,ReadOnly:false,MountPath:/workspace,SubPath:,MountPropagation:nil,SubPathExpr:,RecursiveReadOnly:nil,},},LivenessProbe:nil,ReadinessProbe:nil,Lifecycle:nil,TerminationMessagePath:,ImagePullPolicy:Always,SecurityContext:nil,Stdin:false,StdinOnce:false,TTY:false,EnvFrom:[]EnvFromSource{},TerminationMessagePolicy:,VolumeDevices:[]VolumeDevice{},StartupProbe:nil,ResizePolicy:[]ContainerResizePolicy{},RestartPolicy:nil,},},AutomountServiceAccountToken:nil,Tolerations:[]Toleration{},HostAliases:[]HostAlias{HostAlias{IP:127.0.0.1,Hostnames:[agent.buildkite.localhost],},},PriorityClassName:,Priority:nil,DNSConfig:nil,ShareProcessNamespace:nil,ReadinessGates:[]PodReadinessGate{},RuntimeClassName:nil,EnableServiceLinks:nil,PreemptionPolicy:nil,Overhead:ResourceList{},TopologySpreadConstraints:[]TopologySpreadConstraint{},EphemeralContainers:[]EphemeralContainer{},SetHostnameAsFQDN:nil,OS:nil,HostUsers:nil,SchedulingGates:[]PodSchedulingGate{},ResourceClaims:[]PodResourceClaim{},Resources:nil,}"}
> logger.go:146: 2025-06-03T16:38:10.131+1000 WARN    TestPodSpecPatchWithoutContainers.scheduler.worker      Job invalid, failing job on Buildkite   {"job-uuid": "01973482-fa87-4008-862f-6cb79f05314c", "error": "failed to create job: Job.batch \"buildkite-01973482-fa87-4008-862f-6cb79f05314c\" is invalid: spec.template.spec.containers: Required value"}

Note the `Containers:[]Container{}` section.

I'm not sure what's going on, but I can at least replicate the failure. Perhaps the patch's missing containers collection is being interpreted as an override by the merge strategy? That feels odd.