### PR TITLE
Stacks API client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Khan/genqlient v0.8.1
 	github.com/buildkite/agent/v3 v3.103.1
 	github.com/buildkite/go-buildkite/v3 v3.13.0
-	github.com/buildkite/roko v1.3.1
+	github.com/buildkite/roko v1.4.0
 	github.com/distribution/reference v0.6.0
 	github.com/go-playground/locales v0.14.1
 	github.com/go-playground/universal-translator v0.18.1

--- a/go.sum
+++ b/go.sum
@@ -128,8 +128,8 @@ github.com/buildkite/go-pipeline v0.15.0 h1:ae/TEXC/4HhajbED2vKcRL5vZTtb9C71cajz
 github.com/buildkite/go-pipeline v0.15.0/go.mod h1:VE37qY3X5pmAKKUMoDZvPsHOQuyakB9cmXj9Qn6QasA=
 github.com/buildkite/interpolate v0.1.5 h1:v2Ji3voik69UZlbfoqzx+qfcsOKLA61nHdU79VV+tPU=
 github.com/buildkite/interpolate v0.1.5/go.mod h1:dHnrwHew5O8VNOAgMDpwRlFnhL5VSN6M1bHVmRZ9Ccc=
-github.com/buildkite/roko v1.3.1 h1:t7K30ceLLYn6k7hQP4oq1c7dVlhgD5nRcuSRDEEnY1s=
-github.com/buildkite/roko v1.3.1/go.mod h1:23R9e6nHxgedznkwwfmqZ6+0VJZJZ2Sg/uVcp2cP46I=
+github.com/buildkite/roko v1.4.0 h1:DxixoCdpNqxu4/1lXrXbfsKbJSd7r1qoxtef/TT2J80=
+github.com/buildkite/roko v1.4.0/go.mod h1:0vbODqUFEcVf4v2xVXRfZZRsqJVsCCHTG/TBRByGK4E=
 github.com/buildkite/shellwords v1.0.0 h1:NqZ4Ynp0dar6ACdP5X2RwI8BnNSvuKFf+2StuJl8tjM=
 github.com/buildkite/shellwords v1.0.0/go.mod h1:h/h4NjidF4MJARI+cfAmA/GFChSdroL1GOJXD68s6qU=
 github.com/cenkalti/backoff v1.1.1-0.20171020064038-309aa717adbf h1:yxlp0s+Sge9UsKEK0Bsvjiopb9XRk+vxylmZ9eGBfm8=

--- a/internal/stacksapi/client.go
+++ b/internal/stacksapi/client.go
@@ -1,0 +1,354 @@
+package stacksapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"time"
+
+	"github.com/buildkite/agent-stack-k8s/v2/internal/version"
+	"github.com/buildkite/roko"
+)
+
+// Client is a Buildkite Stacks API client.
+type Client struct {
+	baseURL    *url.URL
+	userAgent  string
+	authHeader string
+
+	logger          *slog.Logger
+	logHTTPPayloads bool
+
+	httpClient  *http.Client
+	retrierOpts []roko.RetrierOpt
+}
+
+func urlMustParse(u string) *url.URL {
+	parsed, err := url.Parse(u)
+	if err != nil {
+		panic(err)
+	}
+	return parsed
+}
+
+type ClientOpt func(*Client) error
+
+const (
+	DefaultBaseURL = "https://agent.buildkite.com/v3/"
+	DefaultQueue   = "_default"
+)
+
+var (
+	DefaultRetrierOptions = []roko.RetrierOpt{
+		roko.WithMaxAttempts(5),
+		roko.WithStrategy(roko.ExponentialSubsecond(1 * time.Second)),
+		roko.WithJitterRange(500*time.Millisecond, 1*time.Second),
+	}
+
+	defaultUserAgent = "agent-stack-k8s/" + version.Version()
+)
+
+// WithLogger sets the [*slog.Logger] for the API client. The default is a [slog.Logger] using the [slog.DiscardHandler] handler.
+func WithLogger(logger *slog.Logger) ClientOpt {
+	return func(c *Client) error {
+		c.logger = logger
+		return nil
+	}
+}
+
+// LogHTTPRequestPayloads instructs the client to log all HTTP request payloads. Note that this may log sensitive information,
+// and should be used with caution
+func LogHTTPPayloads() ClientOpt {
+	return func(c *Client) error {
+		c.logHTTPPayloads = true
+		return nil
+	}
+}
+
+// WithBaseURL sets the base URL for the API client, overriding [DefaultBaseURL]
+func WithBaseURL(baseURL *url.URL) ClientOpt {
+	return func(c *Client) error {
+		c.baseURL = baseURL
+		return nil
+	}
+}
+
+// PrependToUserAgent adds a prefix to the User-Agent header for the API client. Note that overriding of the user-agent
+// is not supported (though can probably be worked around).
+func PrependToUserAgent(prefix string) ClientOpt {
+	return func(c *Client) error {
+		c.userAgent = prefix + " " + c.userAgent
+		return nil
+	}
+}
+
+// WithHTTPClient sets the HTTP client for the API client, overriding [http.DefaultClient].
+func WithHTTPClient(httpClient *http.Client) ClientOpt {
+	return func(c *Client) error {
+		c.httpClient = httpClient
+		return nil
+	}
+}
+
+// WithRetrierOptions sets the default retrier options for the API client. These can be overridden per-request by using the [WithRetrier] RequestOpt.
+func WithRetrierOptions(opts ...roko.RetrierOpt) ClientOpt {
+	return func(c *Client) error {
+		c.retrierOpts = opts
+		return nil
+	}
+}
+
+// NewClient creates a new API client with the given token and options. Note that the token must be a Buildkite Cluster Token,
+// and that REST/GraphQL API tokens will not work.ql
+func NewClient(apiToken string, opts ...ClientOpt) (*Client, error) {
+	client := &Client{
+		httpClient:  http.DefaultClient,
+		baseURL:     urlMustParse(DefaultBaseURL),
+		userAgent:   defaultUserAgent,
+		logger:      slog.New(slog.DiscardHandler),
+		authHeader:  fmt.Sprintf("Token %s", apiToken),
+		retrierOpts: DefaultRetrierOptions,
+	}
+
+	for _, opt := range opts {
+		if err := opt(client); err != nil {
+			return nil, err
+		}
+	}
+
+	return client, nil
+}
+
+type StackAPIRequest struct {
+	*http.Request
+
+	retrier   *roko.Retrier
+	bodyBytes []byte
+}
+
+// resetBody recreates the request body from the stored bytes for retry attempts
+func (r *StackAPIRequest) resetBody() {
+	r.Body = io.NopCloser(bytes.NewReader(r.bodyBytes))
+}
+
+type RequestOption func(*StackAPIRequest) error
+
+// WithRetrier sets the retrier for the request, overriding the default retrier belonging to the [Client].
+func WithRetrier(retrier *roko.Retrier) RequestOption {
+	return func(r *StackAPIRequest) error {
+		r.retrier = retrier
+		return nil
+	}
+}
+
+// newRequest creates a new API request suitable for dispatch to the Buildkite Stacks API with the given context, method, path, and body.
+func (c *Client) newRequest(ctx context.Context, method, path string, body any, opts ...RequestOption) (*StackAPIRequest, error) {
+	fullURL := c.baseURL.ResolveReference(&url.URL{Path: path})
+
+	var bodyBytes []byte
+	if body != nil {
+		var err error
+		bodyBytes, err = json.Marshal(body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to encode request body: %w", err)
+		}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, fullURL.String(), bytes.NewReader(bodyBytes))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("User-Agent", c.userAgent)
+	req.Header.Set("Authorization", c.authHeader)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+
+	logger := c.logger.With(
+		"method", req.Method,
+		"url", req.URL,
+	)
+
+	logger.DebugContext(ctx, "created request")
+
+	stackReq := &StackAPIRequest{
+		Request:   req,
+		retrier:   roko.NewRetrier(c.retrierOpts...),
+		bodyBytes: bodyBytes,
+	}
+
+	for _, opt := range opts {
+		err := opt(stackReq)
+		if err != nil {
+			return nil, fmt.Errorf("failed to apply request option: %w", err)
+		}
+	}
+
+	return stackReq, nil
+}
+
+// do performs the given *StackAPIRequest and returns the HTTP response, unmarshalling the body into val.
+func (c *Client) do(ctx context.Context, req *StackAPIRequest, val any) (*http.Response, error) {
+	resp, err := c.doWithRetry(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := c.processResponse(ctx, resp, val); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// doWithRetry handles the retry logic for HTTP requests
+func (c *Client) doWithRetry(ctx context.Context, req *StackAPIRequest) (*http.Response, error) {
+	logger := c.logger.With(
+		"method", req.Method,
+		"url", req.URL.String(),
+	)
+
+	return roko.DoFunc(ctx, req.retrier, func(r *roko.Retrier) (*http.Response, error) {
+		req.resetBody()
+
+		sendRequestLogger := c.prepareRequestLogger(req, logger)
+		sendRequestLogger.DebugContext(ctx, "sending request")
+
+		resp, err := c.httpClient.Do(req.Request)
+		if err != nil {
+			return nil, err
+		}
+
+		logger := c.logger.With("response_status", resp.StatusCode)
+
+		responseLogger := c.prepareResponseLogger(resp, logger)
+		responseLogger.DebugContext(ctx, "received response")
+
+		if err := c.handleResponseError(ctx, resp, r, logger); err != nil {
+			return nil, err
+		}
+
+		return resp, nil
+	})
+}
+
+// handleResponseError processes error responses and determines retry behavior
+func (c *Client) handleResponseError(ctx context.Context, resp *http.Response, r *roko.Retrier, logger *slog.Logger) error {
+	err := checkResponse(resp)
+	if err != nil {
+		var errResp *ErrorResponse
+		if errors.As(err, &errResp) {
+			if errResp.IsRetryableStatus() {
+				logger = logger.With("retry_state", r.String())
+			} else {
+				r.Break()
+			}
+
+			logger.DebugContext(ctx, "request failed", "error", err)
+			return err
+		}
+
+		logger.DebugContext(ctx, "request errored", "error", err)
+		return err
+	}
+	return nil
+}
+
+// prepareRequestLogger sets up logging with optional request dump
+func (c *Client) prepareRequestLogger(req *StackAPIRequest, logger *slog.Logger) *slog.Logger {
+	if !c.logHTTPPayloads {
+		return logger
+	}
+
+	reqDump, err := httputil.DumpRequestOut(req.Request, true)
+	if err != nil {
+		logger.Warn("Failed to dump request. Log won't include request body", "error", err)
+		return logger
+	}
+
+	return logger.With("request", string(reqDump))
+}
+
+// processResponse handles response body reading and JSON unmarshaling
+func (c *Client) processResponse(ctx context.Context, resp *http.Response, val any) error {
+	if val == nil {
+		return nil
+	}
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response body: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if err := json.Unmarshal(bodyBytes, val); err != nil {
+		return fmt.Errorf("failed to decode response body: %w", err)
+	}
+
+	return nil
+}
+
+func (c *Client) prepareResponseLogger(resp *http.Response, logger *slog.Logger) *slog.Logger {
+	if !c.logHTTPPayloads {
+		return logger
+	}
+
+	respDump, err := httputil.DumpResponse(resp, true)
+	if err != nil {
+		logger.Warn("Failed to dump response. Log won't include response body", "error", err)
+		return logger
+	}
+
+	return logger.With("response", string(respDump))
+}
+
+// ErrorResponse provides a message.
+type ErrorResponse struct {
+	Response *http.Response `json:"-"`       // HTTP response that caused this error
+	RawBody  []byte         `json:"-"`       // Raw Response Body
+	Message  string         `json:"message"` // Error message from Buildkite API
+}
+
+func (r *ErrorResponse) Error() string {
+	return fmt.Sprintf("%v %v: %d %v",
+		r.Response.Request.Method, r.Response.Request.URL,
+		r.Response.StatusCode, r.Message)
+}
+
+func (r *ErrorResponse) IsRetryableStatus() bool {
+	switch {
+	case r.Response.StatusCode >= 500:
+		return true
+	case r.Response.StatusCode == http.StatusTooManyRequests:
+		return true
+	default:
+		return false
+	}
+}
+
+func checkResponse(r *http.Response) error {
+	if c := r.StatusCode; 200 <= c && c <= 299 {
+		return nil
+	}
+
+	errorResponse := &ErrorResponse{Response: r}
+
+	data, err := io.ReadAll(r.Body)
+	if err != nil {
+		return fmt.Errorf("response failed with error %w, but reading response body failed with error %w", errorResponse, err)
+	}
+	errorResponse.RawBody = data
+
+	err = json.Unmarshal(data, errorResponse)
+	if err != nil {
+		return fmt.Errorf("response failed with error %w, but parsing response body JSON failed with error: %w. Raw body of error was: %q", errorResponse, err, string(data))
+	}
+	return errorResponse
+}

--- a/internal/stacksapi/client_test.go
+++ b/internal/stacksapi/client_test.go
@@ -1,0 +1,197 @@
+package stacksapi
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/buildkite/agent-stack-k8s/v2/internal/version"
+	"github.com/buildkite/roko"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestNewClient(t *testing.T) {
+	t.Parallel()
+	t.Run("creates client with defaults", func(t *testing.T) {
+		t.Parallel()
+		client, err := NewClient("test-token")
+		if err != nil {
+			t.Fatalf(`NewClient("test-token") error = %v, expected nil`, err)
+		}
+
+		if client.baseURL.String() != DefaultBaseURL {
+			t.Errorf("client.BaseURL.String() = %q, expected %q", client.baseURL.String(), DefaultBaseURL)
+		}
+
+		expectedUA := "agent-stack-k8s/" + version.Version()
+		if client.userAgent != expectedUA {
+			t.Errorf("client.userAgent = %s, expected %s", client.userAgent, expectedUA)
+		}
+
+		expectedAuth := "Token test-token"
+		if client.authHeader != expectedAuth {
+			t.Errorf("client.authHeader = %s, expected %s", client.authHeader, expectedAuth)
+		}
+	})
+
+	t.Run("applies client options", func(t *testing.T) {
+		t.Parallel()
+		customURL := urlMustParse("https://api.example.com/")
+		customClient := &http.Client{Timeout: 10 * time.Second}
+		logger := slog.New(slog.NewTextHandler(nil, nil))
+
+		opts := []ClientOpt{
+			WithBaseURL(customURL),
+			WithHTTPClient(customClient),
+			WithLogger(logger),
+			PrependToUserAgent("custom-agent"),
+		}
+
+		client, err := NewClient("test-token", opts...)
+		if err != nil {
+			t.Fatalf(`NewClient("test-token", opts...) error = %v, expected nil`, err)
+		}
+
+		if client.baseURL.String() != customURL.String() {
+			t.Errorf("client.baseURL.String() = %q, expected %q", client.baseURL.String(), customURL.String())
+		}
+
+		if diff := cmp.Diff(client.httpClient, customClient); diff != "" {
+			t.Error("client.httpClient mismatch (-want +got):\n" + diff)
+		}
+
+		expectedUA := "custom-agent agent-stack-k8s/" + version.Version()
+		if client.userAgent != expectedUA {
+			t.Errorf("client.userAgent = %q, expected %q", client.userAgent, expectedUA)
+		}
+	})
+}
+
+func TestNewRequest(t *testing.T) {
+	t.Parallel()
+	client, err := NewClient("test-token")
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	t.Run("creates request with proper headers", func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+		req, err := client.newRequest(ctx, "GET", "test", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if req.Method != "GET" {
+			t.Errorf("req.Method = %s, expected GET", req.Method)
+		}
+
+		expectedURL := "https://agent.buildkite.com/v3/test"
+		if req.URL.String() != expectedURL {
+			t.Errorf("req.URL.String() = %s, expected %s", req.URL.String(), expectedURL)
+		}
+
+		if req.Header.Get("Authorization") != "Token test-token" {
+			t.Errorf("req.Header.Get(\"Authorization\") = %q, expected %q", req.Header.Get("Authorization"), "Token test-token")
+		}
+
+		if req.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("req.Header.Get(\"Content-Type\") = %q, expected %q", req.Header.Get("Content-Type"), "application/json")
+		}
+
+		expectedUA := "agent-stack-k8s/" + version.Version()
+		if req.Header.Get("User-Agent") != expectedUA {
+			t.Errorf("req.Header.Get(\"User-Agent\") = %s, expected %s", req.Header.Get("User-Agent"), expectedUA)
+		}
+	})
+
+	t.Run("encodes JSON body", func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+		body := map[string]string{"key": "value"}
+
+		req, err := client.newRequest(ctx, "POST", "test", body)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		jsonBytes, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("failed to read request body: %v", err)
+		}
+
+		expectedJSON := `{"key":"value"}`
+		if string(jsonBytes) != expectedJSON {
+			t.Errorf("JSON body = %q, expected %q", string(jsonBytes), expectedJSON)
+		}
+	})
+
+	t.Run("applies request options", func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+		customRetrier := roko.NewRetrier(roko.WithMaxAttempts(1))
+
+		req, err := client.newRequest(ctx, "GET", "test", nil, WithRetrier(customRetrier))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if req.retrier != customRetrier {
+			t.Errorf("req.retrier = %p, expected %p", req.retrier, customRetrier)
+		}
+	})
+}
+
+func TestErrorResponse(t *testing.T) {
+	t.Parallel()
+	t.Run("formats error message correctly", func(t *testing.T) {
+		t.Parallel()
+		resp := &http.Response{
+			StatusCode: 404,
+			Request: &http.Request{
+				Method: "GET",
+				URL:    urlMustParse("https://api.example.com/test"),
+			},
+		}
+
+		errResp := &ErrorResponse{
+			Response: resp,
+			Message:  "Not found",
+		}
+
+		expected := "GET https://api.example.com/test: 404 Not found"
+		if errResp.Error() != expected {
+			t.Errorf("errResp.Error() = %q, expected %q", errResp.Error(), expected)
+		}
+	})
+
+	t.Run("identifies retryable status codes", func(t *testing.T) {
+		t.Parallel()
+		testCases := []struct {
+			statusCode int
+			retryable  bool
+		}{
+			{200, false},
+			{400, false},
+			{404, false},
+			{500, true},
+			{502, true},
+			{503, true},
+			{429, true},
+		}
+
+		for _, tc := range testCases {
+			errResp := &ErrorResponse{
+				Response: &http.Response{StatusCode: tc.statusCode},
+			}
+
+			if errResp.IsRetryableStatus() != tc.retryable {
+				t.Errorf("status code %d: IsRetryableStatus() = %v, expected %v",
+					tc.statusCode, errResp.IsRetryableStatus(), tc.retryable)
+			}
+		}
+	})
+}

--- a/internal/stacksapi/doc.go
+++ b/internal/stacksapi/doc.go
@@ -1,0 +1,2 @@
+// The stacksapi package implements an API client for the Buildkite Stacks API.
+package stacksapi

--- a/internal/stacksapi/example/main.go
+++ b/internal/stacksapi/example/main.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+
+	"github.com/buildkite/agent-stack-k8s/v2/internal/stacksapi"
+)
+
+func main() {
+	clusterToken := os.Getenv("BUILDKITE_CLUSTER_TOKEN")
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	client, err := stacksapi.NewClient(clusterToken,
+		stacksapi.WithLogger(logger),
+		stacksapi.LogHTTPPayloads(),
+	)
+	if err != nil {
+		logger.Error("Failed to create Stacks API client", "error", err)
+		os.Exit(1)
+	}
+
+	stack, err := client.RegisterStack(context.Background(), stacksapi.RegisterStackRequest{
+		Key:      "example-stack",
+		Type:     stacksapi.StackTypeCustom,
+		QueueKey: stacksapi.DefaultQueue,
+		Metadata: map[string]string{
+			"test": "true",
+		},
+	})
+	if err != nil {
+		logger.Error("Failed to register stack", "error", err)
+		os.Exit(1)
+	}
+
+	logger.Info("registered stack", "stack", stack)
+}

--- a/internal/stacksapi/register.go
+++ b/internal/stacksapi/register.go
@@ -1,0 +1,46 @@
+package stacksapi
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// RegisterStackRequest is the input type for [RegisterStack]. All of its fields are required.
+type RegisterStackRequest struct {
+	Key      string            `json:"key,omitempty"`       // The key to call the stack. Required.
+	Type     StackType         `json:"type,omitempty"`      // A type for the stack. Required.
+	QueueKey string            `json:"queue_key,omitempty"` // The key of a queue for the stack to listen to. Required
+	Metadata map[string]string `json:"metadata"`            // Key-value metadata to associate with the queue. Required, but can be empty
+}
+
+// RegisterStackResponse is the output type for [RegisterStack]. It contains all the information about a registered stack
+type RegisterStackResponse struct {
+	ID               string            `json:"id"`
+	OrganizationUUID string            `json:"organization_uuid"`
+	ClusterQueueKey  string            `json:"cluster_queue_key"`
+	Key              string            `json:"key"`
+	Type             StackType         `json:"type"`
+	Metadata         map[string]string `json:"metadata"`
+	LastConnectedOn  *time.Time        `json:"last_connected_on"`
+	State            StackState        `json:"state"`
+}
+
+// RegisterStack registers a new stack with the Buildkite Stacks API. A stack with the same key can safely be
+// re-registered as many times as necessary.
+func (c *Client) RegisterStack(ctx context.Context, body RegisterStackRequest, opts ...RequestOption) (RegisterStackResponse, error) {
+	req, err := c.newRequest(ctx, http.MethodPost, "stacks/register", body, opts...)
+	if err != nil {
+		return RegisterStackResponse{}, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	var stack RegisterStackResponse
+	resp, err := c.do(ctx, req, &stack)
+	if err != nil {
+		return RegisterStackResponse{}, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	return stack, nil
+}

--- a/internal/stacksapi/register_test.go
+++ b/internal/stacksapi/register_test.go
@@ -1,0 +1,104 @@
+package stacksapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestRegisterStack(t *testing.T) {
+	t.Parallel()
+	t.Run("successful registration", func(t *testing.T) {
+		t.Parallel()
+		server, client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			verifyAuthAndMethod(t, r, "POST", "/stacks/register")
+
+			// Verify request body
+			var params RegisterStackRequest
+			if err := json.NewDecoder(r.Body).Decode(&params); err != nil {
+				t.Fatalf("failed to decode request body: %v", err)
+			}
+
+			expectedParams := RegisterStackRequest{
+				Key:      "test-stack",
+				Type:     StackTypeCustom,
+				QueueKey: "test-queue",
+				Metadata: map[string]string{"env": "test"},
+			}
+
+			if diff := cmp.Diff(expectedParams, params); diff != "" {
+				t.Errorf("request params mismatch (-want +got):\n%s", diff)
+			}
+
+			// Return mock response
+			response := RegisterStackResponse{
+				ID:               "stack-123",
+				OrganizationUUID: "org-456",
+				ClusterQueueKey:  "test-queue",
+				Key:              "test-stack",
+				Type:             StackTypeCustom,
+				Metadata:         map[string]string{"env": "test"},
+				LastConnectedOn:  nil,
+				State:            StackStateConnected,
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(response)
+		})
+		defer server.Close()
+
+		ctx := context.Background()
+		params := RegisterStackRequest{
+			Key:      "test-stack",
+			Type:     StackTypeCustom,
+			QueueKey: "test-queue",
+			Metadata: map[string]string{"env": "test"},
+		}
+
+		stack, err := client.RegisterStack(ctx, params)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		expected := RegisterStackResponse{
+			ID:               "stack-123",
+			OrganizationUUID: "org-456",
+			ClusterQueueKey:  "test-queue",
+			Key:              "test-stack",
+			Type:             StackTypeCustom,
+			Metadata:         map[string]string{"env": "test"},
+			State:            StackStateConnected,
+		}
+
+		if diff := cmp.Diff(expected, stack); diff != "" {
+			t.Errorf("stack mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("handles server error", func(t *testing.T) {
+		t.Parallel()
+		server, client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			respondWithError(w, http.StatusInternalServerError, "Internal server error")
+		})
+		defer server.Close()
+
+		ctx := context.Background()
+		params := RegisterStackRequest{
+			Key:      "test-stack",
+			Type:     StackTypeCustom,
+			QueueKey: "test-queue",
+			Metadata: map[string]string{},
+		}
+
+		_, err := client.RegisterStack(ctx, params)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !errorIsStatusCode(err, 500) {
+			t.Errorf("errorIsStatusCode(err, 500) = false, expected true, err: %v", err)
+		}
+	})
+}

--- a/internal/stacksapi/retry_test.go
+++ b/internal/stacksapi/retry_test.go
@@ -1,0 +1,157 @@
+package stacksapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/buildkite/roko"
+)
+
+func TestRetryLogic(t *testing.T) {
+	t.Parallel()
+
+	t.Run("retries on transient errors", func(t *testing.T) {
+		cases := []struct {
+			name          string
+			responseCode  int
+			callCount     int
+			shouldSucceed bool
+		}{
+			{
+				name:          "500 Internal Server Error",
+				responseCode:  http.StatusInternalServerError,
+				callCount:     3, // Two failures then success
+				shouldSucceed: true,
+			},
+			{
+				name:          "429 Too Many Requests",
+				responseCode:  http.StatusTooManyRequests,
+				callCount:     3, // Two failures then success
+				shouldSucceed: true,
+			},
+			{
+				name:          "400 Bad Request",
+				responseCode:  http.StatusBadRequest,
+				callCount:     1, // One failure, no retries
+				shouldSucceed: false,
+			},
+			{
+				name:          "404 Not Found",
+				responseCode:  http.StatusNotFound,
+				callCount:     1, // One failure, no retries
+				shouldSucceed: false,
+			},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				callCount := 0
+				server, client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+					callCount++
+					if callCount < 3 {
+						// First two attempts fail with the given status code
+						respondWithError(w, tc.responseCode, "Something went wrong")
+					} else {
+						// Third attempt succeeds
+						w.WriteHeader(http.StatusOK)
+						_ = json.NewEncoder(w).Encode(map[string]string{"status": "success"})
+					}
+				})
+				defer server.Close()
+
+				ctx := context.Background()
+				req, err := client.newRequest(ctx, "POST", "test", map[string]string{"key": "value"})
+				if err != nil {
+					t.Fatalf("failed to create request: %v", err)
+				}
+
+				var response map[string]string
+				_, err = client.do(ctx, req, &response)
+				if tc.shouldSucceed {
+					if err != nil {
+						t.Fatalf("expected success after retries, got error: %v", err)
+					}
+				} else {
+					if err == nil {
+						t.Fatal("expected error, got nil")
+					}
+				}
+
+				if callCount != tc.callCount {
+					t.Errorf("callCount = %d, expected %d", callCount, tc.callCount)
+				}
+			})
+		}
+	})
+
+	t.Run("eventually gives up after max retries", func(t *testing.T) {
+		t.Parallel()
+		callCount := 0
+		server, client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			// Always return 500 to exhaust retries
+			respondWithError(w, http.StatusInternalServerError, "Persistent error")
+		})
+		defer server.Close()
+
+		ctx := context.Background()
+		req, err := client.newRequest(ctx, "POST", "test", map[string]string{"key": "value"})
+		if err != nil {
+			t.Fatalf("failed to create request: %v", err)
+		}
+
+		_, err = client.do(ctx, req, nil)
+		if err == nil {
+			t.Fatal("expected error after exhausting retries, got nil")
+		}
+
+		expectedCalls := 5 // Default max attempts
+		if callCount != expectedCalls {
+			t.Errorf("callCount = %d, expected %d (exhausted all retries)", callCount, expectedCalls)
+		}
+
+		if !strings.Contains(err.Error(), "500") {
+			t.Errorf("err.Error() = %v, expected to contain '500'", err)
+		}
+	})
+
+	t.Run("custom retrier configuration", func(t *testing.T) {
+		t.Parallel()
+		callCount := 0
+		server, client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			// Always fail to test max attempts
+			respondWithError(w, http.StatusInternalServerError, "Server error")
+		})
+		defer server.Close()
+
+		// Custom retrier with only 2 attempts
+		customRetrier := roko.NewRetrier(
+			roko.WithMaxAttempts(2),
+			roko.WithStrategy(roko.Constant(1*time.Millisecond)),
+			roko.WithSleepFunc(func(time.Duration) {}), // No sleep for fast test
+		)
+
+		ctx := context.Background()
+		req, err := client.newRequest(ctx, "POST", "test", map[string]string{"key": "value"},
+			WithRetrier(customRetrier),
+		)
+		if err != nil {
+			t.Fatalf("failed to create request: %v", err)
+		}
+
+		_, err = client.do(ctx, req, nil)
+		if err == nil {
+			t.Fatal("expected error after exhausting retries, got nil")
+		}
+
+		if callCount != 2 {
+			t.Errorf("callCount = %d, expected 2 (custom max attempts)", callCount)
+		}
+	})
+}

--- a/internal/stacksapi/test_helpers_test.go
+++ b/internal/stacksapi/test_helpers_test.go
@@ -1,0 +1,59 @@
+package stacksapi
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/buildkite/roko"
+)
+
+func setupTestServer(t *testing.T, handler http.HandlerFunc) (*httptest.Server, *Client) {
+	server := httptest.NewServer(handler)
+	serverURL, err := url.Parse(server.URL + "/")
+	if err != nil {
+		t.Fatalf("parsing test server url: %s", err)
+	}
+
+	retrierOpts := DefaultRetrierOptions
+	retrierOpts = append(retrierOpts, roko.WithSleepFunc(func(time.Duration) {}))
+	client, err := NewClient("test-token",
+		WithBaseURL(serverURL),
+		WithRetrierOptions(retrierOpts...),
+	)
+	if err != nil {
+		t.Fatalf("creating test client: %s", err)
+	}
+
+	return server, client
+}
+
+func verifyAuthAndMethod(t *testing.T, r *http.Request, expectedMethod, expectedPath string) {
+	if r.Method != expectedMethod {
+		t.Errorf("r.Method = %s, expected %s", r.Method, expectedMethod)
+	}
+	if r.URL.Path != expectedPath {
+		t.Errorf("r.URL.Path = %s, expected %s", r.URL.Path, expectedPath)
+	}
+	if auth := r.Header.Get("Authorization"); auth != "Token test-token" {
+		t.Errorf("r.Header.Get(\"Authorization\") = %s, expected %s", auth, "Token test-token")
+	}
+}
+
+func respondWithError(w http.ResponseWriter, statusCode int, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	_ = json.NewEncoder(w).Encode(map[string]string{"message": message})
+}
+
+func errorIsStatusCode(err error, statusCode int) bool {
+	var httpErr *ErrorResponse
+	if errors.As(err, &httpErr) {
+		return httpErr.Response.StatusCode == statusCode
+	}
+	return false
+}

--- a/internal/stacksapi/type.go
+++ b/internal/stacksapi/type.go
@@ -1,0 +1,23 @@
+package stacksapi
+
+// StackType enumerates a few broad categories of stack. Use of [StackTypeKubernetes] and [StackTypeElastic] are discouraged
+// for non-first-party stacks.
+type StackType string
+
+const (
+	StackTypeKubernetes StackType = "kubernetes" // Reserved for use by the first-party agent-stack-k8s
+	StackTypeElastic    StackType = "elastic"    // Reserved for use by the first-party elastic-stack-for-aws
+
+	// For use by custom stacks. If you're reading these docs and you don't work at buildkite, this is almost certainly the
+	// stack type you should be using, even if your stack is backed by Kubernetes
+	StackTypeCustom StackType = "custom"
+)
+
+// StackState enumerates the connection status of a stack
+type StackState string
+
+const (
+	StackStateConnected    StackState = "connected"
+	StackStateDisconnected StackState = "disconnected"
+	StackStateLost         StackState = "lost"
+)


### PR DESCRIPTION
This PR adds an (admittedly somewhat meaty) skeleton of an API client to interact with Buildkite's forthcoming Stacks API. The idea of the Stacks API is to have a dedicated and documented place for orchestrators like the k8s stack to interact with Buildkite.

At some point, we'll probably pull this package out of the k8s stack and into its own repo, but until we have a relatively stable API it'll probably remain in the internal folder of this repo.

This PR contains the meat and potatoes of the API client itself, including default retry policies etc, as well as a single endpoint method, which hits the `POST /stacks/register` endpoint.