### PR TITLE
Mark config.org and config.cluster-uuid as deprecated

### DIFF
--- a/charts/agent-stack-k8s/values.schema.json
+++ b/charts/agent-stack-k8s/values.schema.json
@@ -258,9 +258,9 @@
         "org": {
           "type": "string",
           "default": "",
-          "minLength": 1,
-          "title": "Buildkite organization slug",
-          "examples": [""]
+          "title": "Deprecated as of v0.28 - Buildkite organization slug",
+          "examples": [""],
+          "deprecated": true
         },
         "tags": {
           "type": "array",
@@ -274,8 +274,9 @@
         "cluster-uuid": {
           "type": "string",
           "default": "",
-          "title": "The UUID of the Buildkite cluster to pull Jobs from",
-          "examples": [""]
+          "title": "Deprecated as of v0.28 - The UUID of the Buildkite cluster to pull Jobs from",
+          "examples": [""],
+          "deprecated": true
         },
         "additional-redacted-vars": {
           "type": "array",


### PR DESCRIPTION
The schema should match the new reality that they're no longer needed