### PR TITLE
PB-851 part 1: use Buildkite Secret in favor of K8s Secret

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -1,19 +1,17 @@
 x-anchors:
   push-helm: &push-helm
     label: ":helm::docker: build and push helm chart"
+    env:
+      KO_DOCKER_REPO: ghcr.io/buildkite
+    secrets:
+      REGISTRY_PASSWORD: ghcr_password
+      REGISTRY_USERNAME: ghcr_username
+    image: alpine:latest
+    command: .buildkite/steps/build-and-push-helm.sh
     plugins:
       - kubernetes:
           checkout:
             fetchFlags: -v --tags
-          podSpec:
-            serviceAccountName: deploy
-            containers:
-              - name: deploy
-                image: alpine:latest
-                command: [.buildkite/steps/build-and-push-helm.sh]
-                envFrom:
-                  - secretRef:
-                      name: deploy-secrets
 
   go-cache-env: &go-cache-env
     name: GOCACHE
@@ -124,6 +122,9 @@ steps:
     key: tests
     depends_on: agent
     artifact_paths: junit-*.xml
+    secrets:
+      INTEGRATION_TEST_BUILDKITE_TOKEN: integration_test_buildkite_api_token
+      BUILDKITE_ANALYTICS_TOKEN: test_engine_suite_token
     plugins:
       - kubernetes:
           podSpec:
@@ -143,9 +144,6 @@ steps:
                     value: /etc/config.yaml
                   - *go-cache-env
                   - *go-mod-cache-env
-                envFrom:
-                  - secretRef:
-                      name: agent-stack-k8s-secrets
                 volumeMounts:
                   - mountPath: /etc/config.yaml
                     name: agent-stack-k8s-config
@@ -156,16 +154,17 @@ steps:
                   requests:
                     cpu: 1000m
                     memory: 512Mi
-      - cluster-secrets#v1.0.0:
-          variables:
-            BUILDKITE_TOKEN: integration_test_buildkite_api_token
-            BUILDKITE_ANALYTICS_TOKEN: test_engine_suite_token
       - test-collector:
           files: junit-*.xml
           format: junit
 
   - label: ":docker: build and push controller image"
     key: controller
+    env:
+      KO_DOCKER_REPO: ghcr.io/buildkite
+    secrets:
+      REGISTRY_PASSWORD: ghcr_password
+      REGISTRY_USERNAME: ghcr_username
     plugins:
       - kubernetes:
           podSpec:
@@ -173,9 +172,6 @@ steps:
               - name: ko
                 image: golang:1.24
                 command: [.buildkite/steps/build-and-push-controller.sh]
-                envFrom:
-                  - secretRef:
-                      name: deploy-secrets
                 env: *go-env
                 volumeMounts: *go-mounts
             volumes: *go-volumes
@@ -206,10 +202,14 @@ steps:
       - tests
 
   - if: build.branch == pipeline.default_branch
-    label: ":shipit: deploy"
+    label: ":shipit: deploy to our own k8s cluster"
     key: deploy
     depends_on:
       - push-main-or-tag
+    secrets:
+      REGISTRY_PASSWORD: ghcr_password
+      REGISTRY_USERNAME: ghcr_username
+      DEFAULT_CLUSTER_TOKEN: default_cluster_token
     plugins:
       - kubernetes:
           checkout:
@@ -220,11 +220,6 @@ steps:
               - name: deploy
                 image: alpine:latest
                 command: [.buildkite/steps/deploy.sh]
-                envFrom:
-                  - secretRef:
-                      name: deploy-secrets
-                  - secretRef:
-                      name: agent-stack-k8s-secrets
 
   - if: build.tag =~ /^.+\$/
     label: ":rocket: release"
@@ -232,19 +227,19 @@ steps:
     depends_on:
       - deploy
       - push-main-or-tag
+    secrets:
+      REGISTRY_PASSWORD: ghcr_password
+      REGISTRY_USERNAME: ghcr_username
+      GITHUB_TOKEN: github_release_token
     plugins:
       - kubernetes:
           checkout:
             fetchFlags: -v --tags
           podSpec:
-            serviceAccountName: release
             containers:
               - name: release
                 image: golang:1.24-alpine # Note goreleaser shells out to go!
                 command: [.buildkite/steps/release.sh]
-                envFrom:
-                  - secretRef:
-                      name: release-secrets
                 env: *go-env
                 volumeMounts: *go-mounts
             volumes: *go-volumes

--- a/.buildkite/steps/deploy.sh
+++ b/.buildkite/steps/deploy.sh
@@ -18,7 +18,7 @@ helm upgrade agent-stack-k8s "${helm_repo_pecr}/agent-stack-k8s" \
   --install \
   --create-namespace \
   --wait \
-  --set agentToken="${BUILDKITE_AGENT_TOKEN}" \
+  --set agentToken="${DEFAULT_CLUSTER_TOKEN}" \
   --set config.image="${agent_image}" \
   --set config.debug=true \
   --set config.profiler-address=localhost:6060 \

--- a/cmd/controller/controller_test.go
+++ b/cmd/controller/controller_test.go
@@ -159,12 +159,8 @@ func TestReadAndParseConfig(t *testing.T) {
 		},
 	}
 
-	// The buildkite token is required, but it is set from a Kubernetes secret, not the config file,
-	// which is itself set from a config map that is used to create env variables in the controller
-	// container. As this is required, we set it here to avoid the validation error.
-	t.Setenv("BUILDKITE_TOKEN", "my-graphql-enabled-token")
-
 	// These need to be unset to as it is set in CI which pollutes the test environment
+	t.Setenv("INTEGRATION_TEST_BUILDKITE_TOKEN", "")
 	t.Setenv("IMAGE", "")
 	t.Setenv("NAMESPACE", "")
 

--- a/cmd/controller/flags.go
+++ b/cmd/controller/flags.go
@@ -17,7 +17,7 @@ func AddConfigFlags(cmd *cobra.Command) {
 		"buildkite-agent-token",
 		"name of the Buildkite agent token secret",
 	)
-	cmd.Flags().String("buildkite-token", "", "Deprecated - Buildkite API token with GraphQL scopes")
+	cmd.Flags().String("integration-test-buildkite-token", "", "Deprecated - Buildkite API token with GraphQL scopes")
 
 	// in the config file
 	cmd.Flags().String(

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -1,4 +1,5 @@
 agent-token-secret: my-kubernetes-secret
+integration-test-buildkite-token: my-graphql-enabled-token
 debug: true
 image: my.registry.dev/buildkite-agent:latest
 job-ttl: 5m

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -112,7 +112,7 @@ type Config struct {
 	AllowPodSpecPatchUnsafeCmdMod bool `json:"allow-pod-spec-patch-unsafe-command-modification" validate:"omitempty"`
 
 	// These are only used for integration tests.
-	BuildkiteToken  string `json:"buildkite-token"  validate:"omitempty"`
+	BuildkiteToken  string `json:"integration-test-buildkite-token"  validate:"omitempty"`
 	GraphQLEndpoint string `json:"graphql-endpoint" validate:"omitempty"`
 }
 


### PR DESCRIPTION
This PR replaces all k8s secret reference to Buildkite secrets with proper access policy. 

Note, because current Buildkite Secret restrict BUILDKITE_** env var names, I had to rename some env var names.
