### PR TITLE
PB-1069 follow up: remove $id from values.schema.json

### DIFF
--- a/charts/agent-stack-k8s/values.schema.json
+++ b/charts/agent-stack-k8s/values.schema.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "http://example.com/example.json",
   "type": "object",
   "default": {},
   "title": "Root Schema",


### PR DESCRIPTION
`$id` is a JSON Schema keyword that declares a unique identifier (URI) for the schema and serves as the base URI for resolving relative `$ref` references.

When we had `"$id": "http://example.com/example.json"`, a relative ref like `schemas/kubernetes-v1.35.0.json` was resolved as `http://example.com/schemas/kubernetes-v1.35.0.json` — causing Helm to make an HTTP request instead of reading the local file.