### PR TITLE
PIPE-1111-part-1: allow running k8s agent stack against local bk/bk

### DIFF
--- a/config.dev.yaml
+++ b/config.dev.yaml
@@ -1,0 +1,17 @@
+# For Buildkite Employees.
+# This config is only used when running Agent K8s stack against a local buildkite instance.
+
+agent-config:
+  # Setting a custom Agent REST API endpoint is usually only useful if you have
+  # a different instance of Buildkite itself available to run.
+  endpoint: http://agent.buildkite.localhost/v3
+
+pod-spec-patch:
+  hostAliases:
+    # Minikube specific with docker driver.
+    # Determined by: minikube ssh and then "ping host.minikube.internal"
+    # It will be ideal if we can dynamically determine this depending on user's local env.
+    # Orbstack users might find `0.250.250.254` works instead.
+    - ip: "192.168.65.254"
+      hostnames:
+        - "agent.buildkite.localhost"

--- a/justfile
+++ b/justfile
@@ -1,8 +1,25 @@
 default:
   just --list
 
+# Running the controller locally using production buildkite as backend.
+# This is sufficient for vast majority of issues.
 run *FLAGS:
   go run ./... {{FLAGS}}
+
+# Running the controller locally but with local bk/bk as the backend.
+# This is probably only useful for Buildkite employees.
+run-with-local-bk:
+  #!/usr/bin/env bash
+
+  set -exufo pipefail
+
+  kubectl create namespace local-bk || true
+
+  kubectl -n local-bk delete secret buildkite-agent-token || true
+  kubectl -n local-bk create secret generic buildkite-agent-token \
+    --from-literal=BUILDKITE_AGENT_TOKEN='bkct_buildkite'
+
+  go run ./... --namespace local-bk --config=config.dev.yaml
 
 test *FLAGS:
   #!/usr/bin/env bash


### PR DESCRIPTION
part of PIPE-1111

This PR presents a way to run k8s agent controller against local bk/bk, using an opinionated setup of `minikube`. 

This will vastly simplify our development process when we want to test against new backend change in bk/bk.

Steps to reproduce: 

```
minikube start --driver=docker
just run-with-local-bk
```