### PR TITLE
PIPE-1072-2: fix explicitly setting job default queue causing controller to miss the job

### DIFF
--- a/internal/controller/agenttags/tags.go
+++ b/internal/controller/agenttags/tags.go
@@ -42,6 +42,12 @@ func SetTag(tags []string, key, val string) []string {
 	return tags
 }
 
+func RemoveTag(tags []string, key string) []string {
+	return slices.DeleteFunc(tags, func(tag string) bool {
+		return strings.HasPrefix(tag, key+"=")
+	})
+}
+
 // labelsFromTagMap converts map[key->value] to map[tag.buildkite.com/key->value],
 // with k8s compatibility checks
 func labelsFromTagMap(m map[string]string) (map[string]string, []error) {

--- a/internal/controller/monitor/monitor.go
+++ b/internal/controller/monitor/monitor.go
@@ -181,13 +181,6 @@ func (m *Monitor) passJobsToNextHandler(
 	filteredJobs := make([]*api.AgentScheduledJob, 0, len(jobs))
 
 	for _, job := range jobs {
-		// Ensure the job has the queue tag. We queried a queue-specific
-		// endpoint, but it may be the default queue, which doesn't require
-		// `agents: queue: ...`, so the queue tag might not be present.
-		if m.cfg.Queue != "" {
-			job.AgentQueryRules = agenttags.SetTag(job.AgentQueryRules, "queue", m.cfg.Queue)
-		}
-
 		// Convert the job tags to a map.
 		jobTags, tagErrs := agenttags.TagMapFromTags(job.AgentQueryRules)
 		if len(tagErrs) != 0 {

--- a/internal/integration/fixtures/explicit-default-queue.yaml
+++ b/internal/integration/fixtures/explicit-default-queue.yaml
@@ -1,0 +1,10 @@
+agents:
+  # Target the default queue, but provide a different specific tag
+  # so that the job is picked up by the test controller.
+  pseudoQueue: "{{.pseudoQueue}}"
+
+  queue: default # This test assumes the default queue is called "default".
+
+steps:
+  - label: ":wave:"
+    command: "echo Hi there"


### PR DESCRIPTION
When bk yaml looks like: 

```
agent: 
  queue: default # -> happen to be the default queue
```

And k8s controller starts without a queue tag, the controller will miss the job because controller wants a job that has `queue=""` instead. 

----

This PR fixed it on transport layer so when we poll jobs, its queue tag will always match our expectation. 