### PR TITLE
Fix kubeVersion to include pre-release

### DIFF
--- a/charts/agent-stack-k8s/Chart.yaml
+++ b/charts/agent-stack-k8s/Chart.yaml
@@ -25,4 +25,4 @@ appVersion: "1.16.0"
 
 # Sidecar support requires the SidecarContainers feature gate, first enabled
 # by default in Kubernetes 1.29.
-kubeVersion: ">=1.29.0"
+kubeVersion: ">=1.29.0-0"


### PR DESCRIPTION
> SemVer comparisons using constraints without a prerelease comparator will skip prerelease versions. For example, >=1.2.3 will skip prereleases when looking at a list of releases, while >=1.2.3-0 will evaluate and find prereleases.

🤷🏿 