### PR TITLE
Deregister endpoint

### DIFF
--- a/internal/stacksapi/client.go
+++ b/internal/stacksapi/client.go
@@ -150,7 +150,7 @@ func WithRetrier(retrier *roko.Retrier) RequestOption {
 
 // newRequest creates a new API request suitable for dispatch to the Buildkite Stacks API with the given context, method, path, and body.
 func (c *Client) newRequest(ctx context.Context, method, path string, body any, opts ...RequestOption) (*StackAPIRequest, error) {
-	fullURL := c.baseURL.ResolveReference(&url.URL{Path: path})
+	fullURL := c.baseURL.JoinPath(path)
 
 	var bodyBytes []byte
 	if body != nil {

--- a/internal/stacksapi/example/main.go
+++ b/internal/stacksapi/example/main.go
@@ -12,10 +12,7 @@ func main() {
 	clusterToken := os.Getenv("BUILDKITE_CLUSTER_TOKEN")
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
-	client, err := stacksapi.NewClient(clusterToken,
-		stacksapi.WithLogger(logger),
-		stacksapi.LogHTTPPayloads(),
-	)
+	client, err := stacksapi.NewClient(clusterToken, stacksapi.WithLogger(logger))
 	if err != nil {
 		logger.Error("Failed to create Stacks API client", "error", err)
 		os.Exit(1)
@@ -35,4 +32,13 @@ func main() {
 	}
 
 	logger.Info("registered stack", "stack", stack)
+
+	logger.Info("deregistering stack...")
+	err = client.DeregisterStack(context.Background(), stack.Key)
+	if err != nil {
+		logger.Error("Failed to deregister stack", "error", err)
+		os.Exit(1)
+	}
+
+	logger.Info("deregistered stack", "stack", stack)
 }

--- a/internal/stacksapi/register.go
+++ b/internal/stacksapi/register.go
@@ -47,7 +47,7 @@ func (c *Client) RegisterStack(ctx context.Context, body RegisterStackRequest, o
 
 // DeregisterStack informs the Buildkite Stacks API that a stack is exiting cleanly.
 func (c *Client) DeregisterStack(ctx context.Context, stackKey string, opts ...RequestOption) error {
-	path := fmt.Sprintf("stacks/%s/deregister", stackKey)
+	path := fmt.Sprintf("/stacks/%s/deregister", stackKey)
 	req, err := c.newRequest(ctx, http.MethodPost, path, nil, opts...)
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)

--- a/internal/stacksapi/register.go
+++ b/internal/stacksapi/register.go
@@ -45,8 +45,9 @@ func (c *Client) RegisterStack(ctx context.Context, body RegisterStackRequest, o
 	return stack, nil
 }
 
-func (c *Client) DeregisterStack(ctx context.Context, stackID string, opts ...RequestOption) error {
-	path := fmt.Sprintf("stacks/%s/deregister", stackID)
+// DeregisterStack informs the Buildkite Stacks API that a stack is exiting cleanly.
+func (c *Client) DeregisterStack(ctx context.Context, stackKey string, opts ...RequestOption) error {
+	path := fmt.Sprintf("stacks/%s/deregister", stackKey)
 	req, err := c.newRequest(ctx, http.MethodPost, path, nil, opts...)
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)

--- a/internal/stacksapi/register.go
+++ b/internal/stacksapi/register.go
@@ -38,9 +38,25 @@ func (c *Client) RegisterStack(ctx context.Context, body RegisterStackRequest, o
 	var stack RegisterStackResponse
 	resp, err := c.do(ctx, req, &stack)
 	if err != nil {
-		return RegisterStackResponse{}, fmt.Errorf("request failed: %w", err)
+		return RegisterStackResponse{}, fmt.Errorf("register stack: %w", err)
 	}
 	defer resp.Body.Close()
 
 	return stack, nil
+}
+
+func (c *Client) DeregisterStack(ctx context.Context, stackID string, opts ...RequestOption) error {
+	path := fmt.Sprintf("stacks/%s/deregister", stackID)
+	req, err := c.newRequest(ctx, http.MethodPost, path, nil, opts...)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.do(ctx, req, nil)
+	if err != nil {
+		return fmt.Errorf("deregister stack: %w", err)
+	}
+	defer resp.Body.Close()
+
+	return nil
 }

--- a/internal/stacksapi/register_test.go
+++ b/internal/stacksapi/register_test.go
@@ -33,7 +33,6 @@ func TestRegisterStack(t *testing.T) {
 				t.Errorf("request params mismatch (-want +got):\n%s", diff)
 			}
 
-			// Return mock response
 			response := RegisterStackResponse{
 				ID:               "stack-123",
 				OrganizationUUID: "org-456",
@@ -48,7 +47,7 @@ func TestRegisterStack(t *testing.T) {
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(response)
 		})
-		defer server.Close()
+		t.Cleanup(func() { server.Close() })
 
 		ctx := context.Background()
 		params := RegisterStackRequest{
@@ -83,9 +82,8 @@ func TestRegisterStack(t *testing.T) {
 		server, client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 			respondWithError(w, http.StatusInternalServerError, "Internal server error")
 		})
-		defer server.Close()
+		t.Cleanup(func() { server.Close() })
 
-		ctx := context.Background()
 		params := RegisterStackRequest{
 			Key:      "test-stack",
 			Type:     StackTypeCustom,

--- a/internal/stacksapi/register_test.go
+++ b/internal/stacksapi/register_test.go
@@ -76,30 +76,6 @@ func TestRegisterStack(t *testing.T) {
 			t.Errorf("stack mismatch (-want +got):\n%s", diff)
 		}
 	})
-
-	t.Run("handles server error", func(t *testing.T) {
-		t.Parallel()
-		server, client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
-			respondWithError(w, http.StatusInternalServerError, "Internal server error")
-		})
-		t.Cleanup(func() { server.Close() })
-
-		params := RegisterStackRequest{
-			Key:      "test-stack",
-			Type:     StackTypeCustom,
-			QueueKey: "test-queue",
-			Metadata: map[string]string{},
-		}
-
-		_, err := client.RegisterStack(t.Context(), params)
-		if err == nil {
-			t.Fatal("client.RegisterStack(t.Context(), params) = nil, expected error")
-		}
-
-		if !errorIsStatusCode(err, 500) {
-			t.Errorf("errorIsStatusCode(err, 500) = false, expected true, err: %v", err)
-		}
-	})
 }
 
 func TestDeregisterStack(t *testing.T) {
@@ -118,23 +94,6 @@ func TestDeregisterStack(t *testing.T) {
 		err := client.DeregisterStack(t.Context(), "stack-123")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
-		}
-	})
-
-	t.Run("handles server error", func(t *testing.T) {
-		t.Parallel()
-
-		server, client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
-			respondWithError(w, http.StatusInternalServerError, "Internal server error")
-		})
-		t.Cleanup(func() { server.Close() })
-
-		err := client.DeregisterStack(t.Context(), "stack-123")
-		if err == nil {
-			t.Fatal("expected error, got nil")
-		}
-		if !errorIsStatusCode(err, 500) {
-			t.Errorf("errorIsStatusCode(err, 500) = false, expected true, err: %v", err)
 		}
 	})
 }

--- a/internal/stacksapi/retry_test.go
+++ b/internal/stacksapi/retry_test.go
@@ -62,7 +62,7 @@ func TestRetryLogic(t *testing.T) {
 						_ = json.NewEncoder(w).Encode(map[string]string{"status": "success"})
 					}
 				})
-				defer server.Close()
+				t.Cleanup(func() { server.Close() })
 
 				ctx := context.Background()
 				req, err := client.newRequest(ctx, "POST", "test", map[string]string{"key": "value"})
@@ -97,7 +97,7 @@ func TestRetryLogic(t *testing.T) {
 			// Always return 500 to exhaust retries
 			respondWithError(w, http.StatusInternalServerError, "Persistent error")
 		})
-		defer server.Close()
+		t.Cleanup(func() { server.Close() })
 
 		ctx := context.Background()
 		req, err := client.newRequest(ctx, "POST", "test", map[string]string{"key": "value"})
@@ -128,7 +128,7 @@ func TestRetryLogic(t *testing.T) {
 			// Always fail to test max attempts
 			respondWithError(w, http.StatusInternalServerError, "Server error")
 		})
-		defer server.Close()
+		t.Cleanup(func() { server.Close() })
 
 		// Custom retrier with only 2 attempts
 		customRetrier := roko.NewRetrier(

--- a/internal/stacksapi/test_helpers_test.go
+++ b/internal/stacksapi/test_helpers_test.go
@@ -2,7 +2,6 @@ package stacksapi
 
 import (
 	"encoding/json"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -48,12 +47,4 @@ func respondWithError(w http.ResponseWriter, statusCode int, message string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(statusCode)
 	_ = json.NewEncoder(w).Encode(map[string]string{"message": message})
-}
-
-func errorIsStatusCode(err error, statusCode int) bool {
-	var httpErr *ErrorResponse
-	if errors.As(err, &httpErr) {
-		return httpErr.Response.StatusCode == statusCode
-	}
-	return false
 }


### PR DESCRIPTION
This PR mostly just adds a method that uses the `deregister` endpoint, but it also adds a couple of testing bits and bobs.