### PR TITLE
Return token on context cancellation in worker

### DIFF
--- a/.buildkite/steps/assume-role.sh
+++ b/.buildkite/steps/assume-role.sh
@@ -8,7 +8,7 @@ set -eu
 echo "~~~ :buildkite::key::aws: Requesting an OIDC token for AWS from Buildkite"
 
 role_arn='arn:aws:iam::172840064832:role/pipeline-buildkite-kubernetes-stack-kubernetes-agent-stack'
-BUILDKITE_OIDC_TOKEN="$(buildkite-agent oidc request-token --audience sts.amazonaws.com)"
+BUILDKITE_OIDC_TOKEN="$(buildkite-agent oidc request-token --audience sts.amazonaws.com  --aws-session-tag organization_id,organization_slug,pipeline_slug)"
 
 echo "~~~ :aws: Assuming role using OIDC token"
 ASSUME_ROLE_RESPONSE="$(aws sts assume-role-with-web-identity \

--- a/.buildkite/steps/release.sh
+++ b/.buildkite/steps/release.sh
@@ -24,7 +24,7 @@ wget -qO- "${GHCH_URL}" > /usr/bin/ghch
 chmod +x /usr/bin/ghch
 
 echo --- :git: Determining release version from tags
-# ensure we remove leading `v`
+# ensure we remove the leading `v`
 version="${BUILDKITE_TAG#v}"
 # put it back
 tag="v${version}"

--- a/internal/controller/limiter/limiter.go
+++ b/internal/controller/limiter/limiter.go
@@ -252,6 +252,7 @@ func (l *Limiter) worker(ctx context.Context) {
 		waitingForWorkGauge.Inc()
 		select {
 		case <-ctx.Done():
+			l.tryReturnToken("Handle")
 			return
 
 		case <-l.newWork:


### PR DESCRIPTION
Adds a call to l.tryReturnToken("Handle") when the worker context is cancelled to ensure tokens are properly returned and resource accounting remains accurate

Applies to same fix presented in `main` on commit 94325b0