### PR TITLE
Remove flag for using stacks API

### DIFF
--- a/cmd/controller/flags.go
+++ b/cmd/controller/flags.go
@@ -129,11 +129,6 @@ func AddConfigFlags(cmd *cobra.Command) {
 		false,
 		"Permits PodSpecPatch to modify the command or args fields of stack-provided containers. See the warning in the README before enabling this option",
 	)
-	cmd.Flags().Bool(
-		"experimental-stacks-api-support",
-		false,
-		"Experimental - enables integration with the Buildkite Stacks API for interactions with the Buildkite control plane.",
-	)
 	cmd.Flags().Int(
 		"pagination-page-size",
 		config.DefaultPaginationPageSize,

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -111,9 +111,6 @@ type Config struct {
 	// then the pod will malfunction.
 	AllowPodSpecPatchUnsafeCmdMod bool `json:"allow-pod-spec-patch-unsafe-command-modification" validate:"omitempty"`
 
-	// Enable using the stacks API - this feature is in progress.
-	ExperimentalStacksAPISupport bool `json:"experimental-stacks-api-support" validate:"omitempty"`
-
 	// These are only used for integration tests.
 	BuildkiteToken  string `json:"buildkite-token"  validate:"omitempty"`
 	GraphQLEndpoint string `json:"graphql-endpoint" validate:"omitempty"`


### PR DESCRIPTION
As promised in #745, this PR removes the (now useless) flags to enable the stacks API