### PR TITLE
Linter rules for require/assert

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -2,6 +2,8 @@ version: "2"
 run:
   timeout: 10m
 linters:
+  enable:
+    - testifylint
   exclusions:
     generated: lax
     presets:
@@ -13,6 +15,12 @@ linters:
       - third_party$
       - builtin$
       - examples$
+  settings:
+    testifylint:
+      disable-all: true
+      enable:
+        - require-error
+        - useless-assert
 formatters:
   exclusions:
     generated: lax

--- a/internal/integration/cleanup_test.go
+++ b/internal/integration/cleanup_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/buildkite/agent-stack-k8s/v2/internal/integration/api"
 	"github.com/buildkite/roko"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -55,7 +54,9 @@ func TestCleanupOrphanedPipelines(t *testing.T) {
 					graphqlClient,
 					api.BuildCancelInput{Id: build.Node.Id},
 				)
-				assert.NoError(t, err)
+				if err != nil {
+					t.Logf("failed to cancel build %s: %v", build.Node.Id, err)
+				}
 			}
 
 			tc.deletePipeline(ctx)

--- a/internal/integration/testcase_test.go
+++ b/internal/integration/testcase_test.go
@@ -291,12 +291,12 @@ func (t testcase) FetchLogs(build api.Build) string {
 			strconv.Itoa(build.Number),
 			job.Uuid,
 		)
-		if !assert.NoError(t, err) || !assert.NotNil(t, jobLog.Content) {
+		if err != nil || !assert.NotNil(t, jobLog.Content) {
 			continue
 		}
 
 		_, err = logs.WriteString(*jobLog.Content)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 
 	return logs.String()

--- a/internal/stacksapi/get_job_states_test.go
+++ b/internal/stacksapi/get_job_states_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetJobStates(t *testing.T) {
@@ -19,7 +19,7 @@ func TestGetJobStates(t *testing.T) {
 			verifyAuthMethodPath(t, r, "POST", "/stacks/stack-123/jobs/get-states")
 
 			var params GetJobStatesRequest
-			assert.NoError(t, json.NewDecoder(r.Body).Decode(&params))
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&params))
 
 			expectedParams := GetJobStatesRequest{
 				JobUUIDs: []string{"job-1", "job-2", "job-3"},
@@ -39,7 +39,7 @@ func TestGetJobStates(t *testing.T) {
 
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			assert.NoError(t, json.NewEncoder(w).Encode(response))
+			require.NoError(t, json.NewEncoder(w).Encode(response))
 		})
 		t.Cleanup(func() { server.Close() })
 
@@ -49,7 +49,7 @@ func TestGetJobStates(t *testing.T) {
 		}
 
 		response, _, err := client.GetJobStates(t.Context(), req)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		expectedResponse := &GetJobStatesResponse{
 			States: map[string]string{

--- a/internal/stacksapi/stack_notification_test.go
+++ b/internal/stacksapi/stack_notification_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCreateStackNotifications(t *testing.T) {
@@ -22,7 +23,7 @@ func TestCreateStackNotifications(t *testing.T) {
 			verifyAuthMethodPath(t, r, "POST", "/stacks/stack-123/notifications")
 
 			var params CreateStackNotificationsRequest
-			assert.NoError(t, json.NewDecoder(r.Body).Decode(&params))
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&params))
 
 			expectedParams := CreateStackNotificationsRequest{
 				Notifications: []StackNotification{
@@ -44,7 +45,7 @@ func TestCreateStackNotifications(t *testing.T) {
 
 			w.Header().Set("X-Custom-Header", "custom-value")
 			w.WriteHeader(http.StatusOK)
-			assert.NoError(t, json.NewEncoder(w).Encode(CreateStackNotificationsResponse{
+			require.NoError(t, json.NewEncoder(w).Encode(CreateStackNotificationsResponse{
 				Errors: []StackNotificationError{},
 			}))
 		})
@@ -85,7 +86,7 @@ func TestCreateStackNotifications(t *testing.T) {
 			verifyAuthMethodPath(t, r, "POST", "/stacks/stack-123/notifications")
 
 			w.WriteHeader(http.StatusOK)
-			assert.NoError(t, json.NewEncoder(w).Encode(CreateStackNotificationsResponse{
+			require.NoError(t, json.NewEncoder(w).Encode(CreateStackNotificationsResponse{
 				Errors: []StackNotificationError{
 					{
 						Error:   "detail is required",
@@ -111,7 +112,7 @@ func TestCreateStackNotifications(t *testing.T) {
 		}
 
 		resp, _, err := client.CreateStackNotifications(t.Context(), req)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		wantErrors := []StackNotificationError{
 			{
 				Error:   "detail is required",


### PR DESCRIPTION
Simple linter rules to ensure that we don't use `assert.NoError`. 