### PR TITLE
PB-628 part 2 attempt 2: BatchBuildkiteJobChecker and new GetJobStates method

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -242,6 +242,7 @@ func Run(
 	if err := podWatcher.RegisterInformer(ctx, informerFactory); err != nil {
 		logger.Fatal("failed to register podWatcher informer", zap.Error(err))
 	}
+	podWatcher.StartBuildkiteJobChecker(ctx)
 
 	select {
 	case <-ctx.Done():

--- a/internal/controller/scheduler/batch_buildkite_job_checker.go
+++ b/internal/controller/scheduler/batch_buildkite_job_checker.go
@@ -1,0 +1,173 @@
+package scheduler
+
+import (
+	"context"
+	"math"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/buildkite/agent-stack-k8s/v2/api"
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// BatchBuildkiteJobChecker monitors Buildkite jobs for cancellation state changes.
+// Unlike the old legacy BuildkiteJobChecker, this checker check all pending jobs together,
+// relying on the new Stack API.
+type BatchBuildkiteJobChecker struct {
+	logger      *zap.Logger
+	agentClient *api.AgentClient
+	k8s         kubernetes.Interface
+
+	// The job cancel checkers query the job state every so often.
+	jobCancelCheckerInterval time.Duration
+
+	// Store jobs that we will check against.
+	checkingJobsMu sync.Mutex
+	checkingJobs   map[uuid.UUID]metav1.ObjectMeta
+}
+
+// NewBatchBuildkiteJobChecker creates a new Batch Buildkite job checker.
+func NewBatchBuildkiteJobChecker(
+	logger *zap.Logger,
+	agentClient *api.AgentClient,
+	k8s kubernetes.Interface,
+	interval time.Duration,
+) *BatchBuildkiteJobChecker {
+	return &BatchBuildkiteJobChecker{
+		logger:                   logger,
+		agentClient:              agentClient,
+		k8s:                      k8s,
+		jobCancelCheckerInterval: interval,
+		checkingJobs:             make(map[uuid.UUID]metav1.ObjectMeta),
+	}
+}
+
+// StartChecking starts a gorouting loop to periodically check job states for all jobs that it manages.
+func (c *BatchBuildkiteJobChecker) StartChecking(ctx context.Context) {
+	go c.batchChecker(ctx)
+}
+
+func (c *BatchBuildkiteJobChecker) batchChecker(ctx context.Context) {
+	c.logger.Debug("Starting batch job state checker")
+	defer c.logger.Debug("Stopped batch job state checker")
+
+	ticker := time.NewTicker(c.jobCancelCheckerInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			c.checkJobStates(ctx)
+		}
+	}
+}
+
+func (c *BatchBuildkiteJobChecker) checkJobStates(ctx context.Context) {
+	c.checkingJobsMu.Lock()
+	if len(c.checkingJobs) == 0 {
+		c.checkingJobsMu.Unlock()
+		return
+	}
+
+	// Create slices for job UUIDs and corresponding pod metadata
+	jobUUIDs := make([]string, 0, len(c.checkingJobs))
+	jobToPodMeta := make(map[string]metav1.ObjectMeta, len(c.checkingJobs))
+
+	for jobUUID, podMeta := range c.checkingJobs {
+		jobUUIDStr := jobUUID.String()
+		jobUUIDs = append(jobUUIDs, jobUUIDStr)
+		jobToPodMeta[jobUUIDStr] = podMeta
+	}
+	c.checkingJobsMu.Unlock() // Release the lock as soon as possible.
+
+	// Split jobs into batches of 1000 and process concurrently
+	const batchSize = 1000
+	var wg sync.WaitGroup
+
+	batchCount := int(math.Ceil(float64(len(jobUUIDs)) / float64(batchSize)))
+	jobStatesCh := make(chan map[string]api.JobState, batchCount)
+
+	for batch := range slices.Chunk(jobUUIDs, batchSize) {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			jobStates, _, err := c.agentClient.GetJobStates(ctx, batch)
+			if err != nil {
+				c.logger.Error("Couldn't fetch states of jobs", zap.Error(err), zap.Int("batch_size", len(batch)))
+				return
+			}
+
+			jobStatesCh <- jobStates
+		}()
+	}
+
+	// Wait for all batches to complete and close channel
+	go func() {
+		wg.Wait()
+		close(jobStatesCh)
+	}()
+
+	// Process results from all batches
+	for jobStates := range jobStatesCh {
+		for jobUUIDStr, jobState := range jobStates {
+			podMeta := jobToPodMeta[jobUUIDStr]
+			// Concurrently handle cancelled jobs.
+			// This is at the mercy of k8s API rate limit and buildkite stack API rate limit.
+			// If either rate limit were breached, it will result in delay in resource release.
+			go c.handleJobState(ctx, jobUUIDStr, jobState, podMeta)
+		}
+	}
+}
+
+func (c *BatchBuildkiteJobChecker) AddJob(jobUUID uuid.UUID, podMeta metav1.ObjectMeta) {
+	c.checkingJobsMu.Lock()
+	defer c.checkingJobsMu.Unlock()
+	c.checkingJobs[jobUUID] = podMeta
+}
+
+func (c *BatchBuildkiteJobChecker) StopCheckingJob(jobUUID uuid.UUID) {
+	c.checkingJobsMu.Lock()
+	defer c.checkingJobsMu.Unlock()
+	delete(c.checkingJobs, jobUUID)
+}
+
+func (c *BatchBuildkiteJobChecker) handleJobState(ctx context.Context, jobUUIDStr string, jobState api.JobState, podMeta metav1.ObjectMeta) {
+	log := c.logger.With(zap.String("job_uuid", jobUUIDStr), zap.String("job_state", string(jobState)))
+
+	switch jobState {
+	case api.JobStateCanceled, api.JobStateCanceling:
+		log.Info("Deleting pending pod for cancelled job")
+		if err := forcefullyDeletePod(ctx, log, c.k8s, &podMeta, "job_cancelled"); err != nil {
+			log.Error("Failed to delete pod for cancelled job", zap.Error(err))
+			return
+		}
+		// Remove the job from checking list after successful deletion
+		jobUUID, _ := uuid.Parse(jobUUIDStr)
+		c.StopCheckingJob(jobUUID)
+
+	case api.JobStateScheduled, api.JobStateReserved:
+		// The pod can continue waiting for resources / initializing.
+
+	default:
+		// Assigned, Accepted, Running: Too late. Let the agent within
+		// the pod handle cancellation. Finished, etc: it's already over.
+		// If it's any other state, we probably shouldn't interfere.
+		log.Debug("Ending job cancel checker due to job state")
+		jobUUID, _ := uuid.Parse(jobUUIDStr)
+		c.StopCheckingJob(jobUUID)
+	}
+}
+
+// GetActiveCheckCount returns the number of jobs currently being checked.
+func (c *BatchBuildkiteJobChecker) GetActiveCheckCount() int {
+	c.checkingJobsMu.Lock()
+	defer c.checkingJobsMu.Unlock()
+	return len(c.checkingJobs)
+}

--- a/internal/controller/scheduler/buildkite_job_checker.go
+++ b/internal/controller/scheduler/buildkite_job_checker.go
@@ -13,6 +13,8 @@ import (
 )
 
 // BuildkiteJobChecker monitors Buildkite jobs for cancellation state changes.
+// It operate on individual jobs basis, relying on legacy Agent API.
+// In the future version, we will get rid of it.
 type BuildkiteJobChecker struct {
 	logger      *zap.Logger
 	agentClient *api.AgentClient

--- a/internal/controller/scheduler/fail_job.go
+++ b/internal/controller/scheduler/fail_job.go
@@ -56,7 +56,7 @@ func failForK8sObject(
 		logger.Error("object missing UUID label", zap.String("label", config.UUIDLabel))
 		return errors.New("missing UUID label")
 	}
-	if agentClient.UseStackAPI {
+	if agentClient.UseStackAPI() {
 		return agentClient.FailJob(ctx, jobUUID, failureInfo.Message)
 	} else {
 		tags := agenttags.TagsFromLabels(labels)

--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -1099,7 +1099,7 @@ func (w *worker) failJob(ctx context.Context, inputs buildInputs, message string
 		Reason: agent.SignalReasonStackError,
 	}
 
-	if w.agentClient.UseStackAPI {
+	if w.agentClient.UseStackAPI() {
 		if err := w.agentClient.FailJob(ctx, inputs.uuid, failureInfo.Message); err != nil {
 			w.logger.Error("failed to fail the job via Buildkite Stack API", zap.Error(err))
 			schedulerBuildkiteJobFailErrorsCounter.Inc()

--- a/internal/integration/testcase_test.go
+++ b/internal/integration/testcase_test.go
@@ -216,6 +216,11 @@ func (t testcase) StartController(ctx context.Context, cfg config.Config, custom
 	// Setting a static identifer here so their informer aren't steping on each other.
 	cfg.ID = uuid.New().String()
 
+	// Since we run multiple test controllers in parallel, allowing these would cause port conflict.
+	// We use the profiler nor prometheus metrics for integration test anyway.
+	cfg.PrometheusPort = 0
+	cfg.ProfilerAddress = ""
+
 	go controller.Run(runCtx, t.Logger, t.Kubernetes, &cfg)
 }
 

--- a/internal/stacksapi/get_job_states.go
+++ b/internal/stacksapi/get_job_states.go
@@ -1,0 +1,32 @@
+package stacksapi
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+type GetJobStatesRequest struct {
+	StackKey string   `json:"-"`         // The key to call the stack. Required.
+	JobUUIDs []string `json:"job_uuids"` // A list of job uuids
+}
+
+type GetJobStatesResponse struct {
+	States map[string]string `json:"states"`
+}
+
+// GetJobStates query job states for a list of jobs
+func (c *Client) GetJobStates(ctx context.Context, getJobStatesReq GetJobStatesRequest, opts ...RequestOption) (GetJobStatesResponse, error) {
+	path := fmt.Sprintf("/stacks/%s/jobs/get-states", getJobStatesReq.StackKey)
+	req, err := c.newRequest(ctx, http.MethodPost, path, getJobStatesReq, opts...)
+	if err != nil {
+		return GetJobStatesResponse{}, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	jobStates, _, err := do[GetJobStatesResponse](ctx, c, req)
+	if err != nil {
+		return GetJobStatesResponse{}, fmt.Errorf("get job states: %w", err)
+	}
+
+	return *jobStates, nil
+}

--- a/internal/stacksapi/get_job_states_test.go
+++ b/internal/stacksapi/get_job_states_test.go
@@ -1,0 +1,66 @@
+package stacksapi
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetJobStates(t *testing.T) {
+	t.Parallel()
+
+	t.Run("successful get job states", func(t *testing.T) {
+		t.Parallel()
+
+		server, client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			verifyAuthAndMethod(t, r, "POST", "/stacks/stack-123/jobs/get-states")
+
+			var params GetJobStatesRequest
+			assert.NoError(t, json.NewDecoder(r.Body).Decode(&params))
+
+			expectedParams := GetJobStatesRequest{
+				JobUUIDs: []string{"job-1", "job-2", "job-3"},
+			}
+
+			if diff := cmp.Diff(expectedParams, params); diff != "" {
+				t.Errorf("request params mismatch (-want +got):\n%s", diff)
+			}
+
+			response := GetJobStatesResponse{
+				States: map[string]string{
+					"job-1": "running",
+					"job-2": "finished",
+					"job-3": "failed",
+				},
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			assert.NoError(t, json.NewEncoder(w).Encode(response))
+		})
+		t.Cleanup(func() { server.Close() })
+
+		req := GetJobStatesRequest{
+			StackKey: "stack-123",
+			JobUUIDs: []string{"job-1", "job-2", "job-3"},
+		}
+
+		response, err := client.GetJobStates(t.Context(), req)
+		assert.NoError(t, err)
+
+		expectedResponse := GetJobStatesResponse{
+			States: map[string]string{
+				"job-1": "running",
+				"job-2": "finished",
+				"job-3": "failed",
+			},
+		}
+
+		if diff := cmp.Diff(expectedResponse, response); diff != "" {
+			t.Errorf("response mismatch (-want +got):\n%s", diff)
+		}
+	})
+}


### PR DESCRIPTION
This PR is probably one of the more evolved bit of migrating to Stack API. 

Stack API changes how client should get the job state from single fetch to batched fetch. Therefore, the existing single job oriented go routine approach won't work anymore.

This PR introduces `BatchBuildkiteJobChecker` check job stacks by 1000 per batch. 

This PR also implemented the underlying `GetJobStates` method. 