### PR TITLE
Add PodMonitor to deployment

### DIFF
--- a/charts/agent-stack-k8s/templates/grafana-dashboard.yaml.tpl
+++ b/charts/agent-stack-k8s/templates/grafana-dashboard.yaml.tpl
@@ -1,4 +1,4 @@
-{{ if .Values.deployGrafanaDashboard }}
+{{ if .Values.monitoring.deployGrafanaDashboard }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/agent-stack-k8s/templates/podmonitor.yaml.tpl
+++ b/charts/agent-stack-k8s/templates/podmonitor.yaml.tpl
@@ -1,0 +1,20 @@
+{{ if .Values.monitoring.podMonitor.deploy }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "agent-stack-k8s.fullname" . }}-podmonitor
+  namespace: {{ with .Values.monitoring.podMonitor.namespace }}{{ . }}{{ else }}{{ .Release.Namespace }}{{ end }}
+  labels:
+    app: {{ include "agent-stack-k8s.fullname" . }}
+spec:
+  jobLabel: app
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app: {{ include "agent-stack-k8s.fullname" . }}
+  podMetricsEndpoints:
+    - port: metrics 
+      {{ with .Values.monitoring.podMonitor.scrapeInterval }}interval: {{ . }}{{ end }}
+{{end}}

--- a/charts/agent-stack-k8s/values.schema.json
+++ b/charts/agent-stack-k8s/values.schema.json
@@ -32,10 +32,39 @@
       "title": "The image for the agent-stack-k8s controller",
       "examples": ["ghcr.io/buildkite/agent-stack-k8s/controller:latest"]
     },
-    "deployGrafanaDashboard": {
-      "type": "boolean",
-      "default": true,
-      "title": "When enabled, installs a Grafana dashboard definition using a ConfigMap"
+    "monitoring": {
+      "type": "object",
+      "title": "Monitoring-related properties",
+      "properties": {
+        "deployGrafanaDashboard": {
+          "type": "boolean",
+          "default": true,
+          "title": "When enabled, installs a Grafana dashboard definition using a ConfigMap"
+        },
+        "podMonitor": {
+          "type": "object",
+          "title": "PodMonitor resource properties",
+          "properties": {
+            "deploy": {
+              "type": "boolean",
+              "default": true,
+              "title": "When enabled, installs a PodMonitor resource (https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.PodMonitor) configured to scrape the controller pod metrics"
+            },
+            "namespace": {
+              "type": "string",
+              "default": "",
+              "title": "Alternative namespace to install the PodMonitor resource into. By default the same namespace as the Helm deployment is used.",
+              "examples": ["prometheus"]
+            },
+            "scrapeInterval": {
+              "type": "string",
+              "default": "",
+              "title": "A duration string that overrides the Prometheus scrape interval for this PodMonitor specifically",
+              "examples": ["1s", "5s", "10s", "15s"]
+            }
+          }
+        }
+      }
     },
     "nameOverride": {
       "type": "string",

--- a/charts/agent-stack-k8s/values.yaml
+++ b/charts/agent-stack-k8s/values.yaml
@@ -19,4 +19,7 @@ secretsMetadata: {}
 
 serviceAccountMetadata: {}
 
-deployGrafanaDashboard: true
+monitoring:
+  deployGrafanaDashboard: true
+  podMonitor:
+    deploy: true


### PR DESCRIPTION
### What

Deploy a `PodMonitor` resource with the stack.

### Why

Following on from the inclusion of a Grafana dashboard, we are able to include a resource that would configure Prometheus Operator to scrape the metrics automatically. The controller doesn't come with a `Service`, so a `ServiceMonitor` won't work, but Prometheus Operator can scrape an individual pod using the very similar `PodMonitor` kind.