### PR TITLE
Fix command container detection for steps with no command value

### DIFF
--- a/internal/controller/config/resource_class.go
+++ b/internal/controller/config/resource_class.go
@@ -55,7 +55,7 @@ func (rc *ResourceClass) Apply(podSpec *corev1.PodSpec) {
 // This duplicates model.IsCommandContainer to avoid cyclic dependency
 func isCommandContainer(container *corev1.Container) bool {
 	for _, env := range container.Env {
-		if env.Name == "BUILDKITE_COMMAND" && env.Value != "" {
+		if env.Name == "BUILDKITE_COMMAND" {
 			return true
 		}
 	}

--- a/internal/controller/model/model.go
+++ b/internal/controller/model/model.go
@@ -46,7 +46,7 @@ func JobFinished(job *batchv1.Job) bool {
 // The detection logic is a heuristic, but there is a very low likelihood of false positives.
 func IsCommandContainer(container *corev1.Container) bool {
 	for _, env := range container.Env {
-		if env.Name == "BUILDKITE_COMMAND" && env.Value != "" {
+		if env.Name == "BUILDKITE_COMMAND" {
 			return true
 		}
 	}


### PR DESCRIPTION
This patch removes the check that a command container must have a non-empty command instead relying solely on the existence of the var.

Resolves #816