### PR TITLE
PIPE-1139: fix checkout skip crash + container-0 double handling

### DIFF
--- a/internal/integration/fixtures/skip-checkout.yaml
+++ b/internal/integration/fixtures/skip-checkout.yaml
@@ -1,0 +1,11 @@
+
+steps:
+  - label: "No checkout"
+    agents:
+      queue: "{{.queue}}"
+    command: echo hello-skip-checkout
+    plugins:
+      - kubernetes:
+          checkout:
+            skip: true
+          podSpec: {}

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -44,8 +44,8 @@ func TestWalkingSkeleton(t *testing.T) {
 
 func TestDefaultQueue(t *testing.T) {
 	// Note: this test assumes the default queue is called "default".
-	// This happens to be the case for our CI setup. 
-	// TODO: generalise the test to work with any name default queue once the 
+	// This happens to be the case for our CI setup.
+	// TODO: generalise the test to work with any name default queue once the
 	// controller can function without setting the queue explicitly.
 	tc := testcase{
 		T:           t,
@@ -791,4 +791,19 @@ func TestHooksAndPlugins(t *testing.T) {
 			t.Errorf("Logs did not contain %q", want)
 		}
 	}
+}
+
+func TestSkipCheckoutContainer(t *testing.T) {
+	tc := testcase{
+		T:       t,
+		Fixture: "skip-checkout.yaml",
+		Repo:    repoHTTP,
+		GraphQL: api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
+	}.Init()
+	ctx := context.Background()
+	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)
+	tc.StartController(ctx, cfg)
+	build := tc.TriggerBuild(ctx, pipelineID)
+	tc.AssertSuccess(ctx, build)
+	tc.AssertLogsContain(build, "hello-skip-checkout")
 }


### PR DESCRIPTION
Fixes #618. 

This PR fixes an intricate bug. When `podSpec` is not nil, but does not contain any containers, and at the same time when `checkout.skip = true`, it will cause an incorrectly configured `container-0` to be spawned. 

The obvious reason is that the `containerCount` calculation is wrong. But if this is the case, this issue is supposed to be pretty obvious and discoverable. 

The only reason that we only discover this know is that, we have (seemly incorrect) double handled the default `container-0` logic. Removing that makes this defect easily reproducible. 

This fix could mean a breaking change for a subset of users, I will use inline comment to explain this. 