### PR TITLE
PIPE-1157: Dogfooding buildkite scoped secret for the graphql token

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -145,8 +145,6 @@ steps:
                   - *go-mod-cache-env
                 envFrom:
                   - secretRef:
-                      name: test-secrets
-                  - secretRef:
                       name: agent-stack-k8s-secrets
                 volumeMounts:
                   - mountPath: /etc/config.yaml
@@ -158,6 +156,10 @@ steps:
                   requests:
                     cpu: 1000m
                     memory: 512Mi
+      - cluster-secrets#v1.0.0:
+          variables:
+            BUILDKITE_TOKEN: integration_test_buildkite_api_token
+            BUILDKITE_ANALYTICS_TOKEN: test_engine_suite_token
       - test-collector:
           files: junit-*.xml
           format: junit

--- a/.buildkite/steps/deploy.sh
+++ b/.buildkite/steps/deploy.sh
@@ -18,9 +18,7 @@ helm upgrade agent-stack-k8s "${helm_repo_pecr}/agent-stack-k8s" \
   --install \
   --create-namespace \
   --wait \
-  --set config.org="${BUILDKITE_ORGANIZATION_SLUG}" \
   --set agentToken="${BUILDKITE_AGENT_TOKEN}" \
-  --set graphqlToken="${BUILDKITE_TOKEN}" \
   --set config.image="${agent_image}" \
   --set config.debug=true \
   --set config.profiler-address=localhost:6060


### PR DESCRIPTION
Context: PIPE-1157

GraphQL used to be a requirement to run controller, but since v0.27 we no longer need that to run controller. We only need that to run integration test. 

Therefore storing it as a k8s secret along with Agent Token no longer make sense. 

This is an opportunity for us to test Buildkite scoped secret! 