### PR TITLE
Mount signing JWKS volume to agent container

### DIFF
--- a/internal/controller/scheduler/scheduler_test.go
+++ b/internal/controller/scheduler/scheduler_test.go
@@ -1534,17 +1534,17 @@ func TestPipelineSigningOptions(t *testing.T) {
 		{
 			name: "both keys",
 			agentConfig: &config.AgentConfig{
-				VerificationJWKSFile:   ptr.To("/path/to/verification.jwks"),
+				VerificationJWKSFile:   ptr.To("/verification/path/verification.jwks"),
 				VerificationJWKSVolume: verificationVol,
-				SigningJWKSFile:        ptr.To("/path/to/signing.jwks"),
+				SigningJWKSFile:        ptr.To("/signing/path/signing.jwks"),
 				SigningJWKSVolume:      signingVol,
 			},
 			wantPodVolumes: []string{verificationVol.Name, signingVol.Name},
 			wantAgentEnv: map[string]string{
-				"BUILDKITE_AGENT_SIGNING_JWKS_FILE":      "/path/to/signing.jwks",
-				"BUILDKITE_AGENT_VERIFICATION_JWKS_FILE": "/path/to/verification.jwks",
+				"BUILDKITE_AGENT_SIGNING_JWKS_FILE":      "/signing/path/signing.jwks",
+				"BUILDKITE_AGENT_VERIFICATION_JWKS_FILE": "/verification/path/verification.jwks",
 			},
-			wantAgentMounts:   []string{verificationVol.Name},
+			wantAgentMounts:   []string{verificationVol.Name, signingVol.Name},
 			wantCommandMounts: []string{signingVol.Name},
 		},
 		{
@@ -1558,7 +1558,7 @@ func TestPipelineSigningOptions(t *testing.T) {
 				"BUILDKITE_AGENT_SIGNING_JWKS_FILE":      "/buildkite/signing-jwks/key",
 				"BUILDKITE_AGENT_VERIFICATION_JWKS_FILE": "/buildkite/verification-jwks/key",
 			},
-			wantAgentMounts:   []string{verificationVol.Name},
+			wantAgentMounts:   []string{verificationVol.Name, signingVol.Name},
 			wantCommandMounts: []string{signingVol.Name},
 		},
 		{
@@ -1574,7 +1574,7 @@ func TestPipelineSigningOptions(t *testing.T) {
 				"BUILDKITE_AGENT_SIGNING_JWKS_FILE":      "/buildkite/signing-jwks/my-special-key",
 				"BUILDKITE_AGENT_VERIFICATION_JWKS_FILE": "/buildkite/verification-jwks/my-awesome-key",
 			},
-			wantAgentMounts:   []string{verificationVol.Name},
+			wantAgentMounts:   []string{verificationVol.Name, signingVol.Name},
 			wantCommandMounts: []string{signingVol.Name},
 		},
 	}


### PR DESCRIPTION
In `v0.28.0-beta5` the changes introduced a bug where the `SigningJWKSVolume` is not mounted to the `agent` container, but the agent requires access to the JWKS file at startup for [validation](https://github.com/buildkite/agent/blob/64385feb367535ab3aa9bbe0a56e3baf99165430/clicommand/agent_start.go#L985-L991). This causes the following error in the `agent` container logs:
```
2025-11-06 20:23:43 FATAL  Signing JWKS failed validation: Failed to read job signing keyset: open /buildkite/signing-jwks/key: no such file or directory
```
This change additionally mounts the signing key volume to the `agent` container, similar to the existing verification key volume mount.

A workaround to this missing volume is to explicitly mount the signing key volume to the `agent` container by patching PodSpec when `config.agent-config.signingJWKSVolume` and `config.agent-config.verificationJWKSVolume` are correctly configured:
```
config:
...
  agent-config:
    signing-jwks-file: key
    signing-jwks-key-id: my-jwks-key
    signingJWKSVolume:
      name: buildkite-signing-jwks
      secret:
        secretName: my-signing-key
    verification-jwks-file: key
    verificationJWKSVolume:
      name: buildkite-verification-jwks
      secret:
        secretName: my-verification-key
  pod-spec-patch:
    containers:
    - name: agent
      volumeMounts:
      - name: buildkite-signing-jwks
        mountPath: /buildkite/signing-jwks
```