### PR TITLE
PB-946 part 1: backfill unit test for reserver

### DIFF
--- a/api/fake_agent_server.go
+++ b/api/fake_agent_server.go
@@ -1,0 +1,148 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+
+	"github.com/buildkite/stacksapi"
+)
+
+// FakeAgentServer is an httptest.Server that implements the Buildkite Agent API.
+// It records all requests for verification in tests.
+// Use with a real AgentClient for realistic integration testing.
+type FakeAgentServer struct {
+	server *httptest.Server
+	mu     sync.Mutex
+
+	// ReserveCalls records the job IDs passed to each ReserveJobs call.
+	ReserveCalls [][]string
+
+	// ReserveResponse configures the response for ReserveJobs.
+	// If nil, returns all job IDs as reserved.
+	ReserveResponse *stacksapi.BatchReserveJobsResponse
+
+	// ReserveStatusCode configures the HTTP status code for ReserveJobs.
+	// Default is 200.
+	ReserveStatusCode int
+
+	// ReserveError configures an error message to return.
+	ReserveError string
+}
+
+// NewFakeAgentServer creates and starts a fake agent API server.
+// Use server.URL() to get the endpoint for creating a real AgentClient.
+func NewFakeAgentServer() *FakeAgentServer {
+	fake := &FakeAgentServer{
+		ReserveStatusCode: http.StatusOK,
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/stacks/register", fake.handleRegisterStack)
+	mux.HandleFunc("/stacks/test-stack/scheduled-jobs/batch-reserve", fake.handleReserveJobs)
+
+	fake.server = httptest.NewServer(mux)
+	return fake
+}
+
+// URL returns the base URL of the fake server.
+// Use this as the Endpoint when creating a real AgentClient.
+func (f *FakeAgentServer) URL() string {
+	return f.server.URL
+}
+
+// Close shuts down the fake server.
+func (f *FakeAgentServer) Close() {
+	f.server.Close()
+}
+
+func (f *FakeAgentServer) handleRegisterStack(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req stacksapi.RegisterStackRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	resp := stacksapi.RegisterStackResponse{
+		Key:             req.Key,
+		ClusterQueueKey: req.QueueKey,
+		Metadata:        req.Metadata,
+	}
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(resp); err != nil {
+		http.Error(w, "fake: failed to encode response: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if _, err := w.Write(buf.Bytes()); err != nil {
+		log.Printf("fake: failed to write register stack response: %v", err)
+	}
+}
+
+func (f *FakeAgentServer) handleReserveJobs(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPut && r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req stacksapi.BatchReserveJobsRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// Record the call (mutex protects concurrent access from HTTP handler)
+	f.mu.Lock()
+	f.ReserveCalls = append(f.ReserveCalls, req.JobUUIDs)
+	f.mu.Unlock()
+
+	// Return configured error if set
+	if f.ReserveError != "" {
+		var buf bytes.Buffer
+		if err := json.NewEncoder(&buf).Encode(map[string]string{
+			"message": f.ReserveError,
+		}); err != nil {
+			http.Error(w, "fake: failed to encode error response: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(f.ReserveStatusCode)
+		if _, err := w.Write(buf.Bytes()); err != nil {
+			log.Printf("fake: failed to write error response: %v", err)
+		}
+		return
+	}
+
+	// Return configured response
+	resp := f.ReserveResponse
+	if resp == nil {
+		// Default: all jobs reserved successfully
+		resp = &stacksapi.BatchReserveJobsResponse{
+			Reserved:    req.JobUUIDs,
+			NotReserved: []string{},
+		}
+	}
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(resp); err != nil {
+		http.Error(w, "fake: failed to encode response: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(f.ReserveStatusCode)
+	if _, err := w.Write(buf.Bytes()); err != nil {
+		log.Printf("fake: failed to write reserve jobs response: %v", err)
+	}
+}

--- a/api/fake_agent_server_test.go
+++ b/api/fake_agent_server_test.go
@@ -1,0 +1,144 @@
+package api_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/buildkite/agent-stack-k8s/v2/api"
+	"github.com/buildkite/stacksapi"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestFakeAgentServer_DefaultBehavior(t *testing.T) {
+	ctx := context.Background()
+
+	// Create fake server
+	server := api.NewFakeAgentServer()
+	defer server.Close()
+
+	// Create REAL AgentClient pointing to fake server
+	client, err := api.NewAgentClient(ctx, api.AgentClientOpts{
+		Token:    "fake-token",
+		Endpoint: server.URL(),
+		StackID:  "test-stack",
+		Logger:   slog.Default(),
+	})
+	if err != nil {
+		t.Fatalf("NewAgentClient() error = %v", err)
+	}
+
+	jobIDs := []string{"job-1", "job-2", "job-3"}
+	result, retryAfter, err := client.ReserveJobs(ctx, jobIDs)
+	if err != nil {
+		t.Errorf("ReserveJobs(ctx, %q) error = %v, want nil", jobIDs, err)
+	}
+	if retryAfter != 0 {
+		t.Errorf("ReserveJobs(ctx, %q) retryAfter = %v, want 0", jobIDs, retryAfter)
+	}
+
+	want := &stacksapi.BatchReserveJobsResponse{
+		Reserved:    jobIDs,
+		NotReserved: []string{},
+	}
+	if diff := cmp.Diff(result, want); diff != "" {
+		t.Errorf("ReserveJobs(ctx, %q) diff (-got +want):\n%s", jobIDs, diff)
+	}
+}
+
+func TestFakeAgentServer_RecordsCalls(t *testing.T) {
+	ctx := context.Background()
+
+	server := api.NewFakeAgentServer()
+	defer server.Close()
+
+	client, err := api.NewAgentClient(ctx, api.AgentClientOpts{
+		Token:    "fake-token",
+		Endpoint: server.URL(),
+		StackID:  "test-stack",
+		Logger:   slog.Default(),
+	})
+	if err != nil {
+		t.Fatalf("NewAgentClient() error = %v", err)
+	}
+
+	jobIDs := []string{"job-1", "job-2"}
+	_, _, err = client.ReserveJobs(ctx, jobIDs)
+	if err != nil {
+		t.Fatalf("ReserveJobs(ctx, %q) error = %v", jobIDs, err)
+	}
+	_, _, err = client.ReserveJobs(ctx, []string{"job-3"})
+	if err != nil {
+		t.Fatalf("ReserveJobs(ctx, %q) error = %v", jobIDs, err)
+	}
+
+	want := [][]string{
+		{"job-1", "job-2"},
+		{"job-3"},
+	}
+	if diff := cmp.Diff(server.ReserveCalls, want); diff != "" {
+		t.Errorf("server.ReserveCalls diff (-got +want):\n%s", diff)
+	}
+}
+
+func TestFakeAgentServer_CustomError(t *testing.T) {
+	ctx := context.Background()
+
+	server := api.NewFakeAgentServer()
+	defer server.Close()
+
+	server.ReserveError = "reservation failed"
+	server.ReserveStatusCode = 500
+
+	client, err := api.NewAgentClient(ctx, api.AgentClientOpts{
+		Token:    "fake-token",
+		Endpoint: server.URL(),
+		StackID:  "test-stack",
+		Logger:   slog.Default(),
+	})
+	if err != nil {
+		t.Fatalf("NewAgentClient() error = %v", err)
+	}
+
+	jobIDs := []string{"job-1"}
+	result, _, err := client.ReserveJobs(ctx, []string{"job-1"})
+	if err == nil {
+		t.Errorf("ReserveJobs(ctx, %q) error = nil, want error", jobIDs)
+	}
+	if result != nil {
+		t.Errorf("ReserveJobs(ctx, %q) result = %v, want nil", jobIDs, result)
+	}
+}
+
+func TestFakeAgentServer_CustomResult(t *testing.T) {
+	ctx := context.Background()
+
+	server := api.NewFakeAgentServer()
+	defer server.Close()
+
+	want := &stacksapi.BatchReserveJobsResponse{
+		Reserved:    []string{"job-1"},
+		NotReserved: []string{"job-2", "job-3"},
+	}
+	server.ReserveResponse = want
+
+	client, err := api.NewAgentClient(ctx, api.AgentClientOpts{
+		Token:    "fake-token",
+		Endpoint: server.URL(),
+		StackID:  "test-stack",
+		Logger:   slog.Default(),
+	})
+	if err != nil {
+		t.Fatalf("NewAgentClient() error = %v", err)
+	}
+
+	jobIDs := []string{"job-1", "job-2", "job-3"}
+	result, _, err := client.ReserveJobs(ctx, jobIDs)
+	if err != nil {
+		t.Errorf("ReserveJobs(ctx, %q) error = %v, want nil", jobIDs, err)
+	}
+
+	if diff := cmp.Diff(result, want); diff != "" {
+		t.Errorf("ReserveJobs(ctx, %q) diff (-got +want):\n%s", jobIDs, diff)
+	}
+}

--- a/internal/controller/reserver/reserver_test.go
+++ b/internal/controller/reserver/reserver_test.go
@@ -1,0 +1,74 @@
+package reserver
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/buildkite/agent-stack-k8s/v2/api"
+
+	"github.com/google/uuid"
+)
+
+type fakeHandler struct {
+	called int
+}
+
+func (f *fakeHandler) HandleMany(ctx context.Context, jobs []*api.AgentScheduledJob) error {
+	f.called++
+	return nil
+}
+
+func (f *fakeHandler) Pause(pause bool) {}
+
+func TestReserver_ChunksJobsInto1000(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	// Create fake server
+	server := api.NewFakeAgentServer()
+	defer server.Close()
+
+	// Create REAL AgentClient pointing to fake server
+	client, err := api.NewAgentClient(ctx, api.AgentClientOpts{
+		Token:    "fake-token",
+		Endpoint: server.URL(),
+		StackID:  "test-stack",
+		Logger:   slog.Default(),
+	})
+	if err != nil {
+		t.Fatalf("NewAgentClient() error = %v", err)
+	}
+
+	fakeNext := &fakeHandler{}
+	r := New(slog.Default(), client, fakeNext)
+
+	var jobs []*api.AgentScheduledJob
+	for range 2500 {
+		id := uuid.New().String()
+		jobs = append(jobs, &api.AgentScheduledJob{ID: id})
+	}
+
+	if err := r.HandleMany(ctx, jobs); err != nil {
+		t.Errorf("r.HandleMany(ctx, jobs) = %v", err)
+	}
+
+	if got, want := len(server.ReserveCalls), 3; got != want {
+		t.Fatalf("number of ReserveJobs calls = %d, want %d", got, want)
+	}
+
+	if got, want := len(server.ReserveCalls[0]), 1000; got != want {
+		t.Errorf("first chunk size = %d, want %d", got, want)
+	}
+	if got, want := len(server.ReserveCalls[1]), 1000; got != want {
+		t.Errorf("second chunk size = %d, want %d", got, want)
+	}
+	if got, want := len(server.ReserveCalls[2]), 500; got != want {
+		t.Errorf("third chunk size = %d, want %d", got, want)
+	}
+
+	if got, want := fakeNext.called, 1; got != want {
+		t.Errorf("next handler called = %d times, want %d", got, want)
+	}
+}


### PR DESCRIPTION
Add unit test for reserver, locking in the batching behavior. 

As part of it, introducing fake agent server, that can be handy during test. (this fake agent server was _mostly_ written by Claude)