### PR TITLE
A-1136: stop detecting init container failure for sidecar containers

### DIFF
--- a/internal/controller/scheduler/pod_watcher.go
+++ b/internal/controller/scheduler/pod_watcher.go
@@ -363,9 +363,15 @@ func (w *podWatcher) failOnInitContainerFailure(ctx context.Context, log *slog.L
 
 	// If any init container fails, whether it's one we added specifically to
 	// check for pull failure or not, the pod won't run.
+	// However, native sidecar containers (init containers with RestartPolicy:
+	// Always) run alongside main containers and are expected to terminate with
+	// non-zero exit codes (e.g. SIGKILL/SIGTERM) during normal pod shutdown.
 	for _, containerStatus := range pod.Status.InitContainerStatuses {
 		term := containerStatus.State.Terminated
 		if term == nil || term.ExitCode == 0 { // not terminated, or succeeded
+			continue
+		}
+		if isSidecarInitContainer(pod, containerStatus.Name) {
 			continue
 		}
 		containerFails[containerStatus.Name] = term
@@ -789,6 +795,18 @@ func (w *podWatcher) stopWatchingForPendingTimeout(jobUUID uuid.UUID) {
 	w.watchingForPendingTimeoutMu.Lock()
 	defer w.watchingForPendingTimeoutMu.Unlock()
 	delete(w.watchingForPendingTimeout, jobUUID)
+}
+
+// isSidecarInitContainer reports whether the named init container is a native
+// sidecar (has RestartPolicy set to Always). These containers run alongside
+// main containers and should not be treated as gating init containers.
+func isSidecarInitContainer(pod *corev1.Pod, name string) bool {
+	for _, c := range pod.Spec.InitContainers {
+		if c.Name == name {
+			return c.RestartPolicy != nil && *c.RestartPolicy == corev1.ContainerRestartPolicyAlways
+		}
+	}
+	return false
 }
 
 // All container-\d containers will have the agent installed as their PID 1.

--- a/internal/controller/scheduler/pod_watcher_test.go
+++ b/internal/controller/scheduler/pod_watcher_test.go
@@ -6,9 +6,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 )
 
 func TestPodHasExceededPendingTimeout(t *testing.T) {
@@ -135,4 +137,26 @@ func TestPodHasExceededPendingTimeout(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestIsSidecarInitContainer(t *testing.T) {
+	t.Parallel()
+
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{
+				{Name: "checkout"},
+				{
+					Name:          "sidecar-0",
+					RestartPolicy: ptr.To(corev1.ContainerRestartPolicyAlways),
+				},
+				{Name: "imagecheck-0"},
+			},
+		},
+	}
+
+	assert.False(t, isSidecarInitContainer(pod, "checkout"))
+	assert.True(t, isSidecarInitContainer(pod, "sidecar-0"))
+	assert.False(t, isSidecarInitContainer(pod, "imagecheck-0"))
+	assert.False(t, isSidecarInitContainer(pod, "nonexistent"))
 }


### PR DESCRIPTION
### Problem

When a pod completes, native sidecar init containers (`restartPolicy: Always`) are terminated by the kubelet. If any sidecar exits with a non-zero code — either from SIGKILL (137) after the grace period or SIGTERM (143) if the process doesn't handle it gracefully — `failOnInitContainerFailure` misinterprets this as an init container startup failure and attempts to fail the already-finished Buildkite job, which returns 404.

At high scale (200+ concurrent jobs), this creates a burst of blocking 404 API calls that stalls the informer event loop, delaying new job pickup.

Fixes #827.

### Fix

Skip init containers with `RestartPolicy: Always` in `failOnInitContainerFailure`. These are native K8s sidecar containers that run alongside main containers — their non-zero exit codes during pod shutdown are expected, not failures.