### PR TITLE
PB-680 follow up: fix experimental flag test cases

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -166,13 +166,14 @@ steps:
 
   - label: ":buildkite::test_tube::rocket: tests (experimental features)"
     key: tests-experimental
-    soft_fail: true
     depends_on: agent
     artifact_paths: junit-*.xml
     command: .buildkite/steps/tests.sh
     env:
       CONFIG: /etc/config.yaml
-      EXPERIMENTAL_JOB_RESERVATION_SUPPORT: true
+      # Turn me on when PB-629 is done.
+      # Even better -> merge these two flags into one when PB-629 is happening.
+      EXPERIMENTAL_JOB_RESERVATION_SUPPORT: false
       EXPERIMENTAL_STACKS_API_SUPPORT: true
     plugins:
       - kubernetes:

--- a/cmd/controller/controller_test.go
+++ b/cmd/controller/controller_test.go
@@ -18,6 +18,8 @@ func ptr[T any](v T) *T {
 }
 
 func TestReadAndParseConfig(t *testing.T) {
+	t.Setenv("EXPERIMENTAL_JOB_RESERVATION_SUPPORT", "true")
+	t.Setenv("EXPERIMENTAL_STACKS_API_SUPPORT", "true")
 	expected := config.Config{
 		Debug:                          true,
 		AgentTokenSecret:               "my-kubernetes-secret",

--- a/justfile
+++ b/justfile
@@ -29,6 +29,7 @@ test *FLAGS:
   GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
   export EXPERIMENTAL_JOB_RESERVATION_SUPPORT=true
+  export EXPERIMENTAL_STACKS_API_SUPPORT=true
 
   go test \
     -ldflags="-X github.com/buildkite/agent-stack-k8s/v2/internal/integration_test.branch=${GIT_BRANCH}" \


### PR DESCRIPTION
The new testing setup has 2 problems: 
- old reservation support does not support new fail job API yet because the reservation api migration isn't done yet. 
- new fail job approach won't put logs in the job logs, so a bunch of validation failed. A proper fix would be validating against timeline/events, but we seem to lack such support on go-buildkite?

This PR is an contingency fix to make the pipeline pass. 