### PR TITLE
Quiet down logs by default

### DIFF
--- a/internal/controller/monitor/monitor.go
+++ b/internal/controller/monitor/monitor.go
@@ -49,9 +49,7 @@ func New(logger *slog.Logger, agentClient *api.AgentClient, cfg Config) (*Monito
 
 // getScheduledCommandJobs gets scheduled jobs from the API.
 func (m *Monitor) getScheduledCommandJobs(ctx context.Context) (jobs []*api.AgentScheduledJob, retryAfter time.Duration, err error) {
-	m.logger.Info("retrieving scheduled jobs via Agent API...",
-		"poll-interval", m.cfg.PollInterval,
-	)
+	m.logger.Debug("retrieving scheduled jobs via Agent API...", "poll-interval", m.cfg.PollInterval)
 
 	jobQueryCounter.Inc()
 	start := time.Now()
@@ -155,7 +153,11 @@ func (m *Monitor) Start(ctx context.Context, handler model.ManyJobHandler) <-cha
 				continue
 			}
 
-			m.logger.Info("job processing of Agent API results completed...", "agent-api-jobs-processed", len(jobs))
+			level := slog.LevelDebug
+			if len(jobs) > 0 {
+				level = slog.LevelInfo
+			}
+			m.logger.Log(ctx, level, "job processing of Agent API results completed", "agent-api-jobs-processed", len(jobs))
 
 			if len(jobs) == 0 {
 				continue


### PR DESCRIPTION
By default, the k8s stack produces a lot of logs doing nothing, ie logging every time it checks for new jobs, and logging again every time it finds zero new jobs.

This PR downgrades the "retrieving scheduled jobs...." log to to `DEBUG`, and downgrades the "found x many jobs" message to `DEBUG` if and only if it finds zero jobs. If it finds more than zero, it'll still log at `INFO`.