### PR TITLE
PIPE-1071: remove cluster uuid from stack parameter

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -68,7 +68,6 @@ To get the integration test running locally, you will need:
 
 1. A valid Buildkite API token with GraphQL enabled.
 2. A valid Buildkite Agent Token in your target Buildkite Cluster.
-3. Your target Buildkite Cluster UUID.
 4. Depending on test cases, you may also need SSH keys, please keep reading.
 5. Your shell environment will need CLI write access to a Kubernetes cluster such as the one provided by https://orbstack.dev/.
 
@@ -78,7 +77,6 @@ It's generally convenient to supply the API token, your Buildkite organization n
 
 ```bash
 export BUILDKITE_TOKEN="bkua_**************"
-export CLUSTER_UUID="UUID-UUID-UUID-UUID"
 ```
 
 ## Running locally
@@ -208,7 +206,7 @@ running a integration test.
 In this case, you can choose to supply some inputs via CLI parameters instead of environment variables:
 
 ```bash
-just run --buildkite-token my-api-token --debug --cluster-uuid my-cluster-uuid
+just run --buildkite-token my-api-token --debug
 ```
 
 ### Local deployment with Helm

--- a/cmd/controller/controller_test.go
+++ b/cmd/controller/controller_test.go
@@ -36,7 +36,6 @@ func TestReadAndParseConfig(t *testing.T) {
 		K8sClientRateLimiterBurst:      30,
 		Namespace:                      "my-buildkite-ns",
 		Tags:                           []string{"queue=my-queue", "priority=high"},
-		ClusterUUID:                    "beefcafe-abbe-baba-abba-deedcedecade",
 		PrometheusPort:                 9216,
 		ProhibitKubernetesPlugin:       true,
 		PaginationPageSize:             1000,

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -24,10 +24,6 @@ work-queue-limit: 2000000
 image-check-container-cpu-limit: 201m
 image-check-container-memory-limit: 129Mi
 
-# only set cluster-uuid if the pipelines are in a cluster
-# the UUID may be found in the cluster settings
-cluster-uuid: beefcafe-abbe-baba-abba-deedcedecade
-
 tags:
   - queue=my-queue
   - priority=high

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -59,9 +59,6 @@ type Config struct {
 	K8sClientRateLimiterQPS   int `json:"k8s-client-rate-limiter-qps" validate:"omitempty"`
 	K8sClientRateLimiterBurst int `json:"k8s-client-rate-limiter-burst" validate:"omitempty"`
 
-	// ClusterUUID field is mandatory for most new orgs.
-	// Some old orgs allows unclustered setup.
-	ClusterUUID                  string          `json:"cluster-uuid"                     validate:"omitempty"`
 	AdditionalRedactedVars       stringSlice     `json:"additional-redacted-vars"         validate:"omitempty"`
 	PodSpecPatch                 *corev1.PodSpec `json:"pod-spec-patch"                   validate:"omitempty"`
 	ImagePullBackOffGracePeriod  time.Duration   `json:"image-pull-backoff-grace-period"  validate:"omitempty"`
@@ -101,6 +98,9 @@ type Config struct {
 	// FIXME: This is unused. Only keeping here temporarily to ease our transition.
 	// Once we promote our new version of k8s stack into our own CI, we can remove this line.
 	Org string `json:"org" validate:"omitempty"`
+	// Deprecated: ClusterUUID is unused. Only keeping here temporarily to ease our transition.
+	// Once we promote our new version of k8s stack into our own CI, we can remove this line.
+	ClusterUUID string `json:"cluster-uuid" validate:"omitempty"`
 }
 
 type stringSlice []string
@@ -128,7 +128,6 @@ func (c Config) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	}
 	enc.AddString("profiler-address", c.ProfilerAddress)
 	enc.AddUint16("prometheus-port", c.PrometheusPort)
-	enc.AddString("cluster-uuid", c.ClusterUUID)
 	enc.AddBool("prohibit-kubernetes-plugin", c.ProhibitKubernetesPlugin)
 	enc.AddBool("allow-pod-spec-patch-unsafe-command-modification", c.AllowPodSpecPatchUnsafeCmdMod)
 	if err := enc.AddArray("additional-redacted-vars", c.AdditionalRedactedVars); err != nil {


### PR DESCRIPTION
With the new `GET /token` API, we don't need to manually set cluster uuid anymore. 

This PR changes stack initialization code to call `/token` agent api to get cluster uuid. 

This PR is stacked on top of #609. 