### PR TITLE
PS-1583: Replace Alpine-specific shell commands with portable alternatives

### DIFF
--- a/internal/controller/scheduler/shell.go
+++ b/internal/controller/scheduler/shell.go
@@ -1,0 +1,46 @@
+package scheduler
+
+import (
+	"bytes"
+	"text/template"
+)
+
+var createUserScriptTmpl = template.Must(template.New("createUser").Parse(`# Portable user/group creation
+if command -v adduser >/dev/null 2>&1 && adduser --help 2>&1 | grep -q BusyBox; then
+{{- if .CreateGroup }}
+    addgroup -g {{.GID}} {{.Groupname}} 2>/dev/null || true
+{{- end }}
+    adduser -D -u {{.UID}} -G {{.Groupname}} -h /workspace {{.Username}}
+elif command -v useradd >/dev/null 2>&1; then
+{{- if .CreateGroup }}
+    groupadd -g {{.GID}} {{.Groupname}} 2>/dev/null || true
+{{- end }}
+    useradd -M -u {{.UID}} -g {{.Groupname}} -d /workspace -s /bin/sh {{.Username}}
+else
+    echo "Error: No supported user creation tool found" >&2
+    exit 1
+fi
+`))
+
+// generateCreateUserScript generates a shell script that creates a user
+// and optionally a group, working on both Alpine (BusyBox) and glibc-based
+// systems (Debian, Ubuntu, RHEL).
+func generateCreateUserScript(uid, gid int64, username, groupname string) string {
+	data := struct {
+		UID         int64
+		GID         int64
+		Username    string
+		Groupname   string
+		CreateGroup bool
+	}{
+		UID:         uid,
+		GID:         gid,
+		Username:    username,
+		Groupname:   groupname,
+		CreateGroup: groupname != "" && groupname != "root",
+	}
+
+	var buf bytes.Buffer
+	_ = createUserScriptTmpl.Execute(&buf, data)
+	return buf.String()
+}

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/buildkite/agent-stack-k8s/v2/internal/controller/config"
 	"github.com/buildkite/agent-stack-k8s/v2/internal/controller/scheduler"
 	"github.com/buildkite/agent-stack-k8s/v2/internal/integration/api"
+	agentversion "github.com/buildkite/agent/v3/version"
 	"github.com/buildkite/roko"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -32,6 +33,24 @@ func TestWalkingSkeleton(t *testing.T) {
 	ctx := context.Background()
 	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)
 	tc.StartController(ctx, cfg)
+	build := tc.TriggerBuild(ctx, pipelineID)
+	tc.AssertSuccess(ctx, build)
+}
+
+func TestUbuntuAgentImage(t *testing.T) {
+	tc := testcase{
+		T:       t,
+		Fixture: "helloworld.yaml",
+		Repo:    repoHTTP,
+		GraphQL: api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
+	}.Init()
+	ctx := context.Background()
+	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)
+
+	testCfg := cfg
+	testCfg.Image = "ghcr.io/buildkite/agent:" + agentversion.Version() + "-ubuntu-24.04"
+
+	tc.StartController(ctx, testCfg)
 	build := tc.TriggerBuild(ctx, pipelineID)
 	tc.AssertSuccess(ctx, build)
 }


### PR DESCRIPTION
This PR builds on top of the awesome #809(@seemethere). Solve #808. 

The goal remain the same: 
> Use /bin/sh instead of ash and add auto-detection for user/group creation commands to support both Alpine (BusyBox) and glibc-based images (Ubuntu, Debian, Rocky Linux). This enables use of non-Alpine agent images which may be needed for glibc-specific features like TCP-based DNS queries (use-vc resolv.conf option).

I fixed a number of paper cuts issue in #809: 
- improved naming. 
- added an integration test.
- increase readability on the script constructing code path, unify some duplicated condition. 
- fix the incorrect tinit-static path.