### PR TITLE
Monitoring tweaks

### DIFF
--- a/charts/agent-stack-k8s/templates/grafana-dashboard.yaml.tpl
+++ b/charts/agent-stack-k8s/templates/grafana-dashboard.yaml.tpl
@@ -3,22 +3,14 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "agent-stack-k8s.fullname" . }}-grafana-dashboard
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ with .Values.monitoring.namespace }}{{ . }}{{ else }}{{ .Release.Namespace }}{{ end }}
   labels:
     grafana_dashboard: "1"
+    app.kubernetes.io/name: grafana
 data:
   agent-stack-k8s.json: |-
     {
-      "__inputs": [
-        {
-          "name": "DS_PROMETHEUS",
-          "label": "Prometheus",
-          "description": "",
-          "type": "datasource",
-          "pluginId": "prometheus",
-          "pluginName": "Prometheus"
-        }
-      ],
+      "__inputs": [],
       "__elements": {},
       "__requires": [
         {
@@ -85,7 +77,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "prometheus"
           },
           "description": "This heatmap shows the duration between receiving a job from Buildkite and creating the corresponding job in Kubernetes. Note this chart only functions with native histograms enabled in Prometheus.",
           "fieldConfig": {
@@ -150,7 +142,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "sum(rate(buildkite_job_end_to_end_seconds{namespace=~\"$NAMESPACE\", pod=~\"$POD\"}[$__rate_interval]))",
@@ -180,7 +172,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "prometheus"
           },
           "description": "The monitor is the first component in the stack. It periodically queries Buildkite for new jobs to run.",
           "fieldConfig": {
@@ -260,7 +252,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "sum(rate(buildkite_monitor_jobs_returned_total{namespace=~\"$NAMESPACE\", pod=~\"$POD\"}[$__rate_interval]))",
@@ -272,7 +264,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "sum(rate(buildkite_monitor_jobs_handled_total{namespace=~\"$NAMESPACE\", pod=~\"$POD\"}[$__rate_interval]))",
@@ -285,7 +277,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "sum(rate(buildkite_monitor_jobs_filtered_out_total{namespace=~\"$NAMESPACE\", pod=~\"$POD\"}[$__rate_interval]))",
@@ -298,7 +290,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "sum(rate(buildkite_monitor_job_handler_errors_total{namespace=~\"$NAMESPACE\", pod=~\"$POD\"}[$__rate_interval]))",
@@ -315,7 +307,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "prometheus"
           },
           "description": "This heatmap shows the duration of time spent querying Buildkite for jobs. Note this chart only functions with native histograms enabled in Prometheus.",
           "fieldConfig": {
@@ -380,7 +372,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "sum(rate(buildkite_monitor_job_query_seconds{namespace=~\"$NAMESPACE\", pod=~\"$POD\"}[$__rate_interval]))",
@@ -409,7 +401,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "prometheus"
           },
           "description": "The limiter is the second component in the stack. It has an internal queue of jobs, and also applies the max-in-flight limit (if configured).",
           "fieldConfig": {
@@ -488,7 +480,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "sum(buildkite_limiter_work_queue_length{namespace=~\"$NAMESPACE\", pod=~\"$POD\"})",
@@ -500,7 +492,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "sum(buildkite_limiter_max_in_flight{namespace=~\"$NAMESPACE\", pod=~\"$POD\"})",
@@ -513,7 +505,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "sum(buildkite_limiter_tokens_available{namespace=~\"$NAMESPACE\", pod=~\"$POD\"})",
@@ -526,7 +518,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "sum(buildkite_limiter_waiting_for_token{namespace=~\"$NAMESPACE\", pod=~\"$POD\"})",
@@ -539,7 +531,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "sum(buildkite_limiter_waiting_for_work{namespace=~\"$NAMESPACE\", pod=~\"$POD\"})",
@@ -556,7 +548,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "prometheus"
           },
           "description": "The limiter is the second component in the stack. It has an internal queue of jobs, and also applies the max-in-flight limit (if configured).",
           "fieldConfig": {
@@ -636,7 +628,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "sum(rate(buildkite_limiter_job_handler_calls_total{namespace=~\"$NAMESPACE\", pod=~\"$POD\"}[$__rate_interval]))",
@@ -648,7 +640,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "sum by(reason) (rate(buildkite_limiter_job_handler_errors_total{namespace=~\"$NAMESPACE\", pod=~\"$POD\"}[$__rate_interval]))",
@@ -665,7 +657,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "prometheus"
           },
           "description": "This heatmap shows the duration of time each limiter worker spent waiting for new work. Note this chart only functions with native histograms enabled in Prometheus.",
           "fieldConfig": {
@@ -730,7 +722,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "sum(rate(buildkite_limiter_work_wait_duration_seconds{namespace=~\"$NAMESPACE\", pod=~\"$POD\"}[$__rate_interval]))",
@@ -746,7 +738,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "prometheus"
           },
           "description": "This heatmap shows the duration of time each limiter worker spent waiting for a limiter token. Note this chart only functions with native histograms enabled in Prometheus.",
           "fieldConfig": {
@@ -811,7 +803,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "sum(rate(buildkite_limiter_token_wait_duration_seconds{namespace=~\"$NAMESPACE\", pod=~\"$POD\"}[$__rate_interval]))",
@@ -827,7 +819,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "prometheus"
           },
           "description": "",
           "fieldConfig": {
@@ -907,7 +899,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "sum(rate(buildkite_limiter_onadd_events_total{namespace=~\"$NAMESPACE\", pod=~\"$POD\"}[$__rate_interval]))",
@@ -919,7 +911,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "sum(rate(buildkite_limiter_ondelete_events_total{namespace=~\"$NAMESPACE\", pod=~\"$POD\"}[$__rate_interval]))",
@@ -931,7 +923,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "sum(rate(buildkite_limiter_onupdate_events_total{namespace=~\"$NAMESPACE\", pod=~\"$POD\"}[$__rate_interval]))",
@@ -960,7 +952,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "prometheus"
           },
           "description": "The deduper is the third component in the stack. It prevents duplicate jobs from being scheduled and has the most accurate estimate of jobs present on Kubernetes, which includes both running jobs and completed jobs not yet cleaned up.",
           "fieldConfig": {
@@ -1040,7 +1032,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "sum(buildkite_deduper_jobs_running{namespace=~\"$NAMESPACE\", pod=~\"$POD\"})",
@@ -1056,7 +1048,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "prometheus"
           },
           "description": "The deduper is the third component in the stack. It prevents duplicate jobs from being scheduled. ",
           "fieldConfig": {
@@ -1136,7 +1128,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "sum(rate(buildkite_deduper_job_handler_calls_total{namespace=~\"$NAMESPACE\", pod=~\"$POD\"}[$__rate_interval]))",
@@ -1148,7 +1140,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "sum(rate(buildkite_deduper_job_handler_errors_total{namespace=~\"$NAMESPACE\", pod=~\"$POD\"}[$__rate_interval]))",
@@ -1161,7 +1153,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "sum(rate(buildkite_deduper_jobs_unmarked_running_total{namespace=~\"$NAMESPACE\", pod=~\"$POD\"}[$__rate_interval]))",
@@ -1174,7 +1166,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "sum(rate(buildkite_deduper_jobs_marked_running_total{namespace=~\"$NAMESPACE\", pod=~\"$POD\"}[$__rate_interval]))",
@@ -1191,7 +1183,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "prometheus"
           },
           "description": "",
           "fieldConfig": {
@@ -1271,7 +1263,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "sum(rate(buildkite_deduper_onadd_events_total{namespace=~\"$NAMESPACE\", pod=~\"$POD\"}[$__rate_interval]))",
@@ -1283,7 +1275,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "sum(rate(buildkite_deduper_ondelete_events_total{namespace=~\"$NAMESPACE\", pod=~\"$POD\"}[$__rate_interval]))",
@@ -1295,7 +1287,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "sum(rate(buildkite_deduper_onupdate_events_total{namespace=~\"$NAMESPACE\", pod=~\"$POD\"}[$__rate_interval]))",
@@ -1324,7 +1316,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "prometheus"
           },
           "description": "The scheduler is the last component in the stack prior to jobs running. It is responsible for passing the job onto Kubernetes.",
           "fieldConfig": {
@@ -1404,7 +1396,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "sum(rate(buildkite_scheduler_job_create_calls_total{namespace=~\"$NAMESPACE\", pod=~\"$POD\"}[$__rate_interval]))",
@@ -1416,7 +1408,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "sum(rate(buildkite_scheduler_job_create_success_total{namespace=~\"$NAMESPACE\", pod=~\"$POD\"}[$__rate_interval]))",
@@ -1429,7 +1421,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "sum by (reason) (rate(buildkite_scheduler_job_create_errors_total{namespace=~\"$NAMESPACE\", pod=~\"$POD\"}[$__rate_interval]))",
@@ -1442,7 +1434,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "sum(rate(buildkite_scheduler_jobs_failed_on_buildkite_total{namespace=~\"$NAMESPACE\", pod=~\"$POD\"}[$__rate_interval]))",
@@ -1455,7 +1447,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "sum(rate(buildkite_pod_watcher_job_fail_on_buildkite_errors_total{namespace=~\"$NAMESPACE\", pod=~\"$POD\"}[$__rate_interval]))",
@@ -1482,7 +1474,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "prometheus"
               },
               "description": "The job watcher is an auxiliary component that watches for certain Kubernetes job conditions, such as stalling or finishing without ever starting a pod.",
               "fieldConfig": {
@@ -1562,7 +1554,7 @@ data:
                 {
                   "datasource": {
                     "type": "prometheus",
-                    "uid": "${DS_PROMETHEUS}"
+                    "uid": "prometheus"
                   },
                   "editorMode": "builder",
                   "expr": "sum(rate(buildkite_job_watcher_cleanups_total{namespace=~\"$NAMESPACE\", pod=~\"$POD\"}[$__rate_interval]))",
@@ -1574,7 +1566,7 @@ data:
                 {
                   "datasource": {
                     "type": "prometheus",
-                    "uid": "${DS_PROMETHEUS}"
+                    "uid": "prometheus"
                   },
                   "editorMode": "builder",
                   "expr": "sum(rate(buildkite_job_watcher_jobs_stalled_without_pod_total{namespace=~\"$NAMESPACE\", pod=~\"$POD\"}[$__rate_interval]))",
@@ -1586,7 +1578,7 @@ data:
                 {
                   "datasource": {
                     "type": "prometheus",
-                    "uid": "${DS_PROMETHEUS}"
+                    "uid": "prometheus"
                   },
                   "editorMode": "builder",
                   "expr": "sum(rate(buildkite_job_watcher_jobs_finished_without_pod_total{namespace=~\"$NAMESPACE\", pod=~\"$POD\"}[$__rate_interval]))",
@@ -1598,7 +1590,7 @@ data:
                 {
                   "datasource": {
                     "type": "prometheus",
-                    "uid": "${DS_PROMETHEUS}"
+                    "uid": "prometheus"
                   },
                   "editorMode": "builder",
                   "expr": "sum(rate(buildkite_job_watcher_jobs_failed_on_buildkite_total{namespace=~\"$NAMESPACE\", pod=~\"$POD\"}[$__rate_interval]))",
@@ -1610,7 +1602,7 @@ data:
                 {
                   "datasource": {
                     "type": "prometheus",
-                    "uid": "${DS_PROMETHEUS}"
+                    "uid": "prometheus"
                   },
                   "editorMode": "builder",
                   "expr": "sum(rate(buildkite_job_watcher_job_fail_on_buildkite_errors_total{namespace=~\"$NAMESPACE\", pod=~\"$POD\"}[$__rate_interval]))",
@@ -1626,7 +1618,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "prometheus"
               },
               "description": "",
               "fieldConfig": {
@@ -1705,7 +1697,7 @@ data:
                 {
                   "datasource": {
                     "type": "prometheus",
-                    "uid": "${DS_PROMETHEUS}"
+                    "uid": "prometheus"
                   },
                   "editorMode": "builder",
                   "expr": "sum(buildkite_job_watcher_num_ignored_jobs{namespace=~\"$NAMESPACE\", pod=~\"$POD\"})",
@@ -1717,7 +1709,7 @@ data:
                 {
                   "datasource": {
                     "type": "prometheus",
-                    "uid": "${DS_PROMETHEUS}"
+                    "uid": "prometheus"
                   },
                   "editorMode": "builder",
                   "expr": "sum(buildkite_job_watcher_num_stalling_jobs{namespace=~\"$NAMESPACE\", pod=~\"$POD\"})",
@@ -1733,7 +1725,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "prometheus"
               },
               "description": "The job watcher is an auxiliary component that watches for certain Kubernetes job conditions, such as stalling or finishing without ever starting a pod.",
               "fieldConfig": {
@@ -1813,7 +1805,7 @@ data:
                 {
                   "datasource": {
                     "type": "prometheus",
-                    "uid": "${DS_PROMETHEUS}"
+                    "uid": "prometheus"
                   },
                   "editorMode": "builder",
                   "expr": "sum(rate(buildkite_job_watcher_onadd_events_total{namespace=~\"$NAMESPACE\", pod=~\"$POD\"}[$__rate_interval]))",
@@ -1825,7 +1817,7 @@ data:
                 {
                   "datasource": {
                     "type": "prometheus",
-                    "uid": "${DS_PROMETHEUS}"
+                    "uid": "prometheus"
                   },
                   "editorMode": "builder",
                   "expr": "sum(rate(buildkite_job_watcher_ondelete_events_total{namespace=~\"$NAMESPACE\", pod=~\"$POD\"}[$__rate_interval]))",
@@ -1837,7 +1829,7 @@ data:
                 {
                   "datasource": {
                     "type": "prometheus",
-                    "uid": "${DS_PROMETHEUS}"
+                    "uid": "prometheus"
                   },
                   "editorMode": "builder",
                   "expr": "sum(rate(buildkite_job_watcher_onupdate_events_total{namespace=~\"$NAMESPACE\", pod=~\"$POD\"}[$__rate_interval]))",
@@ -1867,7 +1859,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "prometheus"
               },
               "description": "The pod watcher is an auxiliary component that watches for certain Kubernetes pod conditions, such as failing to pull an image.",
               "fieldConfig": {
@@ -1947,7 +1939,7 @@ data:
                 {
                   "datasource": {
                     "type": "prometheus",
-                    "uid": "${DS_PROMETHEUS}"
+                    "uid": "prometheus"
                   },
                   "editorMode": "builder",
                   "expr": "sum(rate(buildkite_pod_watcher_jobs_failed_on_buildkite_total{namespace=~\"$NAMESPACE\", pod=~\"$POD\"}[$__rate_interval]))",
@@ -1959,7 +1951,7 @@ data:
                 {
                   "datasource": {
                     "type": "prometheus",
-                    "uid": "${DS_PROMETHEUS}"
+                    "uid": "prometheus"
                   },
                   "editorMode": "builder",
                   "expr": "sum(rate(buildkite_pod_watcher_job_fail_on_buildkite_errors_total{namespace=~\"$NAMESPACE\", pod=~\"$POD\"}[$__rate_interval]))",
@@ -1975,7 +1967,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "prometheus"
               },
               "description": "",
               "fieldConfig": {
@@ -2054,7 +2046,7 @@ data:
                 {
                   "datasource": {
                     "type": "prometheus",
-                    "uid": "${DS_PROMETHEUS}"
+                    "uid": "prometheus"
                   },
                   "editorMode": "builder",
                   "expr": "sum(buildkite_pod_watcher_num_ignored_jobs{namespace=~\"$NAMESPACE\", pod=~\"$POD\"})",
@@ -2066,7 +2058,7 @@ data:
                 {
                   "datasource": {
                     "type": "prometheus",
-                    "uid": "${DS_PROMETHEUS}"
+                    "uid": "prometheus"
                   },
                   "editorMode": "builder",
                   "expr": "sum(buildkite_pod_watcher_num_job_cancel_checkers{namespace=~\"$NAMESPACE\", pod=~\"$POD\"})",
@@ -2078,7 +2070,7 @@ data:
                 {
                   "datasource": {
                     "type": "prometheus",
-                    "uid": "${DS_PROMETHEUS}"
+                    "uid": "prometheus"
                   },
                   "editorMode": "builder",
                   "expr": "sum(buildkite_pod_watcher_num_watching_for_image_failure{namespace=~\"$NAMESPACE\", pod=~\"$POD\"})",
@@ -2094,7 +2086,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "prometheus"
               },
               "description": "",
               "fieldConfig": {
@@ -2174,7 +2166,7 @@ data:
                 {
                   "datasource": {
                     "type": "prometheus",
-                    "uid": "${DS_PROMETHEUS}"
+                    "uid": "prometheus"
                   },
                   "editorMode": "builder",
                   "expr": "sum(rate(buildkite_pod_watcher_onadd_events_total{namespace=~\"$NAMESPACE\", pod=~\"$POD\"}[$__rate_interval]))",
@@ -2186,7 +2178,7 @@ data:
                 {
                   "datasource": {
                     "type": "prometheus",
-                    "uid": "${DS_PROMETHEUS}"
+                    "uid": "prometheus"
                   },
                   "editorMode": "builder",
                   "expr": "sum(rate(buildkite_pod_watcher_ondelete_events_total{namespace=~\"$NAMESPACE\", pod=~\"$POD\"}[$__rate_interval]))",
@@ -2198,7 +2190,7 @@ data:
                 {
                   "datasource": {
                     "type": "prometheus",
-                    "uid": "${DS_PROMETHEUS}"
+                    "uid": "prometheus"
                   },
                   "editorMode": "builder",
                   "expr": "sum(rate(buildkite_pod_watcher_onupdate_events_total{namespace=~\"$NAMESPACE\", pod=~\"$POD\"}[$__rate_interval]))",
@@ -2228,7 +2220,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "prometheus"
               },
               "description": "The completion watcher is an auxiliary stack component that watches pods for certain completion conditions in order to effectively clean up, e.g. to prevent a sidecar container from causing a pod to live forever.",
               "fieldConfig": {
@@ -2308,7 +2300,7 @@ data:
                 {
                   "datasource": {
                     "type": "prometheus",
-                    "uid": "${DS_PROMETHEUS}"
+                    "uid": "prometheus"
                   },
                   "editorMode": "builder",
                   "expr": "sum(rate(buildkite_completion_watcher_cleanups_total{namespace=~\"$NAMESPACE\", pod=~\"$POD\"}[$__rate_interval]))",
@@ -2320,7 +2312,7 @@ data:
                 {
                   "datasource": {
                     "type": "prometheus",
-                    "uid": "${DS_PROMETHEUS}"
+                    "uid": "prometheus"
                   },
                   "editorMode": "builder",
                   "expr": "sum(rate(buildkite_completion_watcher_onadd_events_total{namespace=~\"$NAMESPACE\", pod=~\"$POD\"}[$__rate_interval]))",
@@ -2332,7 +2324,7 @@ data:
                 {
                   "datasource": {
                     "type": "prometheus",
-                    "uid": "${DS_PROMETHEUS}"
+                    "uid": "prometheus"
                   },
                   "editorMode": "builder",
                   "expr": "sum(rate(buildkite_completion_watcher_onupdate_events_total{namespace=~\"$NAMESPACE\", pod=~\"$POD\"}[$__rate_interval]))",
@@ -2361,7 +2353,7 @@ data:
             "current": {},
             "datasource": {
               "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
+              "uid": "prometheus"
             },
             "definition": "label_values(buildkite_monitor_job_queries_total,namespace)",
             "description": "",
@@ -2383,7 +2375,7 @@ data:
             "current": {},
             "datasource": {
               "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
+              "uid": "prometheus"
             },
             "definition": "label_values(buildkite_monitor_job_queries_total{namespace=~\"$NAMESPACE\"},pod)",
             "description": "",

--- a/charts/agent-stack-k8s/templates/podmonitor.yaml.tpl
+++ b/charts/agent-stack-k8s/templates/podmonitor.yaml.tpl
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: {{ include "agent-stack-k8s.fullname" . }}-podmonitor
-  namespace: {{ with .Values.monitoring.podMonitor.namespace }}{{ . }}{{ else }}{{ .Release.Namespace }}{{ end }}
+  namespace: {{ with .Values.monitoring.namespace }}{{ . }}{{ else }}{{ .Release.Namespace }}{{ end }}
   labels:
     app: {{ include "agent-stack-k8s.fullname" . }}
 spec:

--- a/charts/agent-stack-k8s/values.schema.json
+++ b/charts/agent-stack-k8s/values.schema.json
@@ -36,6 +36,12 @@
       "type": "object",
       "title": "Monitoring-related properties",
       "properties": {
+        "namespace": {
+          "type": "string",
+          "default": "",
+          "title": "Namespace to install monitoring resources into; some Prometheus Operator deployments only scan a particular namespace for monitoring resources such as PodMonitor and ServiceMonitor. By default the same namespace as the agent-stack-k8s controller is used.",
+          "examples": ["monitoring", "prometheus"]
+        },
         "deployGrafanaDashboard": {
           "type": "boolean",
           "default": true,
@@ -48,13 +54,7 @@
             "deploy": {
               "type": "boolean",
               "default": true,
-              "title": "When enabled, installs a PodMonitor resource (https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.PodMonitor) configured to scrape the controller pod metrics"
-            },
-            "namespace": {
-              "type": "string",
-              "default": "",
-              "title": "Alternative namespace to install the PodMonitor resource into. By default the same namespace as the Helm deployment is used.",
-              "examples": ["prometheus"]
+              "title": "When enabled, installs a PodMonitor resource (https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.PodMonitor) configured to scrape the controller pod metrics. Note this requires the Prometheus port on the controller to be enabled (see config.prometheus-port)."
             },
             "scrapeInterval": {
               "type": "string",
@@ -359,7 +359,7 @@
         },
         "prometheus-port": {
           "type": "integer",
-          "default": 0,
+          "default": 9216,
           "minimum": 0,
           "maximum": 65535,
           "title": "Bind port to expose Prometheus /metrics; 0 disables it"

--- a/charts/agent-stack-k8s/values.yaml
+++ b/charts/agent-stack-k8s/values.yaml
@@ -5,6 +5,7 @@ tolerations: []
 
 config:
   org: ""
+  prometheus-port: 9216
 
 resources:
   requests:


### PR DESCRIPTION
### What

- Enable Prometheus /metrics by default
- Apply the `monitoring.namespace` to both the `PodMonitor` and the Grafana dashboard `ConfigMap`
- Remove the `${DS_PROMETHEUS}` nonsense from the dashboard, as it seems to prevent the dashboard using the default Prometheus service

### Why

Things I found while trying to use these autodeployed resources.