### PR TITLE
PB-133: feature flag for job reservation support

### DIFF
--- a/charts/agent-stack-k8s/values.schema.json
+++ b/charts/agent-stack-k8s/values.schema.json
@@ -336,6 +336,12 @@
           "title": "Permits PodSpecPatch to modify the command or args fields of containers. See the warning in the README before enabling this option",
           "examples": [false]
         },
+        "experimental-job-reservation-support": {
+          "type": "boolean",
+          "default": false,
+          "title": "Experimental - does not fully function yet. This experiment enables job reservation support for better job observability and scalable job fetching. If you try it, please let us know about your experiences by filing an issue on https://github.com/buildkite/agent-stack-k8s",
+          "examples": [false]
+        },
         "workspaceVolume": {
           "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.Volume"
         },

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -156,6 +156,11 @@ func AddConfigFlags(cmd *cobra.Command) {
 		false,
 		"Permits PodSpecPatch to modify the command or args fields of stack-provided containers. See the warning in the README before enabling this option",
 	)
+	cmd.Flags().Bool(
+		"experimental-job-reservation-support",
+		false,
+		"Please contact us before enabling this flag. This feature enables job reservation support: Better job observability, scalable job fetching!",
+	)
 	cmd.Flags().Int(
 		"pagination-page-size",
 		config.DefaultPaginationPageSize,

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -99,6 +99,9 @@ type Config struct {
 	// then the pod will malfunction.
 	AllowPodSpecPatchUnsafeCmdMod bool `json:"allow-pod-spec-patch-unsafe-command-modification" validate:"omitempty"`
 
+	// Enable job reservation support - this feature is in-progress.
+	ExperimentalJobReservationSupport bool `json:"experimental-job-reservation-support" validate:"omitempty"`
+
 	// These are only used for integration tests.
 	BuildkiteToken  string `json:"buildkite-token" validate:"omitempty"`
 	GraphQLEndpoint string `json:"graphql-endpoint" validate:"omitempty"`
@@ -138,6 +141,7 @@ func (c Config) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	enc.AddUint16("prometheus-port", c.PrometheusPort)
 	enc.AddBool("prohibit-kubernetes-plugin", c.ProhibitKubernetesPlugin)
 	enc.AddBool("allow-pod-spec-patch-unsafe-command-modification", c.AllowPodSpecPatchUnsafeCmdMod)
+	enc.AddBool("experimental-job-reservation-support", c.ExperimentalJobReservationSupport)
 	if err := enc.AddArray("additional-redacted-vars", c.AdditionalRedactedVars); err != nil {
 		return err
 	}


### PR DESCRIPTION
This feature flag currently does nothing, but it will de-risk our incoming job reservation related changes to k8s stack.

Also, hopefully this gently conveys a message that we are doubling down our investment in our k8s stack offering 🙂 