### PR TITLE
Register/deregister stacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 Brewfile.lock.json
 
+config.local.yaml
+
 .DS_Store
 .vscode
 

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -161,6 +161,11 @@ func AddConfigFlags(cmd *cobra.Command) {
 		false,
 		"Experimental - does not fully function yet. This experiment enables job reservation support for better job observability and scalable job fetching. If you try it, please let us know about your experiences by filing an issue on https://github.com/buildkite/agent-stack-k8s",
 	)
+	cmd.Flags().Bool(
+		"experimental-stacks-api-support",
+		false,
+		"Experimental - enables integration with the Buildkite Stacks API for interactions with the Buildkite control plane.",
+	)
 	cmd.Flags().Int(
 		"pagination-page-size",
 		config.DefaultPaginationPageSize,

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/jedib0t/go-pretty/v6 v6.6.8
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
+	github.com/samber/slog-zap/v2 v2.6.2
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.20.1
 	github.com/xeipuuv/gojsonschema v1.2.0
@@ -30,6 +31,8 @@ require (
 
 require (
 	github.com/DataDog/go-libddwaf/v4 v4.3.0 // indirect
+	github.com/samber/lo v1.47.0 // indirect
+	github.com/samber/slog-common v0.18.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.37.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -390,6 +390,12 @@ github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sagikazarmark/locafero v0.7.0 h1:5MqpDsTGNDhY8sGp0Aowyf0qKsPrhewaLSsFaodPcyo=
 github.com/sagikazarmark/locafero v0.7.0/go.mod h1:2za3Cg5rMaTMoG/2Ulr9AwtFaIppKXTRYnozin4aB5k=
+github.com/samber/lo v1.47.0 h1:z7RynLwP5nbyRscyvcD043DWYoOcYRv3mV8lBeqOCLc=
+github.com/samber/lo v1.47.0/go.mod h1:RmDH9Ct32Qy3gduHQuKJ3gW1fMHAnE/fAzQuf6He5cU=
+github.com/samber/slog-common v0.18.1 h1:c0EipD/nVY9HG5shgm/XAs67mgpWDMF+MmtptdJNCkQ=
+github.com/samber/slog-common v0.18.1/go.mod h1:QNZiNGKakvrfbJ2YglQXLCZauzkI9xZBjOhWFKS3IKk=
+github.com/samber/slog-zap/v2 v2.6.2 h1:IPHgVQjBfEwqu7fBxSxvvl+/E4b7TqAu/eispdQdv9M=
+github.com/samber/slog-zap/v2 v2.6.2/go.mod h1:bMOphuaRcThr+2X7vE4kFaqyr1lqGkc9Js95n9X6xaU=
 github.com/secure-systems-lab/go-securesystemslib v0.9.0 h1:rf1HIbL64nUpEIZnjLZ3mcNEL9NBPB0iuVjyxvq3LZc=
 github.com/secure-systems-lab/go-securesystemslib v0.9.0/go.mod h1:DVHKMcZ+V4/woA/peqr+L0joiRXbPpQ042GgJckkFgw=
 github.com/segmentio/asm v1.2.0 h1:9BQrFxC+YOHJlTlHGkTrFWf59nbL3XnCoFLTwDCI7ys=

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -106,6 +106,9 @@ type Config struct {
 	// Enable job reservation support - this feature is in-progress.
 	ExperimentalJobReservationSupport bool `json:"experimental-job-reservation-support" validate:"omitempty"`
 
+	// Enable using the stacks API - this feature is in progress.
+	ExperimentalStacksAPISupport bool `json:"experimental-stacks-api-support" validate:"omitempty"`
+
 	// These are only used for integration tests.
 	BuildkiteToken  string `json:"buildkite-token" validate:"omitempty"`
 	GraphQLEndpoint string `json:"graphql-endpoint" validate:"omitempty"`
@@ -146,6 +149,7 @@ func (c Config) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	enc.AddBool("prohibit-kubernetes-plugin", c.ProhibitKubernetesPlugin)
 	enc.AddBool("allow-pod-spec-patch-unsafe-command-modification", c.AllowPodSpecPatchUnsafeCmdMod)
 	enc.AddBool("experimental-job-reservation-support", c.ExperimentalJobReservationSupport)
+	enc.AddBool("experimental-stacks-api-support", c.ExperimentalStacksAPISupport)
 	if err := enc.AddArray("additional-redacted-vars", c.AdditionalRedactedVars); err != nil {
 		return err
 	}

--- a/internal/controller/monitor/monitor.go
+++ b/internal/controller/monitor/monitor.go
@@ -11,7 +11,6 @@ import (
 	"github.com/buildkite/agent-stack-k8s/v2/internal/controller/model"
 
 	"go.uber.org/zap"
-	"k8s.io/client-go/kubernetes"
 )
 
 // Monitor is responsible for polling Buildkite for jobs.
@@ -37,7 +36,7 @@ type Config struct {
 	QueryResetInterval   time.Duration
 }
 
-func New(logger *zap.Logger, k8s kubernetes.Interface, agentClient *api.AgentClient, cfg Config) (*Monitor, error) {
+func New(logger *zap.Logger, agentClient *api.AgentClient, cfg Config) (*Monitor, error) {
 	// Poll no more frequently than every 1s (please don't DoS us).
 	cfg.PollInterval = max(cfg.PollInterval, time.Second)
 

--- a/internal/stacksapi/client.go
+++ b/internal/stacksapi/client.go
@@ -148,6 +148,13 @@ func WithRetrier(retrier *roko.Retrier) RequestOption {
 	}
 }
 
+func WithNoRetry() RequestOption {
+	return WithRetrier(roko.NewRetrier(
+		roko.WithMaxAttempts(1),
+		roko.WithStrategy(roko.Constant(0)),
+	))
+}
+
 // newRequest creates a new API request suitable for dispatch to the Buildkite Stacks API with the given context, method, path, and body.
 func (c *Client) newRequest(ctx context.Context, method, path string, body any, opts ...RequestOption) (*StackAPIRequest, error) {
 	fullURL := c.baseURL.JoinPath(path)

--- a/justfile
+++ b/justfile
@@ -4,7 +4,7 @@ default:
 # Running the controller locally using production buildkite as backend.
 # This is sufficient for vast majority of issues.
 run *FLAGS:
-  go run ./... {{FLAGS}}
+  go run ./main.go {{FLAGS}}
 
 # Running the controller locally but with local bk/bk as the backend.
 # This is probably only useful for Buildkite employees.
@@ -19,7 +19,7 @@ run-with-local-bk:
   kubectl -n local-bk create secret generic buildkite-agent-token \
     --from-literal=BUILDKITE_AGENT_TOKEN='bkct_buildkite'
 
-  go run ./... --namespace local-bk --config=config.dev.yaml
+  go run ./main.go --namespace local-bk --config=config.dev.yaml
 
 test *FLAGS:
   #!/usr/bin/env bash


### PR DESCRIPTION
This PR adjusts the k8s stack to register itself as a stack on the buildkite backend, and deregister itself when it exits cleanly. if the controller is SIGKILLed or gets two SIGTERMs, the deregister call will be interrupted.