### PR TITLE
PS-1176: detect command containter using BUILDKITE_COMMAND EnvVar

### DIFF
--- a/internal/controller/config/resource_class_test.go
+++ b/internal/controller/config/resource_class_test.go
@@ -9,6 +9,16 @@ import (
 )
 
 func TestResourceClass_Apply(t *testing.T) {
+	commandContainerEnv := []corev1.EnvVar{
+		{
+			Name:  "BUILDKITE_BOOTSTRAP_PHASES",
+			Value: "plugin,command",
+		},
+		{
+			Name:  "BUILDKITE_COMMAND",
+			Value: "buildkite-agent foo",
+		},
+	}
 	tests := []struct {
 		name          string
 		resourceClass *ResourceClass
@@ -32,15 +42,15 @@ func TestResourceClass_Apply(t *testing.T) {
 			podSpec: &corev1.PodSpec{
 				Containers: []corev1.Container{
 					{
-						Name:      commandContainerName,
 						Resources: corev1.ResourceRequirements{},
+						Env:       commandContainerEnv,
 					},
 				},
 			},
 			want: &corev1.PodSpec{
 				Containers: []corev1.Container{
 					{
-						Name: commandContainerName,
+						Env: commandContainerEnv,
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
 								corev1.ResourceCPU:    resource.MustParse("100m"),
@@ -65,7 +75,9 @@ func TestResourceClass_Apply(t *testing.T) {
 			},
 			podSpec: &corev1.PodSpec{
 				Containers: []corev1.Container{
-					{Name: commandContainerName},
+					{
+						Env: commandContainerEnv,
+					},
 				},
 			},
 			want: &corev1.PodSpec{
@@ -74,7 +86,9 @@ func TestResourceClass_Apply(t *testing.T) {
 					"zone":          "us-west-2a",
 				},
 				Containers: []corev1.Container{
-					{Name: commandContainerName},
+					{
+						Env: commandContainerEnv,
+					},
 				},
 			},
 		},
@@ -92,7 +106,9 @@ func TestResourceClass_Apply(t *testing.T) {
 			},
 			podSpec: &corev1.PodSpec{
 				Containers: []corev1.Container{
-					{Name: commandContainerName},
+					{
+						Env: commandContainerEnv,
+					},
 				},
 			},
 			want: &corev1.PodSpec{
@@ -101,7 +117,7 @@ func TestResourceClass_Apply(t *testing.T) {
 				},
 				Containers: []corev1.Container{
 					{
-						Name: commandContainerName,
+						Env: commandContainerEnv,
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
 								corev1.ResourceCPU: resource.MustParse("500m"),
@@ -117,12 +133,16 @@ func TestResourceClass_Apply(t *testing.T) {
 			resourceClass: nil,
 			podSpec: &corev1.PodSpec{
 				Containers: []corev1.Container{
-					{Name: commandContainerName},
+					{
+						Env: commandContainerEnv,
+					},
 				},
 			},
 			want: &corev1.PodSpec{
 				Containers: []corev1.Container{
-					{Name: commandContainerName},
+					{
+						Env: commandContainerEnv,
+					},
 				},
 			},
 		},

--- a/internal/controller/model/model.go
+++ b/internal/controller/model/model.go
@@ -8,6 +8,7 @@ import (
 	"github.com/buildkite/agent-stack-k8s/v2/api"
 
 	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // ErrDuplicateJob is a sentinel error returned when a job has already been
@@ -38,5 +39,17 @@ func JobFinished(job *batchv1.Job) bool {
 			return true
 		}
 	}
+	return false
+}
+
+// Detect if a container is a buildkite command container.
+// The detection logic is a heuristic, but there is a very low likelihood of false positives.
+func IsCommandContainer(container *corev1.Container) bool {
+	for _, env := range container.Env {
+		if env.Name == "BUILDKITE_COMMAND" && env.Value != "" {
+			return true
+		}
+	}
+
 	return false
 }

--- a/internal/controller/scheduler/build_inputs.go
+++ b/internal/controller/scheduler/build_inputs.go
@@ -1,6 +1,9 @@
 package scheduler
 
-import v1 "k8s.io/api/core/v1"
+import (
+	"github.com/buildkite/agent-stack-k8s/v2/internal/controller/model"
+	v1 "k8s.io/api/core/v1"
+)
 
 func applyCustomImageIfPresent(podSpec *v1.PodSpec, inputs *buildInputs) *v1.PodSpec {
 
@@ -11,7 +14,7 @@ func applyCustomImageIfPresent(podSpec *v1.PodSpec, inputs *buildInputs) *v1.Pod
 
 	for i := range podSpec.Containers {
 		c := &podSpec.Containers[i]
-		if c.Name != CommandContainerName {
+		if !model.IsCommandContainer(c) {
 			continue
 		}
 

--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -43,7 +43,7 @@ const (
 	CopyAgentContainerName        = "copy-agent"
 	ImageCheckContainerNamePrefix = "imagecheck-"
 	CheckoutContainerName         = "checkout"
-	CommandContainerName          = "container-0"
+	DefaultCommandContainerName   = "container-0"
 )
 
 var errK8sPluginProhibited = errors.New("the kubernetes plugin is prohibited by this controller, but was configured on this job")
@@ -450,7 +450,7 @@ func (w *worker) Build(podSpec *corev1.PodSpec, skipCheckout bool, inputs buildI
 	if len(podSpec.Containers) == 0 {
 		// Create a default command container
 		c := corev1.Container{
-			Name:         CommandContainerName,
+			Name:         DefaultCommandContainerName,
 			Image:        w.cfg.Image,
 			Command:      commandContainerCommand,
 			Args:         commandContainerArgs,
@@ -471,7 +471,7 @@ func (w *worker) Build(podSpec *corev1.PodSpec, skipCheckout bool, inputs buildI
 				},
 				{
 					Name:  "BUILDKITE_SOCKETS_PATH",
-					Value: "/workspace/sockets/" + CommandContainerName,
+					Value: "/workspace/sockets/" + DefaultCommandContainerName,
 				},
 			},
 		}

--- a/internal/controller/scheduler/scheduler_test.go
+++ b/internal/controller/scheduler/scheduler_test.go
@@ -945,7 +945,7 @@ func TestCustomImageSyntax_pluginTakesTopPriority(t *testing.T) {
 	kjob, err := worker.Build(&corev1.PodSpec{}, false, inputs)
 	require.NoError(t, err)
 
-	commandContainer := findContainer(t, kjob.Spec.Template.Spec.Containers, CommandContainerName)
+	commandContainer := findContainer(t, kjob.Spec.Template.Spec.Containers, DefaultCommandContainerName)
 	require.Equal(t, "x-image:plugin", commandContainer.Image)
 }
 
@@ -954,7 +954,8 @@ func TestCustomImageSyntax_jobLevelImagePriority(t *testing.T) {
 	t.Parallel()
 
 	job := &api.AgentJob{
-		ID: "abc",
+		ID:      "abc",
+		Command: "echo hello",
 		Env: map[string]string{
 			"BUILDKITE_IMAGE": "x-image:job",
 		},
@@ -978,7 +979,8 @@ func TestCustomImageSyntax_jobLevelImagePriority(t *testing.T) {
 	kjob, err := worker.Build(&corev1.PodSpec{}, false, inputs)
 	require.NoError(t, err)
 
-	commandContainer := findContainer(t, kjob.Spec.Template.Spec.Containers, CommandContainerName)
+	commandContainer := findContainer(t, kjob.Spec.Template.Spec.Containers, DefaultCommandContainerName)
+
 	require.Equal(t, "x-image:job", commandContainer.Image)
 }
 


### PR DESCRIPTION
When we introduced the image attribute and resource class, we (I) incorrectly assume that command container would all have a simple "name: container-0" pattern. 

This PR breaks this wrong assumption by using `BUILDKITE_COMMAND` and `BUILDKITE_BOOTSTRAP_PHASES` as the main detection mechanism. 

Closes #697 