### PR TITLE
PIPE-1391: support image syntax

### DIFF
--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -419,10 +419,14 @@ func (w *worker) Build(podSpec *corev1.PodSpec, skipCheckout bool, inputs buildI
 	}
 
 	if len(podSpec.Containers) == 0 {
+		image := w.cfg.Image
+		if customImage := inputs.envMap["BUILDKITE_IMAGE"]; customImage != "" {
+			image = inputs.envMap["BUILDKITE_IMAGE"]
+		}
 		// Create a default command container named "container-0".
 		c := corev1.Container{
 			Name:         "container-0",
-			Image:        w.cfg.Image,
+			Image:        image,
 			Command:      commandContainerCommand,
 			Args:         commandContainerArgs,
 			WorkingDir:   "/workspace",

--- a/internal/integration/fixtures/image-attribute.yaml
+++ b/internal/integration/fixtures/image-attribute.yaml
@@ -1,0 +1,14 @@
+image: ruby:alpine
+
+steps:
+  - label: "Node alpine"
+    image: node:22-alpine
+    agents:
+      queue: "{{.queue}}"
+    command: yarn --version
+
+  # This job should take the global image attribute
+  - label: "Ruby alpine"
+    agents:
+      queue: "{{.queue}}"
+    command: ruby --version

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -836,3 +836,17 @@ func TestSkipCheckoutContainer(t *testing.T) {
 	tc.AssertSuccess(ctx, build)
 	tc.AssertLogsContain(build, "hello-skip-checkout")
 }
+
+func TestImageAttribute(t *testing.T) {
+	tc := testcase{
+		T:       t,
+		Fixture: "image-attribute.yaml",
+		Repo:    repoHTTP,
+		GraphQL: api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
+	}.Init()
+	ctx := context.Background()
+	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)
+	tc.StartController(ctx, cfg)
+	build := tc.TriggerBuild(ctx, pipelineID)
+	tc.AssertSuccess(ctx, build)
+}


### PR DESCRIPTION
This PR add the `image` attribute support, so this is not a dream: 

```yaml
steps:
  - image: ruby:alpine
    command: ruby --version
```

Very simple, but good impact 🙂 . 