### PR TITLE
Fix missing hooks and plugins volume mounts

### DIFF
--- a/.buildkite/fixtures/hooks.yaml
+++ b/.buildkite/fixtures/hooks.yaml
@@ -1,0 +1,12 @@
+# This configmap is used by TestHooksAndPlugins.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: integration-tests-fixture-hooks
+  namespace: buildkite-k8s-integration-test
+data:
+  environment: echo 'Hello from the environment hook'
+  pre-checkout: echo 'Hello from the pre-checkout hook'
+  post-checkout: echo 'Hello from the post-checkout hook'
+  pre-command: echo 'Hello from the pre-command hook'
+  post-command: echo 'Hello from the post-command hook'

--- a/internal/integration/fixtures/hooks-and-plugins-volumes.yaml
+++ b/internal/integration/fixtures/hooks-and-plugins-volumes.yaml
@@ -1,0 +1,12 @@
+agents:
+  queue: "{{.queue}}"
+steps:
+  - label: ":fishing_pole_and_fish: Hooks and Plugins"
+    command: echo 'Hello from the command!'
+    plugins:
+      - improbable-eng/metahook#v0.4.1:
+          environment: echo 'Hello from the metahook environment hook'
+          pre-checkout: echo 'Hello from the metahook pre-checkout hook'
+          post-checkout: echo 'Hello from the metahook post-checkout hook'
+          pre-command: echo 'Hello from the metahook pre-command hook'
+          post-command: echo 'Hello from the metahook post-command hook'


### PR DESCRIPTION
### What
Attach the hooks and plugins volumes to the other containers (as they were before #595).

Add an integration test to prevent regression.

### Why

Fixes #617 

### Notes

Hooks are easy to write in a configmap and then mount.

Plugins are less easy to write declaratively, since all plugins (except vendored plugins) are Git repos, and the agent expects to "check out" plugins that already exist in the local filesystem into the plugins path. So the plugins path has to be writable, so a config map can't be mounted there, requiring shenanigans (PodSpecPatch, ExtraVolumeMounts) just to get working, and because it must be a Git repo, it would contain ugly blobs of binary data. In lieu of that, the test specifies a new emptyDir for PluginsVolume and just uses metahook, which should be checked out into that directory.