### PR TITLE
PIPE-1664 follow up: unify how plugin podSpec is passed to scheduler Build

### DIFF
--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -150,13 +150,7 @@ func (w *worker) Handle(ctx context.Context, job *api.AgentScheduledJob) error {
 		return w.failJob(ctx, inputs, fmt.Sprintf("agent-stack-k8s failed to parse the job: %v", err))
 	}
 
-	podSpec := &corev1.PodSpec{}
-	// Use the podSpec provided by the plugin, if allowed.
-	if inputs.k8sPlugin != nil && inputs.k8sPlugin.PodSpec != nil {
-		podSpec = inputs.k8sPlugin.PodSpec
-	}
-
-	kjob, err := w.Build(podSpec, false, inputs)
+	kjob, err := w.Build(false, inputs)
 	if err != nil {
 		logger.Warn("Job definition error detected, failing job", zap.Error(err))
 		return w.failJob(ctx, inputs, fmt.Sprintf("agent-stack-k8s failed to build a podSpec for the job: %v", err))
@@ -254,7 +248,9 @@ func (w *worker) ParseJob(job *api.AgentJob, sjob *api.AgentScheduledJob) (build
 
 // Build builds a job. The checkout container will be skipped either by passing
 // `true` or if the configuration is configured to skip it.
-func (w *worker) Build(podSpec *corev1.PodSpec, skipCheckout bool, inputs buildInputs) (*batchv1.Job, error) {
+func (w *worker) Build(skipCheckout bool, inputs buildInputs) (*batchv1.Job, error) {
+	podSpec := &corev1.PodSpec{}
+
 	// If Build was called with skipCheckout == false, then look at the config
 	// and plugin.
 	if !skipCheckout {

--- a/internal/controller/scheduler/scheduler_test.go
+++ b/internal/controller/scheduler/scheduler_test.go
@@ -387,7 +387,7 @@ func TestJobPluginConversion(t *testing.T) {
 	)
 	inputs, err := worker.ParseJob(job, sjob)
 	require.NoError(t, err)
-	kjob, err := worker.Build(pluginConfig.PodSpec, false, inputs)
+	kjob, err := worker.Build(false, inputs)
 	require.NoError(t, err)
 
 	gotPodSpec := kjob.Spec.Template.Spec
@@ -472,7 +472,7 @@ func TestTagEnv(t *testing.T) {
 	)
 	inputs, err := worker.ParseJob(job, sjob)
 	require.NoError(t, err)
-	kjob, err := worker.Build(pluginConfig.PodSpec, false, inputs)
+	kjob, err := worker.Build(false, inputs)
 	require.NoError(t, err)
 
 	container := findContainer(t, kjob.Spec.Template.Spec.Containers, "agent")
@@ -506,7 +506,7 @@ func TestJobWithNoKubernetesPlugin(t *testing.T) {
 	})
 	inputs, err := worker.ParseJob(job, sjob)
 	require.NoError(t, err)
-	kjob, err := worker.Build(&corev1.PodSpec{}, false, inputs)
+	kjob, err := worker.Build(false, inputs)
 	require.NoError(t, err)
 
 	require.Len(t, kjob.Spec.Template.Spec.Containers, 3)
@@ -568,7 +568,7 @@ func TestBuild(t *testing.T) {
 	)
 	inputs, err := worker.ParseJob(job, sjob)
 	require.NoError(t, err)
-	kjob, err := worker.Build(&corev1.PodSpec{}, false, inputs)
+	kjob, err := worker.Build(false, inputs)
 	require.NoError(t, err)
 
 	require.Len(t, kjob.Spec.Template.Spec.Containers, 3)
@@ -626,7 +626,7 @@ func TestBuildSkipCheckout(t *testing.T) {
 	)
 	inputs, err := worker.ParseJob(job, sjob)
 	require.NoError(t, err)
-	kjob, err := worker.Build(&corev1.PodSpec{}, false, inputs)
+	kjob, err := worker.Build(false, inputs)
 	require.NoError(t, err)
 
 	require.Len(t, kjob.Spec.Template.Spec.Containers, 2)
@@ -674,7 +674,7 @@ func TestBuildCheckoutEmptyConfigEnv(t *testing.T) {
 	)
 	inputs, err := worker.ParseJob(job, sjob)
 	require.NoError(t, err)
-	kjob, err := worker.Build(&corev1.PodSpec{}, false, inputs)
+	kjob, err := worker.Build(false, inputs)
 	require.NoError(t, err)
 
 	for _, container := range kjob.Spec.Template.Spec.Containers {
@@ -720,7 +720,7 @@ func TestBuildDefaultCheckoutParams(t *testing.T) {
 	})
 	inputs, err := worker.ParseJob(job, sjob)
 	require.NoError(t, err)
-	kjob, err := worker.Build(&corev1.PodSpec{}, false, inputs)
+	kjob, err := worker.Build(false, inputs)
 	require.NoError(t, err)
 
 	var checkoutContainer *corev1.Container
@@ -813,7 +813,7 @@ func TestBuildCheckoutParams(t *testing.T) {
 	)
 	inputs, err := worker.ParseJob(job, sjob)
 	require.NoError(t, err)
-	kjob, err := worker.Build(&corev1.PodSpec{}, false, inputs)
+	kjob, err := worker.Build(false, inputs)
 	require.NoError(t, err)
 
 	var checkoutContainer *corev1.Container
@@ -942,7 +942,7 @@ func TestCustomImageSyntax_pluginTakesTopPriority(t *testing.T) {
 	})
 	inputs, err := worker.ParseJob(job, sjob)
 	require.NoError(t, err)
-	kjob, err := worker.Build(&corev1.PodSpec{}, false, inputs)
+	kjob, err := worker.Build(false, inputs)
 	require.NoError(t, err)
 
 	commandContainer := findContainer(t, kjob.Spec.Template.Spec.Containers, CommandCommanderName)
@@ -975,7 +975,7 @@ func TestCustomImageSyntax_jobLevelImagePriority(t *testing.T) {
 	})
 	inputs, err := worker.ParseJob(job, sjob)
 	require.NoError(t, err)
-	kjob, err := worker.Build(&corev1.PodSpec{}, false, inputs)
+	kjob, err := worker.Build(false, inputs)
 	require.NoError(t, err)
 
 	commandContainer := findContainer(t, kjob.Spec.Template.Spec.Containers, CommandCommanderName)
@@ -1419,12 +1419,16 @@ func TestImagePullPolicies(t *testing.T) {
 				},
 			)
 			kjob, err := worker.Build(
-				&corev1.PodSpec{Containers: test.podSpecContainers},
 				false,
 				buildInputs{
 					uuid:            "1234",
 					command:         "echo shell",
 					agentQueryRules: []string{"queue=bernetes"},
+					k8sPlugin: &KubernetesPlugin{
+						PodSpecPatch: &corev1.PodSpec{
+							Containers: test.podSpecContainers,
+						},
+					},
 				},
 			)
 			if err != nil {
@@ -1593,7 +1597,6 @@ func TestPipelineSigningOptions(t *testing.T) {
 				},
 			)
 			kjob, err := worker.Build(
-				&corev1.PodSpec{},
 				false,
 				buildInputs{
 					uuid:            "1234",


### PR DESCRIPTION
We currently pass plugin's podSpec to build function in two ways: via the 1st parameter podSpec and via the 3rd parameter `inputs.k8sPlugin`. 

It's unnecessarily confusing since only one is sufficient. 

part of PIPE-1664