### PR TITLE
Add `buildkite.com/build-repo` and `buildkite.com/pipeline-slug` annotations

### DIFF
--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -15,8 +15,10 @@ const (
 	ControllerIDLabel                     = "buildkite.com/controller-id"
 	BuildURLAnnotation                    = "buildkite.com/build-url"
 	BuildBranchAnnotation                 = "buildkite.com/build-branch"
+	BuildRepoAnnotation                   = "buildkite.com/build-repo"
 	JobURLAnnotation                      = "buildkite.com/job-url"
 	PriorityAnnotation                    = "buildkite.com/job-priority"
+	PipelineSlugAnnotation                = "buildkite.com/pipeline-slug"
 	DefaultNamespace                      = "default"
 	DefaultImagePullBackOffGracePeriod    = 30 * time.Second
 	DefaultJobCancelCheckerPollInterval   = 5 * time.Second

--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -302,6 +302,10 @@ func (w *worker) Build(podSpec *corev1.PodSpec, skipCheckout bool, inputs buildI
 	kjob.Annotations[config.BuildURLAnnotation] = buildURL
 	buildBranch := inputs.envMap["BUILDKITE_BRANCH"]
 	kjob.Annotations[config.BuildBranchAnnotation] = buildBranch
+	buildRepo := inputs.envMap["BUILDKITE_REPO"]
+	kjob.Annotations[config.BuildRepoAnnotation] = buildRepo
+	pipelineSlug := inputs.envMap["BUILDKITE_PIPELINE_SLUG"]
+	kjob.Annotations[config.PipelineSlugAnnotation] = pipelineSlug
 	jobURL, err := w.jobURL(inputs.uuid, buildURL)
 	if err != nil {
 		w.logger.Warn("could not parse BuildURL when annotating with JobURL", zap.String("buildURL", buildURL))


### PR DESCRIPTION
In previous versions on k8s stack there was `BUILDKITE_REPO` env var on the containers in the pod that we used in k8s admission hook to mount additional volume containing repository to the pod to speed up clones. In latest k8s stack this is no longer exposed and would be great to have an alternative. We are also using `BUILDKITE_PIPELINE_SLUG` to emit some metrics from k8s - this variable is also no longer visible to k8s. 

There seems to be precedent for exposing some of repository and build information through annotations, for example there is `buildkite.com/build-branch` and `buildkite.com/build-url`. So I'm proposing to add 2 new annotations - `buildkite.com/build-repo` and `buildkite.com/pipeline-slug` that would contain above mentioned values.