### PR TITLE
Fix get job states

### DIFF
--- a/api/agent_client.go
+++ b/api/agent_client.go
@@ -171,7 +171,7 @@ type AgentScheduledJob struct {
 
 // GetScheduledJobs gets a page of jobs that could be run.
 func (c *AgentClient) GetScheduledJobs(ctx context.Context, afterCursor string, limit int) (*AgentScheduledJobs, time.Duration, error) {
-	if c.UseStackAPI {
+	if c.UseStackAPI() {
 		return c.getStackScheduledJobs(ctx, afterCursor, limit)
 	}
 

--- a/internal/stacksapi/get_job_states.go
+++ b/internal/stacksapi/get_job_states.go
@@ -16,17 +16,17 @@ type GetJobStatesResponse struct {
 }
 
 // GetJobStates query job states for a list of jobs
-func (c *Client) GetJobStates(ctx context.Context, getJobStatesReq GetJobStatesRequest, opts ...RequestOption) (GetJobStatesResponse, error) {
+func (c *Client) GetJobStates(ctx context.Context, getJobStatesReq GetJobStatesRequest, opts ...RequestOption) (*GetJobStatesResponse, error) {
 	path := fmt.Sprintf("/stacks/%s/jobs/get-states", getJobStatesReq.StackKey)
 	req, err := c.newRequest(ctx, http.MethodPost, path, getJobStatesReq, opts...)
 	if err != nil {
-		return GetJobStatesResponse{}, fmt.Errorf("failed to create request: %w", err)
+		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
 	jobStates, _, err := do[GetJobStatesResponse](ctx, c, req)
 	if err != nil {
-		return GetJobStatesResponse{}, fmt.Errorf("get job states: %w", err)
+		return nil, fmt.Errorf("get job states: %w", err)
 	}
 
-	return *jobStates, nil
+	return jobStates, nil
 }

--- a/internal/stacksapi/get_job_states_test.go
+++ b/internal/stacksapi/get_job_states_test.go
@@ -16,7 +16,7 @@ func TestGetJobStates(t *testing.T) {
 		t.Parallel()
 
 		server, client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
-			verifyAuthAndMethod(t, r, "POST", "/stacks/stack-123/jobs/get-states")
+			verifyAuthMethodPath(t, r, "POST", "/stacks/stack-123/jobs/get-states")
 
 			var params GetJobStatesRequest
 			assert.NoError(t, json.NewDecoder(r.Body).Decode(&params))

--- a/internal/stacksapi/get_job_states_test.go
+++ b/internal/stacksapi/get_job_states_test.go
@@ -29,7 +29,7 @@ func TestGetJobStates(t *testing.T) {
 				t.Errorf("request params mismatch (-want +got):\n%s", diff)
 			}
 
-			response := GetJobStatesResponse{
+			response := &GetJobStatesResponse{
 				States: map[string]string{
 					"job-1": "running",
 					"job-2": "finished",
@@ -51,7 +51,7 @@ func TestGetJobStates(t *testing.T) {
 		response, err := client.GetJobStates(t.Context(), req)
 		assert.NoError(t, err)
 
-		expectedResponse := GetJobStatesResponse{
+		expectedResponse := &GetJobStatesResponse{
 			States: map[string]string{
 				"job-1": "running",
 				"job-2": "finished",


### PR DESCRIPTION
Some merge shenanigans left us with code that wasn't buildable. 

Also, make the `GetJobStates` method return a pointer to its output type, rather than the value. this doesn't have an affect, but it's more consistent with the other methods.