### PR TITLE
Add podTemplate to plugin config

### DIFF
--- a/.buildkite/fixtures/podtemplates.yaml
+++ b/.buildkite/fixtures/podtemplates.yaml
@@ -1,0 +1,14 @@
+# This PodTemplate is used by TestPodTemplate.
+apiVersion: v1
+kind: PodTemplate
+metadata:
+  name: integration-tests-pod-template
+  namespace: buildkite-k8s-integration-test
+template:
+  spec:
+    containers:
+      - name: templated
+        image: alpine:latest
+        env:
+          - name: TEST_POD_TEMPLATE
+            value: kunanyi

--- a/.buildkite/rbac.yaml
+++ b/.buildkite/rbac.yaml
@@ -6,6 +6,7 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - podtemplates
       - secrets
     verbs:
       - get

--- a/charts/agent-stack-k8s/templates/rbac.yaml.tpl
+++ b/charts/agent-stack-k8s/templates/rbac.yaml.tpl
@@ -25,6 +25,7 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - podtemplates
       - secrets
     verbs:
       - get

--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -98,6 +98,7 @@ func New(logger *zap.Logger, client kubernetes.Interface, agentClient *api.Agent
 type KubernetesPlugin struct {
 	PodSpec                  *corev1.PodSpec        `json:"podSpec,omitempty"`
 	PodSpecPatch             *corev1.PodSpec        `json:"podSpecPatch,omitempty"`
+	PodTemplate              string                 `json:"podTemplate,omitempty"`
 	GitEnvFrom               []corev1.EnvFromSource `json:"gitEnvFrom,omitempty"`
 	Sidecars                 []corev1.Container     `json:"sidecars,omitempty"`
 	Metadata                 config.Metadata        `json:"metadata,omitempty"`
@@ -153,9 +154,24 @@ func (w *worker) Handle(ctx context.Context, job *api.AgentScheduledJob) error {
 	}
 
 	podSpec := &corev1.PodSpec{}
-	// Use the podSpec provided by the plugin, if allowed.
-	if inputs.k8sPlugin != nil && inputs.k8sPlugin.PodSpec != nil {
-		podSpec = inputs.k8sPlugin.PodSpec
+
+	if inputs.k8sPlugin != nil {
+		// Use the podSpec provided by the plugin.
+		// If that's not set, use the pod template.
+		// If that's also not set, use the empty podSpec.
+		switch {
+		case inputs.k8sPlugin.PodSpec != nil:
+			podSpec = inputs.k8sPlugin.PodSpec
+
+		case inputs.k8sPlugin.PodTemplate != "":
+			ptName := inputs.k8sPlugin.PodTemplate
+			pt, err := w.client.CoreV1().PodTemplates(w.cfg.Namespace).Get(ctx, ptName, metav1.GetOptions{})
+			if err != nil {
+				logger.Warn("Error fetching podTemplate", zap.String("podTemplate", ptName), zap.Error(err))
+				return w.failJob(ctx, inputs, fmt.Sprintf("Error fetching podTemplate %q: %v", ptName, err))
+			}
+			podSpec = &pt.Template.Spec
+		}
 	}
 
 	kjob, err := w.Build(podSpec, false, inputs)

--- a/internal/integration/fixtures/podtemplate.yaml
+++ b/internal/integration/fixtures/podtemplate.yaml
@@ -1,0 +1,9 @@
+steps:
+  - label: ":wave:"
+    command: echo "$${TEST_POD_TEMPLATE} is a mountain"
+    agents:
+      queue: "{{.queue}}"
+    plugins:
+      - kubernetes:
+          # This template is defined in /.buildkite/fixtures (applied manually).
+          podTemplate: integration-tests-pod-template

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -73,6 +73,21 @@ func TestResourceClass(t *testing.T) {
 	tc.AssertLogsContain(build, "✅ CPU limit is correctly set to ~500m")
 }
 
+func TestPodTemplate(t *testing.T) {
+	tc := testcase{
+		T:       t,
+		Fixture: "podtemplate.yaml",
+		Repo:    repoHTTP,
+		GraphQL: api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
+	}.Init()
+	ctx := context.Background()
+	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)
+	tc.StartController(ctx, cfg)
+	build := tc.TriggerBuild(ctx, pipelineID)
+	tc.AssertSuccess(ctx, build)
+	tc.AssertLogsContain(build, "kunanyi is a mountain")
+}
+
 func TestDefaultQueue(t *testing.T) {
 	// Note: this test assumes the default queue is called "default".
 	// This happens to be the case for our CI setup.


### PR DESCRIPTION
### What

Add a `podTemplate` field to the plugin config. If a `podTemplate` is provided (but not a `podSpec`), fetch it from Kubernetes and use it as the initial pod spec.

### Why

https://linear.app/buildkite/issue/PS-1233

Seems like a straightforward way to reduce in-band configuration using the built-in Kubernetes `PodTemplate` resource kind.

### TODO

- [x] Add a test