### PR TITLE
Update to use OIDC session tokens on AWS role assumption

### DIFF
--- a/.buildkite/steps/assume-role.sh
+++ b/.buildkite/steps/assume-role.sh
@@ -8,7 +8,7 @@ set -eu
 echo "~~~ :buildkite::key::aws: Requesting an OIDC token for AWS from Buildkite"
 
 role_arn='arn:aws:iam::172840064832:role/pipeline-buildkite-kubernetes-stack-kubernetes-agent-stack'
-BUILDKITE_OIDC_TOKEN="$(buildkite-agent oidc request-token --audience sts.amazonaws.com)"
+BUILDKITE_OIDC_TOKEN="$(buildkite-agent oidc request-token --audience sts.amazonaws.com  --aws-session-tag organization_id,organization_slug,pipeline_slug)"
 
 echo "~~~ :aws: Assuming role using OIDC token"
 ASSUME_ROLE_RESPONSE="$(aws sts assume-role-with-web-identity \


### PR DESCRIPTION
Roll out using session tags for OIDC assumable IAM role trust policy.

Follow on from the work to support session tags in https://github.com/buildkite-plugins/aws-assume-role-with-web-identity-buildkite-plugin/pull/18

Requires matching update to the IAM role in PR: https://github.com/buildkite/aws-buildkite-dist/pull/130  to be shipped first