### PR TITLE
Add HTTP timeout and logger for Stacks API client

### DIFF
--- a/api/agent_client.go
+++ b/api/agent_client.go
@@ -72,11 +72,16 @@ func NewAgentClient(ctx context.Context, opts AgentClientOpts) (*AgentClient, er
 		logger:    opts.Logger,
 	}
 
+	stacksAPIHttpClient := &http.Client{
+		Timeout:   60 * time.Second,
+		Transport: NewLogger(http.DefaultTransport),
+	}
 	client.stacksAPIClient, err = stacksapi.NewClient(
 		opts.Token,
 		stacksapi.WithLogger(opts.Logger.With("component", "stacksapi")),
 		stacksapi.WithBaseURL(endpointURL),
 		stacksapi.PrependToUserAgent("agent-stack-k8s/"+version.Version()),
+		stacksapi.WithHTTPClient(stacksAPIHttpClient),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't create Buildkite Stacks API client: %w", err)


### PR DESCRIPTION
In our environment we noticed cases where controller seemed to hang until it was manually restarted. I noticed that stacksapi client is using `http.DefaultClient` which has no timeout and no logging of requests. Wondering whether this is on purpose? Because it seems the `AgentClient` is  using the timeout and request logging.

Also wondering whether maybe these timeouts should be configurable? Happy to modify this if you deem it might be useful.