### PR TITLE
PIPE-1664: job level image attribute take precedence over controller podSpecPatch

### DIFF
--- a/internal/controller/scheduler/build_inputs.go
+++ b/internal/controller/scheduler/build_inputs.go
@@ -1,0 +1,22 @@
+package scheduler
+
+import v1 "k8s.io/api/core/v1"
+
+func applyCustomImageIfPresent(podSpec *v1.PodSpec, inputs *buildInputs) *v1.PodSpec {
+
+	customImage := inputs.envMap["BUILDKITE_IMAGE"]
+	if customImage == "" {
+		return podSpec
+	}
+
+	for i := range podSpec.Containers {
+		c := &podSpec.Containers[i]
+		if c.Name != CommandContainerName {
+			continue
+		}
+
+		c.Image = customImage
+	}
+
+	return podSpec
+}

--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -43,6 +43,7 @@ const (
 	CopyAgentContainerName        = "copy-agent"
 	ImageCheckContainerNamePrefix = "imagecheck-"
 	CheckoutContainerName         = "checkout"
+	CommandContainerName          = "container-0"
 )
 
 var errK8sPluginProhibited = errors.New("the kubernetes plugin is prohibited by this controller, but was configured on this job")
@@ -419,14 +420,10 @@ func (w *worker) Build(podSpec *corev1.PodSpec, skipCheckout bool, inputs buildI
 	}
 
 	if len(podSpec.Containers) == 0 {
-		image := w.cfg.Image
-		if customImage := inputs.envMap["BUILDKITE_IMAGE"]; customImage != "" {
-			image = inputs.envMap["BUILDKITE_IMAGE"]
-		}
-		// Create a default command container named "container-0".
+		// Create a default command container
 		c := corev1.Container{
-			Name:         "container-0",
-			Image:        image,
+			Name:         CommandContainerName,
+			Image:        w.cfg.Image,
 			Command:      commandContainerCommand,
 			Args:         commandContainerArgs,
 			WorkingDir:   "/workspace",
@@ -446,7 +443,7 @@ func (w *worker) Build(podSpec *corev1.PodSpec, skipCheckout bool, inputs buildI
 				},
 				{
 					Name:  "BUILDKITE_SOCKETS_PATH",
-					Value: "/workspace/sockets/container-0",
+					Value: "/workspace/sockets/" + CommandContainerName,
 				},
 			},
 		}
@@ -681,6 +678,9 @@ func (w *worker) Build(podSpec *corev1.PodSpec, skipCheckout bool, inputs buildI
 		podSpec = patched
 		w.logger.Debug("Applied podSpec patch from controller", zap.Any("patched", patched))
 	}
+
+	// Support `image: ` syntax, this HAS TO happen between controller podSpec patch and plugin podSpec patch.
+	podSpec = applyCustomImageIfPresent(podSpec, &inputs)
 
 	// If present, patch from the k8s plugin is applied second.
 	if inputs.k8sPlugin != nil && inputs.k8sPlugin.PodSpecPatch != nil {


### PR DESCRIPTION
We want precedence order goes 

1. Job level plugin spec overrides 👇🏿 
2. Job level individual attribute, like `image`, overrides 👇🏿 
3. Controller level config.  

This PR fixes a situation where controller level config will override job level `image` attribute.