### PR TITLE
Upgrade go to 1.25.4

### DIFF
--- a/.buildkite/go-with-cache-pod-template.yaml
+++ b/.buildkite/go-with-cache-pod-template.yaml
@@ -9,7 +9,7 @@ template:
   spec:
     containers:
       - name: container-0
-        image: golang:1.24-alpine
+        image: golang:1.25-alpine
         # These golang related cache uses node local storage.
         # We will soon refactor this to use the incoming Buildkite Cache.
         env:

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -19,7 +19,7 @@ agents:
 steps:
   - label: ":go::broom: tidy"
     key: tidy
-    image: golang:1.24-alpine
+    image: golang:1.25-alpine
     command: .buildkite/steps/tidy.sh
     plugins:
       - kubernetes:
@@ -35,7 +35,7 @@ steps:
 
   - label: ":golang::robot_face: check code generation"
     key: check-code-generation
-    image: golang:1.24-alpine
+    image: golang:1.25-alpine
     command: .buildkite/steps/check-code-generation.sh
     plugins:
       - kubernetes:
@@ -71,7 +71,7 @@ steps:
     secrets:
       REGISTRY_PASSWORD: ghcr_password
       REGISTRY_USERNAME: ghcr_username
-    image: golang:1.24
+    image: golang:1.25
     command: .buildkite/steps/build-and-push-controller.sh
     plugins:
       - kubernetes:
@@ -130,7 +130,7 @@ steps:
       REGISTRY_PASSWORD: ghcr_password
       REGISTRY_USERNAME: ghcr_username
       GITHUB_TOKEN: github_release_token
-    image: golang:1.24-alpine # Note goreleaser shells out to go!
+    image: golang:1.25-alpine # Note goreleaser shells out to go!
     command: .buildkite/steps/release.sh
     plugins:
       - kubernetes:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/buildkite/agent-stack-k8s/v2
 
-go 1.24.5
+go 1.25.4
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+go = "latest"


### PR DESCRIPTION
This is so I can use the awesome [synctest](https://pkg.go.dev/testing/synctest) tool without fiddling with experimental flag. 