### PR TITLE
PB-630: Get GetJobToRun to use Stack API

### DIFF
--- a/internal/stacksapi/get_job.go
+++ b/internal/stacksapi/get_job.go
@@ -1,0 +1,34 @@
+package stacksapi
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+type GetJobRequest struct {
+	StackKey string `json:"-"` // The key to call the stack. Required.
+	JobUUID  string `json:"-"` // The uuid of a job. Required.
+}
+
+type GetJobResponse struct {
+	ID      string            `json:"id"`
+	Env     map[string]string `json:"env"`
+	Command string            `json:"command"`
+}
+
+// GetJob return Job's runtime data (env and command) for a single job.
+func (c *Client) GetJob(ctx context.Context, getJobReq GetJobRequest, opts ...RequestOption) (*GetJobResponse, http.Header, error) {
+	path := constructPath("/stacks/%s/jobs/%s", getJobReq.StackKey, getJobReq.JobUUID)
+	req, err := c.newRequest(ctx, http.MethodGet, path, nil, opts...)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, header, err := do[GetJobResponse](ctx, c, req)
+	if err != nil {
+		return nil, header, fmt.Errorf("get job: %w", err)
+	}
+
+	return resp, header, nil
+}

--- a/internal/stacksapi/get_job_test.go
+++ b/internal/stacksapi/get_job_test.go
@@ -1,0 +1,85 @@
+package stacksapi
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestGetJob(t *testing.T) {
+	t.Parallel()
+
+	t.Run("successful get job", func(t *testing.T) {
+		t.Parallel()
+
+		expectedResponse := GetJobResponse{
+			ID:      "job-uuid-123",
+			Command: "echo Hello 👋",
+			Env: map[string]string{
+				"BUILDKITE_JOB_ID": "job-uuid-123",
+				"BUILDKITE_BRANCH": "main",
+			},
+		}
+
+		server, client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			verifyAuthMethodPath(t, r, "GET", "/stacks/stack-123/jobs/job-uuid-123")
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+
+			if err := json.NewEncoder(w).Encode(expectedResponse); err != nil {
+				t.Fatalf("failed to encode response: %v", err)
+			}
+		})
+		t.Cleanup(func() { server.Close() })
+
+		req := GetJobRequest{
+			StackKey: "stack-123",
+			JobUUID:  "job-uuid-123",
+		}
+
+		resp, _, err := client.GetJob(t.Context(), req)
+		if err != nil {
+			t.Fatalf("client.GetJob returned an error: %v", err)
+		}
+
+		if diff := cmp.Diff(expectedResponse, *resp); diff != "" {
+			t.Errorf("response mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("job not found", func(t *testing.T) {
+		t.Parallel()
+
+		server, client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			verifyAuthMethodPath(t, r, "GET", "/stacks/stack-123/jobs/non-existent-uuid")
+
+			w.WriteHeader(http.StatusNotFound)
+		})
+		t.Cleanup(func() { server.Close() })
+
+		req := GetJobRequest{
+			StackKey: "stack-123",
+			JobUUID:  "non-existent-uuid",
+		}
+
+		_, _, err := client.GetJob(t.Context(), req)
+		if err == nil {
+			t.Fatal("expected error for not found job, got nil")
+		}
+
+		// Check the error response
+		var errResp *ErrorResponse
+		ok := errors.As(err, &errResp)
+		if !ok {
+			t.Fatalf("expected ErrorResponse, got: %v", err)
+		}
+
+		if errResp.Response.StatusCode != http.StatusNotFound {
+			t.Errorf("expected status code %d, got %d", http.StatusNotFound, errResp.Response.StatusCode)
+		}
+	})
+}


### PR DESCRIPTION
Self explanatory 😄 .

This API changes agent_client.GetJobToRun so when UseStackAPI is true, it would use the new stack api method `GetJob` to get job. 