### PR TITLE
Fix hugepages lowercase issue in podSpecPatch

### DIFF
--- a/cmd/controller/controller_test.go
+++ b/cmd/controller/controller_test.go
@@ -154,8 +154,9 @@ func TestReadAndParseConfig(t *testing.T) {
 					},
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
-							"cpu": resource.MustParse("1000m"),
-							"mem": resource.MustParse("4Gi"),
+							"cpu":           resource.MustParse("1000m"),
+							"mem":           resource.MustParse("4Gi"),
+							"hugepages-2Mi": resource.MustParse("2Mi"),
 						},
 					},
 				},

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -117,3 +117,4 @@ pod-spec-patch:
         requests:
           cpu: 1
           mem: 4Gi
+          hugepages-2Mi: 2Mi


### PR DESCRIPTION
in https://github.com/buildkite/agent-stack-k8s/pull/732, (and its 0.32.x backport, #736), we fixed an issue where to a bug in viper, all keys of maps get downcased when passed in as config values. this caused resource claims for `hugepages`, which are generally of the form `hugepages-2Mi` or `hugepages-2Gi` (and which are case-sensitive) to be downcased to `hugepages-2mi` and `hugepages-2mi`, and in so doing not get recognised by the k8s scheduler.

We fixed this issues when those resource claims were specified in resource classes for the agent-stack-k8s controller, but the same issue presented itself when resource claims were specified in a controller-level `podSpecPatch`.

This PR fixes the same issue (in the same way) for `podSpecPatch` resource claims as for those in resource classes.