### PR TITLE
PB-681: fix reservation support and pod_watcher ignoring reserved state

### DIFF
--- a/api/agent_client.go
+++ b/api/agent_client.go
@@ -71,8 +71,9 @@ func NewAgentClient(ctx context.Context, opts AgentClientOpts) (*AgentClient, er
 			Timeout:   60 * time.Second,
 			Transport: NewLogger(NewAuthedTransportWithToken(http.DefaultTransport, opts.Token)),
 		},
-		clusterID: opts.ClusterID,
-		queue:     opts.Queue,
+		clusterID:   opts.ClusterID,
+		queue:       opts.Queue,
+		reservation: opts.UseReservation,
 	}
 
 	if opts.UseStacksAPI {

--- a/api/job_states.go
+++ b/api/job_states.go
@@ -32,6 +32,8 @@ const (
 	JobStateRunning JobState = "running"
 	// The job is scheduled and waiting for an agent
 	JobStateScheduled JobState = "scheduled"
+	// The job is reserved.
+	JobStateReserved JobState = "reserved"
 	// The job was skipped
 	JobStateSkipped JobState = "skipped"
 	// The job timed out


### PR DESCRIPTION
The reservation support is entirely broken at the moment due to a misconfiguration on agent_client. 

pod_watcher is also incompatible with the reserved state. This PR fixes that. 