### PR TITLE
PB-140 part 2: job reservation support

### DIFF
--- a/config.dev.yaml
+++ b/config.dev.yaml
@@ -6,6 +6,8 @@ agent-config:
   # a different instance of Buildkite itself available to run.
   endpoint: http://agent.buildkite.localhost/v3
 
+experimental-job-reservation-support: true
+
 pod-spec-patch:
   hostAliases:
     # Minikube specific with docker driver.

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -114,6 +114,7 @@ func Run(
 		agentTokenIdentity.ClusterUUID,
 		queue,
 		cfg.Tags,
+		api.WithReservation(cfg.ExperimentalJobReservationSupport),
 	)
 	if err != nil {
 		logger.Error("Couldn't create Agent API client", zap.Error(err))

--- a/internal/controller/reserver/reserver.go
+++ b/internal/controller/reserver/reserver.go
@@ -58,7 +58,9 @@ func (r *Reserver) HandleMany(ctx context.Context, jobs []*api.AgentScheduledJob
 		job_ids = append(job_ids, job.ID)
 	}
 
-	result, err := r.agentClient.ReserveJobs(ctx, job_ids)
+	r.logger.Info("reserving jobs via Agent API...", zap.Int("count", len(job_ids)))
+
+	result, _, err := r.agentClient.ReserveJobs(ctx, job_ids)
 	if err != nil {
 		return fmt.Errorf("error when reserving jobs: %w", err)
 	}

--- a/justfile
+++ b/justfile
@@ -28,6 +28,8 @@ test *FLAGS:
 
   GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
+  export EXPERIMENTAL_JOB_RESERVATION_SUPPORT=true
+
   go test \
     -ldflags="-X github.com/buildkite/agent-stack-k8s/v2/internal/integration_test.branch=${GIT_BRANCH}" \
     {{FLAGS}} \


### PR DESCRIPTION
This is based on top of #650, can only be merged after that. 

In addition, this shall not be merged before the backend counter part been deployed https://github.com/buildkite/buildkite/pull/24130. 

This PR also enables the experiment for test env and local dev env.

-----------

This PR filled the gap in #650, making actual reserve api call to backend. 