### PR TITLE
PB-628 follow up: return retryAfter from get job states API

### DIFF
--- a/api/agent_client.go
+++ b/api/agent_client.go
@@ -337,7 +337,7 @@ func (c *AgentClient) GetJobStates(ctx context.Context, ids []string) (result ma
 		StackKey: c.stack.Key,
 		JobUUIDs: ids,
 	}
-	statesResp, err := c.stacksAPIClient.GetJobStates(ctx, req)
+	statesResp, header, err := c.stacksAPIClient.GetJobStates(ctx, req)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -345,8 +345,7 @@ func (c *AgentClient) GetJobStates(ctx context.Context, ids []string) (result ma
 	for k, v := range statesResp.States {
 		result[k] = JobState(v)
 	}
-	// FIXME: fix the retryAfter later
-	return result, 0, err
+	return result, readRetryAfter(header), err
 }
 
 // ReserveJobBatchResult describes the result of a batch job reservation.

--- a/internal/stacksapi/get_job_states.go
+++ b/internal/stacksapi/get_job_states.go
@@ -16,17 +16,17 @@ type GetJobStatesResponse struct {
 }
 
 // GetJobStates query job states for a list of jobs
-func (c *Client) GetJobStates(ctx context.Context, getJobStatesReq GetJobStatesRequest, opts ...RequestOption) (*GetJobStatesResponse, error) {
+func (c *Client) GetJobStates(ctx context.Context, getJobStatesReq GetJobStatesRequest, opts ...RequestOption) (*GetJobStatesResponse, http.Header, error) {
 	path := fmt.Sprintf("/stacks/%s/jobs/get-states", getJobStatesReq.StackKey)
 	req, err := c.newRequest(ctx, http.MethodPost, path, getJobStatesReq, opts...)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
+		return nil, nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	jobStates, _, err := do[GetJobStatesResponse](ctx, c, req)
+	jobStates, header, err := do[GetJobStatesResponse](ctx, c, req)
 	if err != nil {
-		return nil, fmt.Errorf("get job states: %w", err)
+		return nil, nil, fmt.Errorf("get job states: %w", err)
 	}
 
-	return jobStates, nil
+	return jobStates, header, nil
 }

--- a/internal/stacksapi/get_job_states_test.go
+++ b/internal/stacksapi/get_job_states_test.go
@@ -48,7 +48,7 @@ func TestGetJobStates(t *testing.T) {
 			JobUUIDs: []string{"job-1", "job-2", "job-3"},
 		}
 
-		response, err := client.GetJobStates(t.Context(), req)
+		response, _, err := client.GetJobStates(t.Context(), req)
 		assert.NoError(t, err)
 
 		expectedResponse := &GetJobStatesResponse{


### PR DESCRIPTION
Make sure `agentclient.GetJobStates` return a correct `retryAfter`.