### PR TITLE
PB-119: controller create stack notifications

### DIFF
--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -187,6 +187,7 @@ func (w *worker) Handle(ctx context.Context, job *api.AgentScheduledJob) error {
 			return err
 		}
 	}
+	w.agentClient.CreateStackNotification(ctx, inputs.uuid, "K8s Job created successfully, waiting for Agent to start...")
 	jobCreateSuccessCounter.Inc()
 	jobEndToEndDurationHistogram.Observe(time.Since(job.QueriedAt).Seconds())
 	return nil

--- a/internal/stacksapi/stack_notification.go
+++ b/internal/stacksapi/stack_notification.go
@@ -1,0 +1,36 @@
+package stacksapi
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+type CreateStackNotificationRequest struct {
+	StackKey string `json:"-"`      // The key to call the stack. Required.
+	JobUUID  string `json:"-"`      // The uuid of a job
+	Detail   string `json:"detail"` // Short notification message (max length 255)
+}
+
+func (c *Client) CreateStackNotification(ctx context.Context, req CreateStackNotificationRequest, opts ...RequestOption) (http.Header, error) {
+	const croppedMessage = "… (cropped)"
+	const maxDetailSize = 255 - len(croppedMessage)
+
+	if len(req.Detail) > maxDetailSize {
+		c.logger.Warn("Stack notification detail exceeds character limit, cropping", "original_size", len(req.Detail))
+		req.Detail = req.Detail[:maxDetailSize] + croppedMessage
+	}
+
+	path := constructPath("/stacks/%s/jobs/%s/stack_notifications", req.StackKey, req.JobUUID)
+	httpReq, err := c.newRequest(ctx, http.MethodPost, path, req, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	_, header, err := do[struct{}](ctx, c, httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("create stack notification: %w", err)
+	}
+
+	return header, nil
+}

--- a/internal/stacksapi/stack_notification_test.go
+++ b/internal/stacksapi/stack_notification_test.go
@@ -1,0 +1,84 @@
+package stacksapi
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateStackNotification(t *testing.T) {
+	t.Parallel()
+
+	t.Run("successful create stack notification", func(t *testing.T) {
+		t.Parallel()
+
+		server, client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			verifyAuthMethodPath(t, r, "POST", "/stacks/stack-123/jobs/456/stack_notifications")
+
+			var params CreateStackNotificationRequest
+			assert.NoError(t, json.NewDecoder(r.Body).Decode(&params))
+
+			expectedParams := CreateStackNotificationRequest{
+				Detail: "Pod is starting up",
+			}
+
+			if diff := cmp.Diff(expectedParams, params); diff != "" {
+				t.Errorf("request params mismatch (-want +got):\n%s", diff)
+			}
+
+			w.Header().Set("X-Custom-Header", "custom-value")
+			w.WriteHeader(http.StatusOK)
+		})
+		t.Cleanup(func() { server.Close() })
+
+		req := CreateStackNotificationRequest{
+			StackKey: "stack-123",
+			JobUUID:  "456",
+			Detail:   "Pod is starting up",
+		}
+
+		header, err := client.CreateStackNotification(t.Context(), req)
+		if err != nil {
+			t.Fatalf("client.CreateStackNotification returned an error: %v", err)
+		}
+
+		want, got := "custom-value", header.Get("X-Custom-Header")
+		if want != got {
+			t.Errorf("header.Get(\"X-Custom-Header\") = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("crops detail when exceeds 255 characters", func(t *testing.T) {
+		t.Parallel()
+
+		server, client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			verifyAuthMethodPath(t, r, "POST", "/stacks/stack-123/jobs/456/stack_notifications")
+
+			var params CreateStackNotificationRequest
+			assert.NoError(t, json.NewDecoder(r.Body).Decode(&params))
+
+			// Verify the detail was cropped to 255 characters
+			assert.Equal(t, 255, len(params.Detail))
+			assert.True(t, strings.HasSuffix(params.Detail, "… (cropped)"))
+
+			w.WriteHeader(http.StatusOK)
+		})
+		t.Cleanup(func() { server.Close() })
+
+		// Create a detail longer than 255 characters
+		largeDetail := strings.Repeat("x", 300) // 300 characters
+
+		req := CreateStackNotificationRequest{
+			StackKey: "stack-123",
+			JobUUID:  "456",
+			Detail:   largeDetail,
+		}
+
+		_, err := client.CreateStackNotification(t.Context(), req)
+		assert.NoError(t, err)
+	})
+}


### PR DESCRIPTION
Create a stack notification to when k8s job gets successfully created. 

I had a thought about creating more notifications but as I am making this, I have doubt about what truly useful information is. So to be conservative, I only added one. We can always add more later.