### PR TITLE
PB-631 part 2: use Stack API to fail job

### DIFF
--- a/config.dev.yaml
+++ b/config.dev.yaml
@@ -7,6 +7,7 @@ agent-config:
   endpoint: http://agent.buildkite.localhost/v3
 
 experimental-job-reservation-support: true
+experimental-stacks-api-support: true
 
 pod-spec-patch:
   hostAliases:

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -222,6 +222,7 @@ func Run(
 	jobWatcher := scheduler.NewJobWatcher(
 		logger.Named("jobWatcher"),
 		k8sClient,
+		agentClient,
 		cfg,
 	)
 	if err := jobWatcher.RegisterInformer(ctx, informerFactory); err != nil {

--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -1091,14 +1091,6 @@ buildkite-agent-entrypoint kubernetes-bootstrap`,
 
 // failJob fails the job in Buildkite.
 func (w *worker) failJob(ctx context.Context, inputs buildInputs, message string) error {
-	// Need to fetch the agent token ourselves.
-	agentToken, err := fetchAgentToken(ctx, w.logger, w.client, w.cfg.Namespace, w.cfg.AgentTokenSecretName)
-	if err != nil {
-		w.logger.Error("fetching agent token from secret", zap.Error(err))
-		return err
-	}
-
-	opts := w.cfg.AgentConfig.ControllerOptions()
 	failureInfo := FailureInfo{
 		Message: message,
 		// In scheduler worker, often these failure are technically users error in YAML.
@@ -1106,11 +1098,29 @@ func (w *worker) failJob(ctx context.Context, inputs buildInputs, message string
 		// So using StackError is a temporary choice, subject to change
 		Reason: agent.SignalReasonStackError,
 	}
-	if err := acquireAndFail(ctx, w.logger, agentToken, w.cfg.JobPrefix, inputs.uuid, inputs.agentQueryRules, failureInfo, opts...); err != nil {
-		w.logger.Error("failed to acquire and fail the job on Buildkite", zap.Error(err))
-		schedulerBuildkiteJobFailErrorsCounter.Inc()
-		return err
+
+	if w.agentClient.UseStackAPI {
+		if err := w.agentClient.FailJob(ctx, inputs.uuid, failureInfo.Message); err != nil {
+			w.logger.Error("failed to fail the job via Buildkite Stack API", zap.Error(err))
+			schedulerBuildkiteJobFailErrorsCounter.Inc()
+			return err
+		}
+	} else {
+		// Need to fetch the agent token ourselves.
+		agentToken, err := fetchAgentToken(ctx, w.logger, w.client, w.cfg.Namespace, w.cfg.AgentTokenSecretName)
+		if err != nil {
+			w.logger.Error("fetching agent token from secret", zap.Error(err))
+			return err
+		}
+
+		opts := w.cfg.AgentConfig.ControllerOptions()
+		if err := acquireAndFail(ctx, w.logger, agentToken, w.cfg.JobPrefix, inputs.uuid, inputs.agentQueryRules, failureInfo, opts...); err != nil {
+			w.logger.Error("failed to acquire and fail the job on Buildkite", zap.Error(err))
+			schedulerBuildkiteJobFailErrorsCounter.Inc()
+			return err
+		}
 	}
+
 	schedulerBuildkiteJobFailsCounter.Inc()
 	return fmt.Errorf("%s", message)
 }


### PR DESCRIPTION
Use Stack API to fail job when Stack API feature flag is enabled. 

It's a bit tricky to make a clean PR for this due to the fact that old acquire and fail approach and the new fail by api approach have very different inputs. but I tried as I might to reduce the blast radius. 

I think we would need to have a new test job in CI eventually to test the feature-on situation. I can do that in a separated PR. 

But in the meantime, I've manually tested this in local. And it fails jobs flawlessly. 