### PR TITLE
Increase test queue name uniqueness and improve test cleanup robustness

### DIFF
--- a/internal/integration/testcase_test.go
+++ b/internal/integration/testcase_test.go
@@ -3,6 +3,7 @@ package integration_test
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"os"
 	"slices"
@@ -17,6 +18,7 @@ import (
 	"github.com/buildkite/agent-stack-k8s/v2/internal/controller/config"
 	"github.com/buildkite/agent-stack-k8s/v2/internal/integration/api"
 	"github.com/buildkite/go-buildkite/v3/buildkite"
+	"github.com/buildkite/roko"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -41,8 +43,24 @@ type testcase struct {
 
 // k8s labels are limited to length 63, we use the pipeline name as a label.
 // So we sometimes need to limit the length of the pipeline name too.
-func (t *testcase) ShortPipelineName() string {
-	return strings.Trim(t.PipelineName[:min(len(t.PipelineName), 63)], "-")
+// These pipeline name consists of {name}-{job id}
+// When {name} is too longer, the {job id} bit gets too short, simple truncate 64 will make this queue name non-unique.
+//
+// So we do truncate(name, 63 - 8) + SHA(full name)[:8]
+func (t *testcase) QueueName() string {
+	if len(t.PipelineName) <= 63 {
+		return t.PipelineName
+	}
+
+	// Use SHA256 hash of the pipeline name to ensure uniqueness while keeping length under 63
+	hash := sha256.Sum256([]byte(t.PipelineName))
+	hashPartLength := 8 // Use first 8 characters of hash
+	hashStr := fmt.Sprintf("%x", hash)[:hashPartLength]
+
+	// Keep as much of the original name as possible, then append hash
+	maxOriginalLen := 63 - 1 - hashPartLength // -1 for the dash separator
+	truncated := strings.Trim(t.PipelineName[:maxOriginalLen], "-")
+	return fmt.Sprintf("%s-%s", truncated, hashStr)
 }
 
 func (t testcase) Init() testcase {
@@ -90,7 +108,7 @@ func (t testcase) PrepareQueueAndPipelineWithCleanup(ctx context.Context) string
 	}
 
 	if queueName == "" {
-		queueName = t.ShortPipelineName()
+		queueName = t.QueueName()
 	}
 	p := t.createPipelineWithCleanup(ctx, queueName)
 	return *p.GraphQLID
@@ -99,7 +117,7 @@ func (t testcase) PrepareQueueAndPipelineWithCleanup(ctx context.Context) string
 func (t testcase) createClusterQueueWithCleanup() *buildkite.ClusterQueue {
 	t.Helper()
 
-	queueName := t.ShortPipelineName()
+	queueName := t.QueueName()
 	queue, _, err := t.Buildkite.ClusterQueues.Create(cfg.Org, cfg.ClusterUUID, &buildkite.ClusterQueueCreate{
 		Key: &queueName,
 	})
@@ -110,8 +128,14 @@ func (t testcase) createClusterQueueWithCleanup() *buildkite.ClusterQueue {
 			return
 		}
 
-		_, err := t.Buildkite.ClusterQueues.Delete(cfg.Org, cfg.ClusterUUID, *queue.ID)
-		if err != nil {
+		if err := roko.NewRetrier(
+			roko.WithMaxAttempts(5),
+			roko.WithStrategy(roko.Constant(5*time.Second)),
+		).DoWithContext(context.Background(), func(r *roko.Retrier) error {
+			// There is a small chance that we are deleting queue too soon before queue realize agent has disconnected.
+			_, err := t.Buildkite.ClusterQueues.Delete(cfg.Org, cfg.ClusterUUID, *queue.ID)
+			return err
+		}); err != nil {
 			t.Errorf("Unable to clean up cluster queue %s: %v", *queue.ID, err)
 			return
 		}
@@ -159,7 +183,7 @@ func (t testcase) StartController(ctx context.Context, cfg config.Config) {
 	EnsureCleanup(t.T, cancel)
 
 	// TODO: Use queue name created above
-	cfg.Tags = []string{fmt.Sprintf("queue=%s", t.ShortPipelineName())}
+	cfg.Tags = []string{fmt.Sprintf("queue=%s", t.QueueName())}
 	cfg.Debug = true
 
 	go controller.Run(runCtx, t.Logger, t.Kubernetes, &cfg)
@@ -308,7 +332,7 @@ func (t testcase) waitForBuild(ctx context.Context, build api.Build) api.BuildSt
 func (t testcase) AssertMetadata(ctx context.Context, annotations, labelz map[string]string) {
 	t.Helper()
 
-	tagReq, err := labels.NewRequirement("tag.buildkite.com/queue", selection.Equals, []string{t.ShortPipelineName()})
+	tagReq, err := labels.NewRequirement("tag.buildkite.com/queue", selection.Equals, []string{t.QueueName()})
 	require.NoError(t, err)
 
 	selector := labels.NewSelector().Add(*tagReq)
@@ -332,7 +356,7 @@ func (t testcase) AssertMetadata(ctx context.Context, annotations, labelz map[st
 func (t testcase) AssertHostAlias(ctx context.Context, alias string, host string) {
 	t.Helper()
 
-	tagReq, err := labels.NewRequirement("tag.buildkite.com/queue", selection.Equals, []string{t.ShortPipelineName()})
+	tagReq, err := labels.NewRequirement("tag.buildkite.com/queue", selection.Equals, []string{t.QueueName()})
 	require.NoError(t, err)
 
 	selector := labels.NewSelector().Add(*tagReq)


### PR DESCRIPTION
This will resolve our long standing queue key conflict during test run. 

Currently when two builds running at the same time, it's very likely they will have conflict test queue keys because some test names are getting long. `<test name> + <first 3 character of uuid v7>` isn't unique at all.