### PR TITLE
Run release after pushing helm chart

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -231,6 +231,7 @@ steps:
     key: release
     depends_on:
       - deploy
+      - push-main-or-tag
     plugins:
       - kubernetes:
           checkout:


### PR DESCRIPTION
### What

Make `release` depend on `push-main-or-tag`.

### Why

The things that happen in `release` need the Helm chart to have been pushed. Previously this happened because of the transitive dependency via `deploy`, but as of #739, `deploy` no longer runs on tag builds.