### PR TITLE
PB-732: use new batched notification API

### DIFF
--- a/internal/stacksapi/stack_notification_test.go
+++ b/internal/stacksapi/stack_notification_test.go
@@ -3,27 +3,39 @@ package stacksapi
 import (
 	"encoding/json"
 	"net/http"
-	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCreateStackNotification(t *testing.T) {
+func TestCreateStackNotifications(t *testing.T) {
 	t.Parallel()
 
-	t.Run("successful create stack notification", func(t *testing.T) {
+	t.Run("successful create stack notifications", func(t *testing.T) {
 		t.Parallel()
 
-		server, client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
-			verifyAuthMethodPath(t, r, "POST", "/stacks/stack-123/jobs/456/stack_notifications")
+		sampleTime := time.Now()
 
-			var params CreateStackNotificationRequest
+		server, client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			verifyAuthMethodPath(t, r, "POST", "/stacks/stack-123/notifications")
+
+			var params CreateStackNotificationsRequest
 			assert.NoError(t, json.NewDecoder(r.Body).Decode(&params))
 
-			expectedParams := CreateStackNotificationRequest{
-				Detail: "Pod is starting up",
+			expectedParams := CreateStackNotificationsRequest{
+				Notifications: []StackNotification{
+					{
+						JobUUID:   "456",
+						Detail:    "Pod 1 starting",
+						Timestamp: sampleTime,
+					},
+					{
+						JobUUID: "789",
+						Detail:  "Pod 2 starting",
+					},
+				},
 			}
 
 			if diff := cmp.Diff(expectedParams, params); diff != "" {
@@ -32,53 +44,86 @@ func TestCreateStackNotification(t *testing.T) {
 
 			w.Header().Set("X-Custom-Header", "custom-value")
 			w.WriteHeader(http.StatusOK)
+			assert.NoError(t, json.NewEncoder(w).Encode(CreateStackNotificationsResponse{
+				Errors: []StackNotificationError{},
+			}))
 		})
 		t.Cleanup(func() { server.Close() })
 
-		req := CreateStackNotificationRequest{
+		req := CreateStackNotificationsRequest{
 			StackKey: "stack-123",
-			JobUUID:  "456",
-			Detail:   "Pod is starting up",
+			Notifications: []StackNotification{
+				{
+					JobUUID:   "456",
+					Detail:    "Pod 1 starting",
+					Timestamp: sampleTime,
+				},
+				{
+					JobUUID: "789",
+					Detail:  "Pod 2 starting",
+				},
+			},
 		}
 
-		header, err := client.CreateStackNotification(t.Context(), req)
+		resp, header, err := client.CreateStackNotifications(t.Context(), req)
 		if err != nil {
-			t.Fatalf("client.CreateStackNotification returned an error: %v", err)
+			t.Fatalf("client.CreateStackNotifications returned an error: %v", err)
 		}
 
 		want, got := "custom-value", header.Get("X-Custom-Header")
 		if want != got {
 			t.Errorf("header.Get(\"X-Custom-Header\") = %q, want %q", got, want)
 		}
+
+		assert.Empty(t, resp.Errors)
 	})
 
-	t.Run("crops detail when exceeds 255 characters", func(t *testing.T) {
+	t.Run("returns errors for validation failures", func(t *testing.T) {
 		t.Parallel()
 
 		server, client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
-			verifyAuthMethodPath(t, r, "POST", "/stacks/stack-123/jobs/456/stack_notifications")
-
-			var params CreateStackNotificationRequest
-			assert.NoError(t, json.NewDecoder(r.Body).Decode(&params))
-
-			// Verify the detail was cropped to 255 characters
-			assert.Equal(t, 255, len(params.Detail))
-			assert.True(t, strings.HasSuffix(params.Detail, "… (cropped)"))
+			verifyAuthMethodPath(t, r, "POST", "/stacks/stack-123/notifications")
 
 			w.WriteHeader(http.StatusOK)
+			assert.NoError(t, json.NewEncoder(w).Encode(CreateStackNotificationsResponse{
+				Errors: []StackNotificationError{
+					{
+						Error:   "detail is required",
+						Indexes: []int{1},
+					},
+					{
+						Error:   "detail exceeds its length limit of 256",
+						Indexes: []int{3},
+					},
+				},
+			}))
 		})
 		t.Cleanup(func() { server.Close() })
 
-		// Create a detail longer than 255 characters
-		largeDetail := strings.Repeat("x", 300) // 300 characters
-
-		req := CreateStackNotificationRequest{
+		req := CreateStackNotificationsRequest{
 			StackKey: "stack-123",
-			JobUUID:  "456",
-			Detail:   largeDetail,
+			Notifications: []StackNotification{
+				{JobUUID: "456", Detail: "Valid"},
+				{JobUUID: "789", Detail: ""},
+				{JobUUID: "abc", Detail: "Another valid"},
+				{JobUUID: "def", Detail: string(make([]byte, 257))},
+			},
 		}
 
-		_, err := client.CreateStackNotification(t.Context(), req)
+		resp, _, err := client.CreateStackNotifications(t.Context(), req)
 		assert.NoError(t, err)
+		wantErrors := []StackNotificationError{
+			{
+				Error:   "detail is required",
+				Indexes: []int{1},
+			},
+			{
+				Error:   "detail exceeds its length limit of 256",
+				Indexes: []int{3},
+			},
+		}
+		if diff := cmp.Diff(resp.Errors, wantErrors); diff != "" {
+			t.Errorf("resp.Errors diff (-got +want):\n%s", diff)
+		}
 	})
 }


### PR DESCRIPTION
Accommodate our breaking changes in backend for the stack notification API. 

In this PR, the agent_client level abstraction remains unchanged. I make this so we can quickly cut over to the new API design and get our CI working unblock.

I will very quickly make a follow up PR that actually batch notification on agent_client side. But the changes in stack_api layer will stay. 