### PR TITLE
Set {signal,cancel} grace period agent config

### DIFF
--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -630,15 +630,33 @@ func (w *worker) Build(podSpec *corev1.PodSpec, skipCheckout bool, inputs buildI
 	// Set log collection grace period based on termination grace period.
 	// This allows the agent to coordinate log collection timing with pod termination.
 	if podSpec.TerminationGracePeriodSeconds != nil {
-		// Calculate log collection grace period: termination grace period minus buffer for cleanup
-		logCollectionGracePeriod := *podSpec.TerminationGracePeriodSeconds - 10
-		if logCollectionGracePeriod < 1 {
-			logCollectionGracePeriod = 1 // Minimum 1 second
-		}
-		agentContainer.Env = append(agentContainer.Env, corev1.EnvVar{
-			Name:  "BUILDKITE_KUBERNETES_LOG_COLLECTION_GRACE_PERIOD",
-			Value: fmt.Sprintf("%ds", logCollectionGracePeriod),
-		})
+		termGraceSecs := int(*podSpec.TerminationGracePeriodSeconds)
+		// When the agent cancels the job (e.g. when it receives SIGTERM), it
+		// first interrupts the job, waits for signal-grace-period, then
+		// terminates the job before waiting the remainder of the cancel-grace-
+		// period.
+		// When the pod is deleted, Kubernetes first sends SIGTERM to all
+		// containers. From Agent v3.110.0, kubernetes-bootstrap absorbs that
+		// signal and instead waits for the agent container to send an interrupt
+		// over the socket.
+		// Kubernetes will then take care of killing the job after
+		// TerminationGracePeriodSeconds is up. But we should still configure
+		// signal-grace-period so that the agent has time to upload logs and
+		// mark the job as finished, and also cancel-grace-period in case it
+		// needs to know how long it has left.
+		signalGracePeriod := max(0, termGraceSecs-10)
+		// Note that the agent requires cancelGracePeriod > signalGracePeriod.
+		cancelGracePeriod := max(termGraceSecs, 1)
+		agentContainer.Env = append(agentContainer.Env,
+			corev1.EnvVar{
+				Name:  "BUILDKITE_CANCEL_GRACE_PERIOD",
+				Value: strconv.Itoa(cancelGracePeriod),
+			},
+			corev1.EnvVar{
+				Name:  "BUILDKITE_SIGNAL_GRACE_PERIOD_SECONDS",
+				Value: strconv.Itoa(signalGracePeriod),
+			},
+		)
 	}
 
 	// Append some agent config and checkout config to the agent container.


### PR DESCRIPTION
### What

Instead of setting a Kubernetes-specific env var to set a grace period, use the agent's usual signal- and cancel-grace-period controls.

### Why

Over in buildkite/agent#3534, I determined that BUILDKITE_KUBERNETES_LOG_COLLECTION_GRACE_PERIOD didn't accomplish its goal, and removed it. But its heart is in the right place. We just need to extend the right grace periods. 

Signal-grace-period controls how long the agent will wait for a job to exit once it is interrupted before trying to kill it, and cancel-grace-period controls how long the agent will keep running things like the log streamer before giving up entirely. In the usual case these should be tied to the pod's `terminationGracePeriodSeconds`. Signal-grace-period should be a few seconds short of `terminationGracePeriodSeconds` in order to limit the worst case amount of time spent waiting for the job to wrap up, but still provide time to upload logs and mark the job as finished. Cancel-grace-period should extend all the way to `terminationGracePeriodSeconds` so that the agent continues trying to upload job logs and finish the job after the job is "killed". All containers get killed by Kubernetes at `terminationGracePeriodSeconds`.