### PR TITLE
Link straight to agent tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The Buildkite Agent Stack for Kubernetes (also known as `agent-stack-k8s`) is a 
 ## Requirements
 
 - A Kubernetes cluster.
-- A [Buildkite cluster](https://buildkite.com/docs/pipelines/clusters/manage-clusters) and [agent token](https://buildkite.com/docs/agent/v3/tokens) for this cluster.
+- A [Buildkite Agent Token](https://buildkite.com/organizations/~/clusters/~/tokens).
 
 ## Documentation
 


### PR DESCRIPTION
There's no need to talk about clusters here - that's the default way to create an agent token. And it's link straight into the product, to where they can generate a token.