### PR TITLE
PB-631-follow-up: crop FailJob error detail when it exceed size limit

### DIFF
--- a/internal/stacksapi/fail.go
+++ b/internal/stacksapi/fail.go
@@ -14,6 +14,13 @@ type FailJobRequest struct {
 }
 
 func (c *Client) FailJob(ctx context.Context, failJobReq FailJobRequest, opts ...RequestOption) error {
+	const maxErrorDetailSize = 4 * 1024 // 4KB
+
+	if len(failJobReq.ErrorDetail) > maxErrorDetailSize {
+		c.logger.Warn("ErrorDetail exceeds 4KB limit, cropping", "original_size", len(failJobReq.ErrorDetail), "cropped_size", maxErrorDetailSize)
+		failJobReq.ErrorDetail = failJobReq.ErrorDetail[:maxErrorDetailSize]
+	}
+
 	path := fmt.Sprintf("/stacks/%s/jobs/%s/fail", failJobReq.StackKey, failJobReq.JobUUID)
 	req, err := c.newRequest(ctx, http.MethodPost, path, failJobReq, opts...)
 	if err != nil {

--- a/internal/stacksapi/fail_test.go
+++ b/internal/stacksapi/fail_test.go
@@ -3,6 +3,7 @@ package stacksapi
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -39,6 +40,37 @@ func TestFailJob(t *testing.T) {
 			JobUUID:     "456",
 			ExitStatus:  -10,
 			ErrorDetail: "show me the money",
+		}
+
+		err := client.FailJob(t.Context(), req)
+		assert.NoError(t, err)
+	})
+
+	t.Run("crops error detail when exceeds 4KB", func(t *testing.T) {
+		t.Parallel()
+
+		server, client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			verifyAuthAndMethod(t, r, "POST", "/stacks/stack-123/jobs/456/fail")
+
+			var params FailJobRequest
+			assert.NoError(t, json.NewDecoder(r.Body).Decode(&params))
+
+			// Verify the error detail was cropped to 4KB
+			assert.Equal(t, 4*1024, len(params.ErrorDetail))
+			assert.Equal(t, strings.Repeat("x", 4*1024), params.ErrorDetail)
+
+			w.WriteHeader(http.StatusNoContent)
+		})
+		t.Cleanup(func() { server.Close() })
+
+		// Create an error detail larger than 4KB
+		largeErrorDetail := strings.Repeat("x", 5*1024) // 5KB
+
+		req := FailJobRequest{
+			StackKey:    "stack-123",
+			JobUUID:     "456",
+			ExitStatus:  -10,
+			ErrorDetail: largeErrorDetail,
 		}
 
 		err := client.FailJob(t.Context(), req)


### PR DESCRIPTION
Subject to our error handling philosophy, this may or may not be desirable. 

Generally speaking, I personally believe: 

- Failing gracefully gets better UX. 
- Cropped diagnostic data is better than no diagnostic data. 


I also acknowledge the downside

- it may cause surprise. 
- cropped diagnostic data in some certain case, can get misleading. 


But I reckon the pros outweight the gain. I welcome feedbacks! 