### PR TITLE
[BREAKING]: listen to default queue when no queue is specified

### DIFF
--- a/api/agent_client.go
+++ b/api/agent_client.go
@@ -12,6 +12,9 @@ import (
 	"time"
 )
 
+// This is a special keyword supported on backend for polling from the current default queue in the cluster.
+const defaultQueueKey = "_default"
+
 func NewAgentClient(token, endpoint, clusterID, queue string, agentQueryRules []string) (*AgentClient, error) {
 	if endpoint == "" {
 		endpoint = "https://agent.buildkite.com/v3"
@@ -22,6 +25,9 @@ func NewAgentClient(token, endpoint, clusterID, queue string, agentQueryRules []
 	endpointURL, err := url.Parse(endpoint)
 	if err != nil {
 		return nil, err
+	}
+	if queue == "" {
+		queue = defaultQueueKey
 	}
 	return &AgentClient{
 		endpoint: endpointURL,

--- a/charts/agent-stack-k8s/values.schema.json
+++ b/charts/agent-stack-k8s/values.schema.json
@@ -265,7 +265,7 @@
         "tags": {
           "type": "array",
           "default": [],
-          "title": "Buildkite agent tags used for acquiring jobs - 'queue' is required",
+          "title": "Buildkite agent tags used for acquiring jobs. If you don't specify a queue tag, it will listen to the default queue.",
           "items": {
             "type": "string"
           },

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -59,7 +59,7 @@ func AddConfigFlags(cmd *cobra.Command) {
 	)
 	cmd.Flags().StringSlice(
 		"tags",
-		[]string{"queue=kubernetes"},
+		[]string{},
 		`A comma-separated list of agent tags. The "queue" tag must be unique (e.g. "queue=kubernetes,os=linux")`,
 	)
 	cmd.Flags().String(

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -46,7 +46,7 @@ type Config struct {
 	JobPrefix                string        `json:"job-prefix"               validate:"required"`
 	MaxInFlight              int           `json:"max-in-flight"            validate:"min=0"`
 	Namespace                string        `json:"namespace"                validate:"required"`
-	Tags                     stringSlice   `json:"tags"                     validate:"min=1"`
+	Tags                     stringSlice   `json:"tags"`
 	PrometheusPort           uint16        `json:"prometheus-port"          validate:"omitempty"`
 	ProfilerAddress          string        `json:"profiler-address"         validate:"omitempty,hostname_port"`
 	PaginationPageSize       int           `json:"pagination-page-size"     validate:"min=1,max=1000"`

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -88,8 +88,7 @@ func Run(
 
 	queue := agentTags["queue"]
 	if queue == "" {
-		logger.Error("The 'queue' tag is missing, but it is required", zap.Error(err))
-		return
+		logger.Info("Listening to the default queue for the given cluster. To listen to a specific queue, please pass in 'queue' as a tag, e.g. --tags='queue=kubernetes'")
 	}
 
 	agentTokenClient, err := api.NewAgentTokenClient(agentToken, agentEndpoint)

--- a/internal/controller/monitor/monitor.go
+++ b/internal/controller/monitor/monitor.go
@@ -184,7 +184,9 @@ func (m *Monitor) passJobsToNextHandler(
 		// Ensure the job has the queue tag. We queried a queue-specific
 		// endpoint, but it may be the default queue, which doesn't require
 		// `agents: queue: ...`, so the queue tag might not be present.
-		job.AgentQueryRules = agenttags.SetTag(job.AgentQueryRules, "queue", m.cfg.Queue)
+		if m.cfg.Queue != "" {
+			job.AgentQueryRules = agenttags.SetTag(job.AgentQueryRules, "queue", m.cfg.Queue)
+		}
 
 		// Convert the job tags to a map.
 		jobTags, tagErrs := agenttags.TagMapFromTags(job.AgentQueryRules)


### PR DESCRIPTION
Context: PIPE-1072

## Background

In the past when we don't supply a queue tag to k8s stack, it will by default listen to a `kubernetes` queue. User would have to manually provision this queue before stack can run. 

This is unnecessary friction (does user even need to know about queue before getting this to run?) and it's inconsistent with agent's behavior where in the case of unspecified queue, it will listen to the "default" queue. 

## Change

This PR changes the k8s stack behavior to align with agent.

After this change, when a user starts with buildkite k8s stack, all they need to supply is the cluster queue token, everything works out of box. 