### PR TITLE
go.mod: remove mapstructure replace

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,6 @@ go 1.24.0
 
 toolchain go1.24.1
 
-replace github.com/mitchellh/mapstructure => github.com/triarius/mapstructure v1.5.0-squash-inline
-
 require (
 	github.com/Khan/genqlient v0.8.1
 	github.com/buildkite/agent/v3 v3.100.0


### PR DESCRIPTION
This replace directive was originally added in https://github.com/buildkite/agent-stack-k8s/commit/8f253f55b807acf309c112157a9e6df235c62552 to address a podSpecPatch implementation issue caused by unmarshaling Kubernetes structures in the config via mapstructure, needed by Viper. 

Viper has since adopted mapstructure, so Viper is no longer using the mitchellh original. So the replace should have no effect. I believe the squash tag patch made it into Viper's fork - if it didn't, I presume we would have heard about it by now.