### PR TITLE
Update Kubernetes schema references

### DIFF
--- a/charts/agent-stack-k8s/values.schema.json
+++ b/charts/agent-stack-k8s/values.schema.json
@@ -85,7 +85,7 @@
       "default": [],
       "title": "K8s EnvVar environment variables to add to the agent-stack-k8s controller container",
       "items": {
-        "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.EnvVar"
+        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.35.0/_definitions.json#/definitions/io.k8s.api.core.v1.EnvVar"
       }
     },
     "nodeSelector": {
@@ -363,7 +363,7 @@
           "examples": [false]
         },
         "workspaceVolume": {
-          "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.Volume"
+          "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.35.0/_definitions.json#/definitions/io.k8s.api.core.v1.Volume"
         },
         "agent-config": {
           "type": "object",
@@ -434,10 +434,10 @@
               "type": "string"
             },
             "hooksVolume": {
-              "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.Volume"
+              "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.35.0/_definitions.json#/definitions/io.k8s.api.core.v1.Volume"
             },
             "pluginsVolume": {
-              "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.Volume"
+              "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.35.0/_definitions.json#/definitions/io.k8s.api.core.v1.Volume"
             },
             "debug-signing": {
               "type": "boolean"
@@ -449,7 +449,7 @@
               "type": "string"
             },
             "signingJWKSVolume": {
-              "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.Volume"
+              "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.35.0/_definitions.json#/definitions/io.k8s.api.core.v1.Volume"
             },
             "verification-jwks-file": {
               "type": "string"
@@ -458,7 +458,7 @@
               "type": "string"
             },
             "verificationJWKSVolume": {
-              "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.Volume"
+              "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.35.0/_definitions.json#/definitions/io.k8s.api.core.v1.Volume"
             }
           }
         },
@@ -505,7 +505,7 @@
                   "default": null
                 },
                 "volume": {
-                  "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.Volume"
+                  "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.35.0/_definitions.json#/definitions/io.k8s.api.core.v1.Volume"
                 },
                 "cloneFlags": {
                   "type": "string",
@@ -522,14 +522,14 @@
               }
             },
             "gitCredentialsSecret": {
-              "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.SecretVolumeSource"
+              "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.35.0/_definitions.json#/definitions/io.k8s.api.core.v1.SecretVolumeSource"
             },
             "envFrom": {
               "type": "array",
               "default": [],
               "title": "k8s envFrom sources to add",
               "items": {
-                "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.EnvFromSource"
+                "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.35.0/_definitions.json#/definitions/io.k8s.api.core.v1.EnvFromSource"
               }
             },
             "extraVolumeMounts": {
@@ -537,7 +537,7 @@
               "default": [],
               "title": "extra volumes to mount to all checkout containers",
               "items": {
-                "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.VolumeMount"
+                "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.35.0/_definitions.json#/definitions/io.k8s.api.core.v1.VolumeMount"
               }
             }
           }
@@ -558,7 +558,7 @@
               "default": [],
               "title": "k8s envFrom sources to add",
               "items": {
-                "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.EnvFromSource"
+                "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.35.0/_definitions.json#/definitions/io.k8s.api.core.v1.EnvFromSource"
               }
             },
             "extraVolumeMounts": {
@@ -566,7 +566,7 @@
               "default": [],
               "title": "extra volumes to mount to all command containers",
               "items": {
-                "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.VolumeMount"
+                "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.35.0/_definitions.json#/definitions/io.k8s.api.core.v1.VolumeMount"
               }
             }
           }
@@ -581,7 +581,7 @@
               "default": [],
               "title": "k8s envFrom sources to add",
               "items": {
-                "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.EnvFromSource"
+                "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.35.0/_definitions.json#/definitions/io.k8s.api.core.v1.EnvFromSource"
               }
             },
             "extraVolumeMounts": {
@@ -589,7 +589,7 @@
               "default": [],
               "title": "extra volumes to mount to all sidecar containers",
               "items": {
-                "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.VolumeMount"
+                "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.35.0/_definitions.json#/definitions/io.k8s.api.core.v1.VolumeMount"
               }
             }
           }
@@ -646,7 +646,7 @@
           "examples": ["Always", "IfNotPresent", "Never", ""]
         },
         "pod-spec-patch": {
-          "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.PodSpec"
+          "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.35.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodSpec"
         },
         "graphql-results-limit": {
           "deprecated": true,

--- a/cmd/linter/linter.go
+++ b/cmd/linter/linter.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	pipelineSchema = "https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json"
-	k8sSchema      = "https://kubernetesjsonschema.dev/master/_definitions.json"
+	k8sSchema      = "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.35.0/_definitions.json"
 )
 
 //go:embed schema.json

--- a/cmd/linter/schema.json
+++ b/cmd/linter/schema.json
@@ -5,24 +5,24 @@
       "type": "object",
       "properties": {
         "podSpec": {
-          "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.PodSpec"
+          "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.35.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodSpec"
         },
         "gitEnvFrom": {
           "type": "array",
           "items": {
-            "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.EnvFromSource"
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.35.0/_definitions.json#/definitions/io.k8s.api.core.v1.EnvFromSource"
           }
         },
         "sidecars": {
           "type": "array",
           "items": {
-            "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.Container"
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.35.0/_definitions.json#/definitions/io.k8s.api.core.v1.Container"
           }
         },
         "extraVolumeMounts": {
           "type": "array",
           "items": {
-            "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.VolumeMount"
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.35.0/_definitions.json#/definitions/io.k8s.api.core.v1.VolumeMount"
           }
         },
         "metadata": {


### PR DESCRIPTION
Replaced references to kubernetesjsonschema.dev with direct links to the v1.35.0 schema definitions from yannh/kubernetes-json-schema.

As of the time of this PR, kubernetesjsonschema.dev is down and has been for over a day, with it looking like it's not coming back, or not soon at least.

This will prevent schema validation erroring out with a 404 when specified, or when there's a tool used such as Terraform to deploy, which is pretty standard.

We were previously pinning to `master`, which would could also be breaking. To avoid schema validation breaking in future for older releases, I've opted to pin to `v1.35.0`, which is the latest version currently anyway.

This adds maintenance burden with the benefit of stability for past releases. Feel free to flag this if you would prefer `master/master` over `master/v1.35.0`.

I've opted for the source of [yannh/kubernetes-json-schema](https://github.com/yannh/kubernetes-json-schema) as this seems to be the most up-to-date and maintained source, with it being highly used throughout the K8's community. Again, if you have any issues, just flag which source you'd prefer and I can change it. 