### PR TITLE
Return token on context cancellation in worker

### DIFF
--- a/internal/controller/limiter/limiter.go
+++ b/internal/controller/limiter/limiter.go
@@ -252,6 +252,7 @@ func (l *Limiter) worker(ctx context.Context) {
 		waitingForWorkGauge.Inc()
 		select {
 		case <-ctx.Done():
+			l.tryReturnToken("Handle")
 			return
 
 		case <-l.newWork:


### PR DESCRIPTION
Adds a call to l.tryReturnToken("Handle") when the worker exits due to context cancellation, ensuring tokens are properly returned and resource accounting remains accurate