### PR TITLE
Fix the Grafana dashboard installation

### DIFF
--- a/charts/agent-stack-k8s/templates/grafana-dashboard.yaml.tpl
+++ b/charts/agent-stack-k8s/templates/grafana-dashboard.yaml.tpl
@@ -1,6 +1,7 @@
 {{ if .Values.deployGrafanaDashboard }}
 apiVersion: v1
 kind: ConfigMap
+metadata:
   name: {{ include "agent-stack-k8s.fullname" . }}-grafana-dashboard
   namespace: {{ .Release.Namespace }}
   labels:
@@ -653,7 +654,7 @@ data:
               "expr": "sum by(reason) (rate(buildkite_limiter_job_handler_errors_total{namespace=~\"$NAMESPACE\", pod=~\"$POD\"}[$__rate_interval]))",
               "hide": false,
               "instant": false,
-              "legendFormat": "Error from deduper - {{reason}}",
+              "legendFormat": "Error from deduper - {{"{{"}}reason{{"}}"}}",
               "range": true,
               "refId": "B"
             }
@@ -1434,7 +1435,7 @@ data:
               "expr": "sum by (reason) (rate(buildkite_scheduler_job_create_errors_total{namespace=~\"$NAMESPACE\", pod=~\"$POD\"}[$__rate_interval]))",
               "hide": false,
               "instant": false,
-              "legendFormat": "Create error - {{reason}}",
+              "legendFormat": "Create error - {{"{{"}}reason{{"}}"}}",
               "range": true,
               "refId": "C"
             },


### PR DESCRIPTION
### What

* Escape Go templating within the Go template
* Add missing `metadata:` line

### Why

Helm charts are Go templates. Grafana also uses Go template syntax for variables in things like timeseries names in the legend. We can work around nested templating syntax by using more of it.

Also somehow the `metadata:` line went missing.