### PR TITLE
Don't deploy monitoring resources by default

### DIFF
--- a/.buildkite/steps/deploy.sh
+++ b/.buildkite/steps/deploy.sh
@@ -21,4 +21,6 @@ helm upgrade agent-stack-k8s "${helm_repo_pecr}/agent-stack-k8s" \
   --set agentToken="${BUILDKITE_AGENT_TOKEN}" \
   --set config.image="${agent_image}" \
   --set config.debug=true \
-  --set config.profiler-address=localhost:6060
+  --set config.profiler-address=localhost:6060 \
+  --set monitoring.podMonitor.deploy=true \
+  --set monitoring.deployGrafanaDashboard=true

--- a/charts/agent-stack-k8s/values.schema.json
+++ b/charts/agent-stack-k8s/values.schema.json
@@ -44,8 +44,8 @@
         },
         "deployGrafanaDashboard": {
           "type": "boolean",
-          "default": true,
-          "title": "When enabled, installs a Grafana dashboard definition using a ConfigMap"
+          "default": false,
+          "title": "When enabled, installs a Grafana dashboard definition (as a ConfigMap)"
         },
         "podMonitor": {
           "type": "object",
@@ -53,8 +53,8 @@
           "properties": {
             "deploy": {
               "type": "boolean",
-              "default": true,
-              "title": "When enabled, installs a PodMonitor resource (https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.PodMonitor) configured to scrape the controller pod metrics. Note this requires the Prometheus port on the controller to be enabled (see config.prometheus-port)."
+              "default": false,
+              "title": "When enabled, installs a PodMonitor resource (https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.PodMonitor) configured to scrape the controller pod metrics. Note this requires the Prometheus port on the controller to be enabled (see config.prometheus-port). Ensure that the Prometheus Operator CRDs are installed before enabling this option."
             },
             "scrapeInterval": {
               "type": "string",

--- a/charts/agent-stack-k8s/values.yaml
+++ b/charts/agent-stack-k8s/values.yaml
@@ -21,6 +21,6 @@ secretsMetadata: {}
 serviceAccountMetadata: {}
 
 monitoring:
-  deployGrafanaDashboard: true
+  deployGrafanaDashboard: false
   podMonitor:
-    deploy: true
+    deploy: false


### PR DESCRIPTION
### What

Turn off deployment of the PodMonitor and Grafana Dashboard by default. These can be opted back in to using e.g. 

```shell
helm upgrade ... 
  --set monitoring.podMonitor.deploy=true \
  --set monitoring.deployGrafanaDashboard=true
```
or with a custom values.yaml file.

### Why

Turns out that Helm can't deploy a PodMonitor if it doesn't know what it is (i.e. if the Prometheus Operator CRDs aren't installed yet). This didn't break CI because I installed kube-prometheus-stack in our CI cluster for testing the new resources.

On further reflection, we probably shouldn't be auto-deploying potentially unnecessary things anyway.