### PR TITLE
Fix monitor jobs handled metric

### DIFF
--- a/internal/controller/monitor/metrics.go
+++ b/internal/controller/monitor/metrics.go
@@ -50,16 +50,28 @@ var (
 		Name:      "jobs_filtered_out_total",
 		Help:      "Count of jobs that didn't match the configured agent tags",
 	})
-	jobHandlerCallsCounter = promauto.NewCounter(prometheus.CounterOpts{
+	jobsHandledCounter = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: promNamespace,
 		Subsystem: promSubsystem,
 		Name:      "jobs_handled_total",
 		Help:      "Count of jobs that were passed to the next handler in the chain",
 	})
+	jobsHandledErrorsCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: promSubsystem,
+		Name:      "jobs_handled_errors_total",
+		Help:      "Count of jobs that were passed to the next handler in the chain but the handler returned an error",
+	})
+	jobHandlerCallsCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: promSubsystem,
+		Name:      "job_handler_calls_total",
+		Help:      "Count of calls to the next handler",
+	})
 	jobHandlerErrorCounter = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: promNamespace,
 		Subsystem: promSubsystem,
 		Name:      "job_handler_errors_total",
-		Help:      "Count of jobs that weren't scheduled because the next handler in the chain returned an error",
+		Help:      "Count of calls to the next handler where the call returned an error",
 	})
 )

--- a/internal/controller/monitor/monitor.go
+++ b/internal/controller/monitor/monitor.go
@@ -208,6 +208,7 @@ func (m *Monitor) passJobsToNextHandler(
 		zap.Int("job-count", len(filteredJobs)),
 	)
 	jobHandlerCallsCounter.Inc()
+	jobsHandledCounter.Add(float64(len(filteredJobs)))
 
 	if err := handler.HandleMany(ctx, filteredJobs); err != nil {
 		if ctx.Err() != nil {
@@ -215,5 +216,6 @@ func (m *Monitor) passJobsToNextHandler(
 		}
 		m.logger.Error("failed to create jobs", zap.Error(err))
 		jobHandlerErrorCounter.Inc()
+		jobsHandledErrorsCounter.Add(float64(len(filteredJobs)))
 	}
 }


### PR DESCRIPTION
### What
Fix the monitor metrics to do with jobs being passed to the next handler. 
Add new metrics that have the same values as the current metrics.

### Huh?
`buildkite_monitor_jobs_handled_total` is described as "Count of jobs that were passed to the next handler in the chain", and incremented for every call to the next handler. This was correct when each job was passed in an individual `Handle` call, but for a while now (0.28 betas) the limiter has received batches of jobs with `HandleMany`. There's a similar issue for errors counts.