### PR TITLE
Add queue info to agentTags in controller

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -90,6 +90,8 @@ func Run(ctx context.Context, logger *slog.Logger, k8sClient kubernetes.Interfac
 		queue = stacksapi.DefaultQueue
 	}
 
+	agentTags["queue"] = queue
+
 	agentTokenClient, err := api.NewAgentTokenClient(agentToken, agentEndpoint)
 	if err != nil {
 		logger.Error("Couldn't create Agent token API client", "error", err)


### PR DESCRIPTION
Fixes an issue introduced in #762 where jobs are not being picked up by Agents when using the `queue` config option.

This ensures that the resolved queue value is present in agentTags, regardless of how it was passed