### PR TITLE
Update k8s stack to always use the stacks API

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -164,51 +164,6 @@ steps:
           files: junit-*.xml
           format: junit
 
-  - label: ":buildkite::test_tube::rocket: tests (experimental features)"
-    key: tests-experimental
-    depends_on: agent
-    artifact_paths: junit-*.xml
-    command: .buildkite/steps/tests.sh
-    env:
-      CONFIG: /etc/config.yaml
-      EXPERIMENTAL_STACKS_API_SUPPORT: true
-    plugins:
-      - kubernetes:
-          podSpecPatch:
-            serviceAccountName: integration-tests
-            volumes:
-              - name: agent-stack-k8s-config
-                configMap:
-                  name: agent-stack-k8s-config
-              - *go-cache-volume
-              - *go-mod-cache-volume
-            containers:
-              - name: container-0
-                image: golang:latest
-                env:
-                  - *go-cache-env
-                  - *go-mod-cache-env
-                envFrom:
-                  - secretRef:
-                      name: agent-stack-k8s-secrets
-                volumeMounts:
-                  - mountPath: /etc/config.yaml
-                    name: agent-stack-k8s-config
-                    subPath: config.yaml
-                  - *go-cache-mount
-                  - *go-mod-cache-mount
-                resources:
-                  requests:
-                    cpu: 1000m
-                    memory: 512Mi
-      - cluster-secrets#v1.0.0:
-          variables:
-            BUILDKITE_TOKEN: integration_test_buildkite_api_token
-            BUILDKITE_ANALYTICS_TOKEN: test_engine_suite_token
-      - test-collector:
-          files: junit-*.xml
-          format: junit
-
   - label: ":docker: build and push controller image"
     key: controller
     plugins:
@@ -249,7 +204,6 @@ steps:
       - agent
       - controller
       - tests
-      - tests-experimental
 
   - if: build.branch == pipeline.default_branch
     label: ":shipit: deploy"

--- a/.buildkite/steps/deploy.sh
+++ b/.buildkite/steps/deploy.sh
@@ -22,6 +22,5 @@ helm upgrade agent-stack-k8s "${helm_repo_pecr}/agent-stack-k8s" \
   --set config.image="${agent_image}" \
   --set config.debug=true \
   --set config.profiler-address=localhost:6060 \
-  --set config.experimental-stacks-api-support=true \
   --set monitoring.podMonitor.deploy=true \
   --set monitoring.deployGrafanaDashboard=true

--- a/cmd/controller/controller_test.go
+++ b/cmd/controller/controller_test.go
@@ -18,9 +18,6 @@ func ptr[T any](v T) *T {
 }
 
 func TestReadAndParseConfig(t *testing.T) {
-	t.Setenv("EXPERIMENTAL_JOB_RESERVATION_SUPPORT", "true")
-	t.Setenv("EXPERIMENTAL_STACKS_API_SUPPORT", "true")
-
 	expected := config.Config{
 		Debug:                                true,
 		AgentTokenSecret:                     "my-kubernetes-secret",
@@ -51,8 +48,6 @@ func TestReadAndParseConfig(t *testing.T) {
 		WorkQueueLimit:                       2_000_000,
 		ImageCheckContainerCPULimit:          "201m",
 		ImageCheckContainerMemoryLimit:       "129Mi",
-
-		ExperimentalStacksAPISupport: true,
 
 		ResourceClasses: map[string]*config.ResourceClass{
 			"small": {

--- a/config.dev.yaml
+++ b/config.dev.yaml
@@ -6,8 +6,6 @@ agent-config:
   # a different instance of Buildkite itself available to run.
   endpoint: http://agent.buildkite.localhost/v3
 
-experimental-stacks-api-support: true
-
 pod-spec-patch:
   hostAliases:
     # Minikube specific with docker driver.

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -24,7 +24,6 @@ query-reset-interval: 10s
 work-queue-limit: 2000000
 image-check-container-cpu-limit: 201m
 image-check-container-memory-limit: 129Mi
-experimental-stacks-api-support: true
 
 resource-classes:
   small:

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -147,7 +147,6 @@ func (c Config) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	enc.AddUint16("prometheus-port", c.PrometheusPort)
 	enc.AddBool("prohibit-kubernetes-plugin", c.ProhibitKubernetesPlugin)
 	enc.AddBool("allow-pod-spec-patch-unsafe-command-modification", c.AllowPodSpecPatchUnsafeCmdMod)
-	enc.AddBool("experimental-stacks-api-support", c.ExperimentalStacksAPISupport)
 	if err := enc.AddArray("additional-redacted-vars", c.AdditionalRedactedVars); err != nil {
 		return err
 	}

--- a/internal/controller/reserver/reserver.go
+++ b/internal/controller/reserver/reserver.go
@@ -23,16 +23,14 @@ type Reserver struct {
 	// Logs goes here
 	logger *zap.Logger
 
-	enabled bool
-	paused  bool
+	paused bool
 }
 
-func New(logger *zap.Logger, agentClient *api.AgentClient, nextHandler model.ManyJobHandler, enabled bool) *Reserver {
+func New(logger *zap.Logger, agentClient *api.AgentClient, nextHandler model.ManyJobHandler) *Reserver {
 	r := &Reserver{
 		handler:     nextHandler,
 		agentClient: agentClient,
 		logger:      logger,
-		enabled:     enabled,
 	}
 
 	return r
@@ -48,10 +46,6 @@ func (r *Reserver) Pause(pause bool) {
 func (r *Reserver) HandleMany(ctx context.Context, jobs []*api.AgentScheduledJob) error {
 	if r.paused {
 		return nil
-	}
-
-	if !r.enabled {
-		return r.handler.HandleMany(ctx, jobs)
 	}
 
 	jobIDs := make([]string, 0, len(jobs))

--- a/internal/controller/scheduler/fail_job.go
+++ b/internal/controller/scheduler/fail_job.go
@@ -1,24 +1,14 @@
 package scheduler
 
 import (
-	"cmp"
 	"context"
 	"errors"
-	"fmt"
-	"os"
 
 	"github.com/buildkite/agent-stack-k8s/v2/api"
-	"github.com/buildkite/agent-stack-k8s/v2/internal/controller/agenttags"
 	"github.com/buildkite/agent-stack-k8s/v2/internal/controller/config"
-	"github.com/buildkite/agent-stack-k8s/v2/internal/version"
-
-	"github.com/buildkite/agent/v3/agent"
-	agentcore "github.com/buildkite/agent/v3/core"
-	"github.com/buildkite/agent/v3/logger"
 
 	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 )
 
 // FailureInfo contains data about a job failure for reporting to Buildkite.
@@ -30,20 +20,7 @@ type FailureInfo struct {
 
 // failForK8sObject figures out how to fail the BK job corresponding to
 // the k8s object (a pod or job) by inspecting the object's labels.
-func failForK8sObject(
-	ctx context.Context,
-	logger *zap.Logger,
-	obj metav1.Object,
-	failureInfo FailureInfo,
-
-	// This is used for API driven fail job.
-	agentClient *api.AgentClient,
-
-	// These two are used by fail job via acquire and fail.
-	k8sClient kubernetes.Interface,
-	cfg *config.Config,
-) error {
-
+func failForK8sObject(ctx context.Context, logger *zap.Logger, obj metav1.Object, failureInfo FailureInfo, agentClient *api.AgentClient) error {
 	logger.Info(
 		"failing a job for k8s object",
 		zap.String("name", obj.GetName()),
@@ -56,89 +33,6 @@ func failForK8sObject(
 		logger.Error("object missing UUID label", zap.String("label", config.UUIDLabel))
 		return errors.New("missing UUID label")
 	}
-	if agentClient.UseStackAPI() {
-		return agentClient.FailJob(ctx, jobUUID, failureInfo.Message)
-	} else {
-		tags := agenttags.TagsFromLabels(labels)
-		opts := cfg.AgentConfig.ControllerOptions()
-		agentToken, err := fetchAgentToken(ctx, logger, k8sClient, obj.GetNamespace(), cfg.AgentTokenSecret)
-		if err != nil {
-			logger.Error("fetching agent token from secret", zap.Error(err))
-			return err
-		}
-		return acquireAndFail(ctx, logger, agentToken, cfg.JobPrefix, jobUUID, tags, failureInfo, opts...)
-	}
-}
 
-// acquireAndFail fails the job in Buildkite. agentToken needs to be the token value.
-// Use fetchAgentToken to fetch it from the k8s secret.
-func acquireAndFail(
-	ctx context.Context,
-	zapLogger *zap.Logger,
-	agentToken string,
-	jobPrefix string,
-	jobUUID string,
-	tags []string,
-	failureInfo FailureInfo,
-	options ...agentcore.ControllerOption,
-) error {
-	opts := append([]agentcore.ControllerOption{
-		agentcore.WithUserAgent("agent-stack-k8s/" + version.Version()),
-		agentcore.WithLogger(logger.NewConsoleLogger(logger.NewTextPrinter(os.Stderr), func(int) {})),
-	}, options...)
-
-	// queue is required for acquire! maybe more
-	ctr, err := agentcore.NewController(ctx, agentToken, k8sJobName(jobPrefix, jobUUID), tags, opts...)
-	if err != nil {
-		zapLogger.Error("registering or connecting ephemeral agent", zap.Error(err))
-		return fmt.Errorf("registering or connecting ephemeral agent: %w", err)
-	}
-	defer ctr.Close(ctx)
-
-	job, err := ctr.AcquireJob(ctx, jobUUID)
-	if err != nil {
-		zapLogger.Error("acquiring job", zap.Error(err))
-		return fmt.Errorf("acquiring job: %w", err)
-	}
-
-	jctr := ctr.NewJobController(job)
-	if err := jctr.Start(ctx); err != nil {
-		zapLogger.Error("starting job", zap.Error(err))
-		return fmt.Errorf("starting job: %w", err)
-	}
-
-	if err := jctr.WriteLog(ctx, failureInfo.Message); err != nil {
-		zapLogger.Error("writing log", zap.Error(err))
-		return fmt.Errorf("writing log: %w", err)
-	}
-
-	var ignoreAgentInDispatches *bool
-
-	failureInfo.ExitCode = cmp.Or(failureInfo.ExitCode, 1)
-	// By default, we consider all failure triggered by the stack controller are stack errors
-	failureInfo.Reason = cmp.Or(failureInfo.Reason, string(agent.SignalReasonStackError))
-
-	processExit := agentcore.ProcessExit{Status: int(failureInfo.ExitCode), SignalReason: failureInfo.Reason}
-	if err := jctr.Finish(ctx, processExit, ignoreAgentInDispatches); err != nil {
-		zapLogger.Error("finishing job", zap.Error(err))
-		return fmt.Errorf("finishing job: %w", err)
-	}
-
-	return nil
-}
-
-// fetchAgentToken fetches the agent token from the agent token secret.
-func fetchAgentToken(ctx context.Context, logger *zap.Logger, k8sClient kubernetes.Interface, namespace, agentTokenSecretName string) (string, error) {
-	// Need to fetch the agent token ourselves.
-	tokenSecret, err := k8sClient.CoreV1().Secrets(namespace).Get(ctx, agentTokenSecretName, metav1.GetOptions{})
-	if err != nil {
-		logger.Error("fetching agent token from secret", zap.Error(err))
-		return "", err
-	}
-	agentToken := string(tokenSecret.Data[agentTokenKey])
-	if agentToken == "" {
-		logger.Error("agent token is empty")
-		return "", errors.New("agent token is empty")
-	}
-	return agentToken, nil
+	return agentClient.FailJob(ctx, jobUUID, failureInfo.Message)
 }

--- a/internal/controller/scheduler/job_watcher.go
+++ b/internal/controller/scheduler/job_watcher.go
@@ -241,7 +241,7 @@ func (w *jobWatcher) failJob(ctx context.Context, log *zap.Logger, kjob *batchv1
 		// We can know almost all failures triggered by job watcher are stack related error.
 		Reason: agent.SignalReasonStackError,
 	}
-	if err := failForK8sObject(ctx, log, kjob, failureInfo, w.agentClient, w.k8s, w.cfg); err != nil {
+	if err := failForK8sObject(ctx, log, kjob, failureInfo, w.agentClient); err != nil {
 		// Maybe the job was cancelled in the meantime?
 		log.Error("Could not fail Buildkite job", zap.Error(err))
 		jobWatcherBuildkiteJobFailErrorsCounter.Inc()

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -195,7 +195,7 @@ func TestPodSpecPatchRejectsPatchingAgentContainerCommand(t *testing.T) {
 	build := tc.TriggerBuild(ctx, pipelineID)
 
 	tc.AssertFail(ctx, build)
-	fm := tc.FailureMessage(build, tc.FirstCommandJobID(build), cfg.ExperimentalStacksAPISupport)
+	fm := tc.FailureMessage(tc.FirstCommandJobID(build))
 	assert.Contains(t, fm, scheduler.ErrNoCommandModification.Error(), "expected failure message to mention command modification")
 }
 
@@ -531,7 +531,7 @@ func TestInvalidPodSpec(t *testing.T) {
 	build := tc.TriggerBuild(ctx, pipelineID)
 	tc.AssertFail(ctx, build)
 	jobID := tc.FirstCommandJobID(build)
-	fm := tc.FailureMessage(build, jobID, cfg.ExperimentalStacksAPISupport)
+	fm := tc.FailureMessage(jobID)
 	assert.Contains(t, fm, `is invalid: spec.template.spec.containers[0].volumeMounts[0].name: Not found: "this-doesnt-exist"`)
 }
 
@@ -548,7 +548,7 @@ func TestInvalidPodJSON(t *testing.T) {
 	build := tc.TriggerBuild(ctx, pipelineID)
 	tc.AssertFail(ctx, build)
 	jobID := tc.FirstCommandJobID(build)
-	fm := tc.FailureMessage(build, jobID, cfg.ExperimentalStacksAPISupport)
+	fm := tc.FailureMessage(jobID)
 	assert.Contains(t, fm, "failed parsing Kubernetes plugin: json: cannot unmarshal number into Go struct field EnvVar.podSpec.containers.env.value of type string")
 }
 
@@ -565,7 +565,7 @@ func TestMissingServiceAccount(t *testing.T) {
 	build := tc.TriggerBuild(ctx, pipelineID)
 	tc.AssertFail(ctx, build)
 	jobID := tc.FirstCommandJobID(build)
-	fm := tc.FailureMessage(build, jobID, cfg.ExperimentalStacksAPISupport)
+	fm := tc.FailureMessage(jobID)
 	assert.Contains(t, fm, "error looking up service account")
 }
 
@@ -597,7 +597,7 @@ func TestImagePullBackOffFailed(t *testing.T) {
 	build := tc.TriggerBuild(ctx, pipelineID)
 	tc.AssertFail(ctx, build)
 	jobID := tc.FirstCommandJobID(build)
-	fm := tc.FailureMessage(build, jobID, cfg.ExperimentalStacksAPISupport)
+	fm := tc.FailureMessage(jobID)
 	assert.Contains(t, fm, "The following images could not be pulled or were unavailable:\n")
 	assert.Contains(t, fm, `"buildkite/non-existant-image:latest"`)
 	assert.Contains(t, fm, "ImagePullBackOff")
@@ -619,7 +619,7 @@ func TestPullPolicyNeverMissingImage(t *testing.T) {
 	build := tc.TriggerBuild(ctx, pipelineID)
 	tc.AssertFail(ctx, build)
 	jobID := tc.FirstCommandJobID(build)
-	fm := tc.FailureMessage(build, jobID, cfg.ExperimentalStacksAPISupport)
+	fm := tc.FailureMessage(jobID)
 	assert.Contains(t, fm, "The following images could not be pulled or were unavailable:\n")
 	assert.Contains(t, fm, `"buildkite/agent-extreme:never"`)
 	assert.Contains(t, fm, "ErrImageNeverPull")
@@ -638,7 +638,7 @@ func TestBrokenInitContainer(t *testing.T) {
 	build := tc.TriggerBuild(ctx, pipelineID)
 	tc.AssertFail(ctx, build)
 	jobID := tc.FirstCommandJobID(build)
-	fm := tc.FailureMessage(build, jobID, cfg.ExperimentalStacksAPISupport)
+	fm := tc.FailureMessage(jobID)
 	assert.Contains(t, fm, "The following init containers failed:")
 	assert.Contains(t, fm, "well this isn't going to work")
 }
@@ -656,7 +656,7 @@ func TestInvalidImageRefFormat(t *testing.T) {
 	build := tc.TriggerBuild(ctx, pipelineID)
 	tc.AssertFail(ctx, build)
 	jobID := tc.FirstCommandJobID(build)
-	fm := tc.FailureMessage(build, jobID, cfg.ExperimentalStacksAPISupport)
+	fm := tc.FailureMessage(jobID)
 	assert.Contains(t, fm, `invalid reference format "buildkite/agent:latest plus some extra junk" for container "container-0"`)
 }
 

--- a/internal/integration/testcase_test.go
+++ b/internal/integration/testcase_test.go
@@ -363,12 +363,8 @@ func (t testcase) FirstCommandJobID(build api.Build) string {
 	return ""
 }
 
-func (t testcase) FailureMessage(build api.Build, jobID string, useStacksAPI bool) string {
+func (t testcase) FailureMessage(jobID string) string {
 	t.Helper()
-
-	if !useStacksAPI {
-		return t.FetchLogs(build)
-	}
 
 	time.Sleep(1 * time.Second) // Wait for job events to be available (quicker than logs)
 	jobEvents, err := api.GetJobEvents(t.Context(), t.GraphQL, jobID)

--- a/justfile
+++ b/justfile
@@ -28,8 +28,6 @@ test *FLAGS:
 
   GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
-  export EXPERIMENTAL_STACKS_API_SUPPORT=true
-
   go test \
     -ldflags="-X github.com/buildkite/agent-stack-k8s/v2/internal/integration_test.branch=${GIT_BRANCH}" \
     {{FLAGS}} \


### PR DESCRIPTION
The stacks API, which we've been working on in the background now for a little while, is ready for primetime! While previously enabled in an experimental fashion, this PR makes the stacks API the default, with no way to opt out to the old APIs (without downgrading the stack, anyway — the old APIs will continue to be supported for the foreseeable future, and nothing is going to break in older versions).

The use of the stacks API should only have a few user-facing changes, mostly around the job timeline of jobs picked up by the k8s stack — now, they'll have a little more info given by the k8s stack as to their scheduling process: 
<img width="914" height="1159" alt="CleanShot 2025-10-15 at 13 49 06" src="https://github.com/user-attachments/assets/1c005d65-eaa3-4218-9f19-4c41bed9c557" />

When the k8s stack fails to launch a job, the details of that failure will now be in the job timeline. for example, here's what the output for a job with a malformed `kubernetes` plugin config looks like: 
<img width="914" height="797" alt="CleanShot 2025-10-15 at 13 56 50" src="https://github.com/user-attachments/assets/86cd090c-779f-4bb3-8e81-0fe129101ad9" />

However, the main benefits from the k8s stack using the stacks API come from the fact that it's designed to be much more scalable, and should be able to handle a higher job throughput.

As a procedural note, for the purposes of our CI instance, i've kept the CLI flag that enables the stacks API but it no longer does anything. it'll get removed in a later PR.