### PR TITLE
Allow safe-to-evict annotation to be overridden

### DIFF
--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -299,6 +299,10 @@ func (w *worker) Build(podSpec *corev1.PodSpec, skipCheckout bool, inputs buildI
 		},
 	}
 
+	// Prevent k8s cluster autoscaler from terminating the job before it finishes to scale down cluster.
+	// This default can be overridden, e.g. when targeting spot/preemptible nodes.
+	kjob.Annotations["cluster-autoscaler.kubernetes.io/safe-to-evict"] = "false"
+
 	maps.Copy(kjob.Labels, w.cfg.DefaultMetadata.Labels)
 	maps.Copy(kjob.Annotations, w.cfg.DefaultMetadata.Annotations)
 	if inputs.k8sPlugin != nil {
@@ -334,9 +338,6 @@ func (w *worker) Build(podSpec *corev1.PodSpec, skipCheckout bool, inputs buildI
 		kjob.Annotations[config.JobURLAnnotation] = jobURL
 	}
 	kjob.Annotations[config.PriorityAnnotation] = strconv.Itoa(inputs.priority)
-
-	// Prevent k8s cluster autoscaler from terminating the job before it finishes to scale down cluster
-	kjob.Annotations["cluster-autoscaler.kubernetes.io/safe-to-evict"] = "false"
 
 	kjob.Spec.Template.Labels = kjob.Labels
 	kjob.Spec.Template.Annotations = kjob.Annotations

--- a/internal/controller/scheduler/scheduler_test.go
+++ b/internal/controller/scheduler/scheduler_test.go
@@ -1694,3 +1694,75 @@ func findEnv(t *testing.T, envs []corev1.EnvVar, name string) *corev1.EnvVar {
 
 	return nil
 }
+
+func TestBuildSafeToEvictDefault(t *testing.T) {
+	t.Parallel()
+	job := &api.AgentJob{
+		ID:      "abc",
+		Command: "echo hello world",
+	}
+	sjob := &api.AgentScheduledJob{}
+	worker := New(slog.Default(), nil, nil, Config{
+		Image: "buildkite/agent:latest",
+	})
+	inputs, err := worker.ParseJob(job, sjob)
+	require.NoError(t, err)
+	kjob, err := worker.Build(&corev1.PodSpec{}, false, inputs)
+	require.NoError(t, err)
+
+	assert.Equal(t, "false", kjob.Annotations["cluster-autoscaler.kubernetes.io/safe-to-evict"])
+	assert.Equal(t, "false", kjob.Spec.Template.Annotations["cluster-autoscaler.kubernetes.io/safe-to-evict"])
+}
+
+func TestBuildSafeToEvictDefaultMetadataOverride(t *testing.T) {
+	t.Parallel()
+	job := &api.AgentJob{
+		ID:      "abc",
+		Command: "echo hello world",
+	}
+	sjob := &api.AgentScheduledJob{}
+	worker := New(slog.Default(), nil, nil, Config{
+		Image: "buildkite/agent:latest",
+		DefaultMetadata: config.Metadata{
+			Annotations: map[string]string{
+				"cluster-autoscaler.kubernetes.io/safe-to-evict": "true",
+			},
+		},
+	})
+	inputs, err := worker.ParseJob(job, sjob)
+	require.NoError(t, err)
+	kjob, err := worker.Build(&corev1.PodSpec{}, false, inputs)
+	require.NoError(t, err)
+
+	assert.Equal(t, "true", kjob.Annotations["cluster-autoscaler.kubernetes.io/safe-to-evict"])
+	assert.Equal(t, "true", kjob.Spec.Template.Annotations["cluster-autoscaler.kubernetes.io/safe-to-evict"])
+}
+
+func TestBuildSafeToEvictPluginMetadataOverride(t *testing.T) {
+	t.Parallel()
+
+	pluginsYAML := `- github.com/buildkite-plugins/kubernetes-buildkite-plugin:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"`
+
+	pluginsJSON, err := yaml.YAMLToJSONStrict([]byte(pluginsYAML))
+	require.NoError(t, err)
+
+	job := &api.AgentJob{
+		ID:      "abc",
+		Command: "echo hello world",
+		Env:     map[string]string{"BUILDKITE_PLUGINS": string(pluginsJSON)},
+	}
+	sjob := &api.AgentScheduledJob{}
+	worker := New(slog.Default(), nil, nil, Config{
+		Image: "buildkite/agent:latest",
+	})
+	inputs, err := worker.ParseJob(job, sjob)
+	require.NoError(t, err)
+	kjob, err := worker.Build(&corev1.PodSpec{}, false, inputs)
+	require.NoError(t, err)
+
+	assert.Equal(t, "true", kjob.Annotations["cluster-autoscaler.kubernetes.io/safe-to-evict"])
+	assert.Equal(t, "true", kjob.Spec.Template.Annotations["cluster-autoscaler.kubernetes.io/safe-to-evict"])
+}


### PR DESCRIPTION
The `cluster-autoscaler.kubernetes.io/safe-to-evict` annotation is currently hardcoded to "false", preventing it from being overridden in Helm values. This causes jobs targeting spot nodes to never start in a GKE Autopilot cluster, because the cluster autoscaler refuses to scale up spot nodes for pods that disallow eviction.

Moves the annotation before the metadata merges so it acts as a default that can be overridden via DefaultMetadata or k8s plugin annotations.

Fixes https://github.com/buildkite/agent-stack-k8s/issues/849