### PR TITLE
PS-1049 add branch-build annotation to pods

### DIFF
--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -14,6 +14,7 @@ const (
 	UUIDLabel                             = "buildkite.com/job-uuid"
 	ControllerIDLabel                     = "buildkite.com/controller-id"
 	BuildURLAnnotation                    = "buildkite.com/build-url"
+	BuildBranchAnnotation                 = "buildkite.com/build-branch"
 	JobURLAnnotation                      = "buildkite.com/job-url"
 	PriorityAnnotation                    = "buildkite.com/job-priority"
 	DefaultNamespace                      = "default"

--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -300,6 +300,8 @@ func (w *worker) Build(podSpec *corev1.PodSpec, skipCheckout bool, inputs buildI
 
 	buildURL := inputs.envMap["BUILDKITE_BUILD_URL"]
 	kjob.Annotations[config.BuildURLAnnotation] = buildURL
+	buildBranch := inputs.envMap["BUILDKITE_BRANCH"]
+	kjob.Annotations[config.BuildBranchAnnotation] = buildBranch
 	jobURL, err := w.jobURL(inputs.uuid, buildURL)
 	if err != nil {
 		w.logger.Warn("could not parse BuildURL when annotating with JobURL", zap.String("buildURL", buildURL))


### PR DESCRIPTION
### Description
Customer request: enables querying OTEL traces by branch name. This allows distinguishing between test failures on main branch (which is not usually good) vs WIP branches (which is expected).

The OTEL collector automatically picks up pod annotations, so this will make branch information available in traces alongside existing build-url annotation.

### Context
Support and https://github.com/buildkite/agent-stack-k8s/issues/671

### Changes
Added BuildBranchAnnotation constant in internal/controller/config/config.go
Set annotation in internal/controller/scheduler/scheduler.go following existing pattern

### Deployment
Safe

### Rollback
Safe to rollback
