### PR TITLE
PIPE-1171: fix all jobs must match agent tags bug + introduce controller ID

### DIFF
--- a/charts/agent-stack-k8s/templates/config.yaml.tpl
+++ b/charts/agent-stack-k8s/templates/config.yaml.tpl
@@ -7,4 +7,5 @@ data:
   config.yaml: |
     agent-token-secret: {{ if .Values.agentStackSecret }}{{ .Values.agentStackSecret }}{{ else }}{{ include "agent-stack-k8s.fullname" . }}-secrets{{ end }}
     namespace: {{ .Release.Namespace }}
+    id: {{ include "agent-stack-k8s.fullname" . }}
     {{- .Values.config | toYaml | nindent 4 }}

--- a/internal/controller/agenttags/tags.go
+++ b/internal/controller/agenttags/tags.go
@@ -88,8 +88,8 @@ func LabelsFromTags(tags []string) (map[string]string, []error) {
 	return labels, append(errs1, errs2...)
 }
 
-// MatchJobTags reports whether each tag key in `agentTags` is also
-// present in `jobTags`, and the tag value in `jobTags` is either "*" or the
+// MatchJobTags reports whether each tag key in `jobTags` is also
+// present in `agentTags`, and the tag value in `jobTags` is either "*" or the
 // same as the tag value in `agentTags`.
 //
 // In the future, this may be expanded to: if the tag value `agentTags` is in some
@@ -97,15 +97,12 @@ func LabelsFromTags(tags []string) (map[string]string, []error) {
 // See https://buildkite.com/docs/agent/v3/cli-start#agent-targeting
 
 func MatchJobTags(agentTags, jobTags map[string]string) bool {
-	if len(agentTags) != len(jobTags) {
-		return false
-	}
-	for k, v := range agentTags {
-		jobTagValue, exists := jobTags[k]
+	for k, jobTagValue := range jobTags {
+		agentTagValue, exists := agentTags[k]
 		if !exists {
 			return false
 		}
-		if jobTagValue != "*" && jobTagValue != v {
+		if jobTagValue != "*" && jobTagValue != agentTagValue {
 			return false
 		}
 	}

--- a/internal/controller/agenttags/tags_test.go
+++ b/internal/controller/agenttags/tags_test.go
@@ -158,7 +158,7 @@ func TestMatchJobTags(t *testing.T) {
 		{
 			jobTags:        map[string]string{},
 			agentTags:      map[string]string{"a": "x"},
-			expectedResult: false,
+			expectedResult: true,
 		},
 		{
 			jobTags:        map[string]string{"a": "x"},
@@ -173,7 +173,7 @@ func TestMatchJobTags(t *testing.T) {
 		{
 			jobTags:        map[string]string{"a": "x"},
 			agentTags:      map[string]string{"a": "x", "b": "y"},
-			expectedResult: false,
+			expectedResult: true,
 		},
 		{
 			jobTags:        map[string]string{"a": "x", "b": "y"},
@@ -198,6 +198,11 @@ func TestMatchJobTags(t *testing.T) {
 		{
 			jobTags:        map[string]string{"a": "x", "b": "*"},
 			agentTags:      map[string]string{"a": "x", "b": "y"},
+			expectedResult: true,
+		},
+		{
+			jobTags:        map[string]string{"tag1": "x", "tag2": "*"},
+			agentTags:      map[string]string{"tag1": "x", "tag2": "y", "tags3": "z"},
 			expectedResult: true,
 		},
 	} {

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -12,6 +12,7 @@ import (
 
 const (
 	UUIDLabel                             = "buildkite.com/job-uuid"
+	ControllerIDLabel                     = "buildkite.com/controller-id"
 	BuildURLAnnotation                    = "buildkite.com/build-url"
 	JobURLAnnotation                      = "buildkite.com/job-url"
 	PriorityAnnotation                    = "buildkite.com/job-priority"
@@ -55,6 +56,12 @@ type Config struct {
 	EnableQueuePause         bool          `json:"enable-queue-pause"       validate:"omitempty"`
 	WorkQueueLimit           int           `json:"work-queue-limit"         validate:"omitempty"`
 	// Agent endpoint is set in agent-config.
+
+	// ID is an optional uniquely ID string for the controller.
+	// This is useful when running multiple bk k8s controllers within the same k8s namespace.
+	// So the controller can target the correct pods.
+	// By default, if helm is used to install, this will be set as helm release full name.
+	ID string `json:"id" validate:"omitempty"`
 
 	K8sClientRateLimiterQPS   int `json:"k8s-client-rate-limiter-qps" validate:"omitempty"`
 	K8sClientRateLimiterBurst int `json:"k8s-client-rate-limiter-burst" validate:"omitempty"`
@@ -123,6 +130,7 @@ func (c Config) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	enc.AddInt("job-creation-concurrency", c.JobCreationConcurrency)
 	enc.AddInt("max-in-flight", c.MaxInFlight)
 	enc.AddString("namespace", c.Namespace)
+	enc.AddString("id", c.ID)
 	if err := enc.AddArray("tags", c.Tags); err != nil {
 		return err
 	}

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -144,6 +144,7 @@ func Run(
 	// a pod to run that job. It talks to the k8s API to create pods.
 	sched := scheduler.New(logger.Named("scheduler"), k8sClient, agentClient, scheduler.Config{
 		Namespace:                      cfg.Namespace,
+		ID:                             cfg.ID,
 		Image:                          cfg.Image,
 		AgentTokenSecretName:           cfg.AgentTokenSecret,
 		JobTTL:                         cfg.JobTTL,
@@ -165,7 +166,7 @@ func Run(
 		ImageCheckContainerMemoryLimit: cfg.ImageCheckContainerMemoryLimit,
 	})
 
-	informerFactory, err := NewInformerFactory(k8sClient, cfg.Namespace, cfg.Tags)
+	informerFactory, err := NewInformerFactory(k8sClient, cfg.Namespace, cfg.ID)
 	if err != nil {
 		logger.Fatal("failed to create informer", zap.Error(err))
 	}
@@ -238,26 +239,29 @@ func Run(
 func NewInformerFactory(
 	k8s kubernetes.Interface,
 	namespace string,
-	tags []string,
+	id string,
 ) (informers.SharedInformerFactory, error) {
-	labelsFromTags, errs := agenttags.LabelsFromTags(tags)
-	if len(errs) != 0 {
-		return nil, errors.Join(errs...)
-	}
-
-	requirements := make(labels.Requirements, 0, len(labelsFromTags)+1)
+	requirements := make(labels.Requirements, 0)
 	hasUUID, err := labels.NewRequirement(config.UUIDLabel, selection.Exists, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build uuid label selector for job manager: %w", err)
 	}
 	requirements = append(requirements, *hasUUID)
 
-	for l, v := range labelsFromTags {
-		hasLabel, err := labels.NewRequirement(l, selection.Equals, []string{v})
+	if id != "" {
+		hasRightID, err := labels.NewRequirement(config.ControllerIDLabel, selection.Equals, []string{id})
 		if err != nil {
-			return nil, fmt.Errorf("failed create label selector agent tag: %w", err)
+			return nil, fmt.Errorf("failed to build controller id label selector for job manager: %w", err)
 		}
-		requirements = append(requirements, *hasLabel)
+		requirements = append(requirements, *hasRightID)
+	} else {
+		// In the case when ID isn't specified, we shouldn't try to monitor those jobs that has ID label.
+		// Note that ID is set by the Helm chart, so this should not happen in usual installations.
+		noID, err := labels.NewRequirement(config.ControllerIDLabel, selection.DoesNotExist, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build controller id label selector for job manager: %w", err)
+		}
+		requirements = append(requirements, *noID)
 	}
 
 	return informers.NewSharedInformerFactoryWithOptions(

--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -53,6 +53,7 @@ var (
 
 type Config struct {
 	Namespace                      string
+	ID                             string
 	Image                          string
 	JobPrefix                      string
 	AgentToken                     string
@@ -275,6 +276,11 @@ func (w *worker) Build(podSpec *corev1.PodSpec, skipCheckout bool, inputs buildI
 	}
 
 	kjob.Labels[config.UUIDLabel] = inputs.uuid
+	if w.cfg.ID != "" {
+		kjob.Labels[config.ControllerIDLabel] = w.cfg.ID
+	}
+
+	// These tag labels have no impact, consider moving them into annotation instead.
 	tagLabels, errs := agenttags.LabelsFromTags(inputs.agentQueryRules)
 	if len(errs) > 0 {
 		w.logger.Warn("converting all tags to labels", zap.Errors("errs", errs))

--- a/internal/controller/scheduler/scheduler_test.go
+++ b/internal/controller/scheduler/scheduler_test.go
@@ -511,6 +511,7 @@ func TestBuild(t *testing.T) {
 		nil,
 		nil,
 		Config{
+			ID:                   "controller-1",
 			Namespace:            "buildkite",
 			Image:                "buildkite/agent:latest",
 			AgentTokenSecretName: "bkcq_1234567890",
@@ -538,6 +539,9 @@ func TestBuild(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, kjob.Spec.Template.Spec.Containers, 3)
+
+	controllerIDLabel := kjob.Labels["buildkite.com/controller-id"]
+	assert.Equal(t, controllerIDLabel, "controller-1")
 
 	container0 := findContainer(t, kjob.Spec.Template.Spec.Containers, "container-0")
 	if diff := cmp.Diff(container0.Image, "alpine:latest"); diff != "" {

--- a/internal/integration/testcase_test.go
+++ b/internal/integration/testcase_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/buildkite/agent-stack-k8s/v2/internal/integration/api"
 	"github.com/buildkite/go-buildkite/v3/buildkite"
 	"github.com/buildkite/roko"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -211,6 +212,9 @@ func (t testcase) StartController(ctx context.Context, cfg config.Config, custom
 		cfg.Tags = []string{fmt.Sprintf("queue=%s", t.QueueName())}
 	}
 	cfg.Debug = true
+	// During, we often have many test controller running in the same namespaces
+	// Setting a static identifer here so their informer aren't steping on each other.
+	cfg.ID = uuid.New().String()
 
 	go controller.Run(runCtx, t.Logger, t.Kubernetes, &cfg)
 }


### PR DESCRIPTION
Solves #625

This PR first of all fixes #625, effectively reverting #596, as the fix was addressing one issue, introducing another.

As a replacement, this PR changed controller so it stops using tags to find correct pods to monitor. Using tags to match pods has a few issue: 
- first and foremost: tags can changes between restart.
- tags matching logic is much more difficult to express using k8s. 
  - Previously the controller is finding pods that has identical tags with controller tags. 
  - But not all pods will have the identical tags -> so this is clearly wrong. 

This PR proposed a new `ID` config variable as an stable identifier for controller, the `ID` will be set by helm during install, otherwise it's optional. 