### PR TITLE
A-1068: allow optional pod level resources on resource-class

### DIFF
--- a/charts/agent-stack-k8s/values.schema.json
+++ b/charts/agent-stack-k8s/values.schema.json
@@ -692,6 +692,9 @@
               "resource": {
                 "$ref": "https://raw.githubusercontent.com/buildkite/kubernetes-json-schema/master/v1.35.0/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements"
               },
+              "podResource": {
+                "$ref": "https://raw.githubusercontent.com/buildkite/kubernetes-json-schema/master/v1.35.0/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements"
+              },
               "nodeSelector": {
                 "type": "object",
                 "additionalProperties": {

--- a/internal/controller/config/resource_class.go
+++ b/internal/controller/config/resource_class.go
@@ -10,6 +10,7 @@ import (
 // Affinity or Toleration/taint based configuration may come later.
 type ResourceClass struct {
 	Resource     *corev1.ResourceRequirements `json:"resource,omitempty"`
+	PodResource  *corev1.ResourceRequirements `json:"podResource,omitempty"`
 	NodeSelector map[string]string            `json:"nodeSelector,omitempty"`
 }
 
@@ -47,6 +48,20 @@ func (rc *ResourceClass) Apply(podSpec *corev1.PodSpec) {
 			maps.Copy(container.Resources.Requests, rc.Resource.Requests)
 			maps.Copy(container.Resources.Limits, rc.Resource.Limits)
 		}
+	}
+
+	if rc.PodResource != nil {
+		if podSpec.Resources == nil {
+			podSpec.Resources = &corev1.ResourceRequirements{}
+		}
+		if podSpec.Resources.Requests == nil {
+			podSpec.Resources.Requests = make(corev1.ResourceList)
+		}
+		if podSpec.Resources.Limits == nil {
+			podSpec.Resources.Limits = make(corev1.ResourceList)
+		}
+		maps.Copy(podSpec.Resources.Requests, rc.PodResource.Requests)
+		maps.Copy(podSpec.Resources.Limits, rc.PodResource.Limits)
 	}
 }
 

--- a/internal/controller/config/resource_class_test.go
+++ b/internal/controller/config/resource_class_test.go
@@ -177,6 +177,87 @@ func TestResourceClass_Apply(t *testing.T) {
 			},
 		},
 		{
+			name: "applies podResource to pod-level resources",
+			resourceClass: &ResourceClass{
+				PodResource: &corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("256Mi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("2"),
+						corev1.ResourceMemory: resource.MustParse("512Mi"),
+					},
+				},
+			},
+			podSpec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "agent"},
+					{Name: "command", Env: commandContainerEnv},
+					{Name: "sidecar"},
+				},
+			},
+			want: &corev1.PodSpec{
+				Resources: &corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("256Mi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("2"),
+						corev1.ResourceMemory: resource.MustParse("512Mi"),
+					},
+				},
+				Containers: []corev1.Container{
+					{Name: "agent"},
+					{Name: "command", Env: commandContainerEnv},
+					{Name: "sidecar"},
+				},
+			},
+		},
+		{
+			name: "podResource and resource can be combined",
+			resourceClass: &ResourceClass{
+				Resource: &corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("500m"),
+					},
+				},
+				PodResource: &corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("2"),
+					},
+				},
+			},
+			podSpec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "agent"},
+					{Name: "command", Env: commandContainerEnv},
+				},
+			},
+			want: &corev1.PodSpec{
+				Resources: &corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("2"),
+					},
+					Limits: corev1.ResourceList{},
+				},
+				Containers: []corev1.Container{
+					{Name: "agent"},
+					{
+						Name: "command",
+						Env:  commandContainerEnv,
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU: resource.MustParse("500m"),
+							},
+							Limits: corev1.ResourceList{},
+						},
+					},
+				},
+			},
+		},
+		{
 			name:          "handles nil resource class",
 			resourceClass: nil,
 			podSpec: &corev1.PodSpec{

--- a/internal/integration/fixtures/pod-resource-class.yaml
+++ b/internal/integration/fixtures/pod-resource-class.yaml
@@ -1,0 +1,66 @@
+steps:
+  - label: ":memory: Pod Resource Class Test"
+    agents:
+      queue: "{{.queue}}"
+      resource_class: "pod-res"
+    image: alpine:latest
+    command: |-
+      echo "=== Pod-Level Memory Limit Check ==="
+      # Check memory limit from cgroup v1 or v2
+      if [ -f /sys/fs/cgroup/memory/memory.limit_in_bytes ]; then
+        # cgroup v1
+        MEMORY_LIMIT=$$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
+      elif [ -f /sys/fs/cgroup/memory.max ]; then
+        # cgroup v2
+        MEMORY_LIMIT=$$(cat /sys/fs/cgroup/memory.max)
+      else
+        echo "Could not find memory limit file"
+        exit 1
+      fi
+
+      echo "Memory limit: $$MEMORY_LIMIT bytes"
+
+      # Convert to MB for easier comparison (512Mi = 536870912 bytes)
+      MEMORY_LIMIT_MB=$$((MEMORY_LIMIT / 1024 / 1024))
+      echo "Memory limit: $${MEMORY_LIMIT_MB}MB"
+
+      # Check if memory limit is approximately 512MB (allowing some variance)
+      if [ "$$MEMORY_LIMIT_MB" -ge 500 ] && [ "$$MEMORY_LIMIT_MB" -le 550 ]; then
+        echo "✅ Pod-level memory limit is correctly set to ~512MB"
+      else
+        echo "❌ Pod-level memory limit is not as expected. Got $${MEMORY_LIMIT_MB}MB, expected ~512MB"
+        exit 1
+      fi
+
+      echo "=== Pod-Level CPU Limit Check ==="
+      # Check CPU limit from cgroup
+      if [ -f /sys/fs/cgroup/cpu/cpu.cfs_quota_us ] && [ -f /sys/fs/cgroup/cpu/cpu.cfs_period_us ]; then
+        # cgroup v1
+        CPU_QUOTA=$$(cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us)
+        CPU_PERIOD=$$(cat /sys/fs/cgroup/cpu/cpu.cfs_period_us)
+      elif [ -f /sys/fs/cgroup/cpu.max ]; then
+        # cgroup v2
+        CPU_MAX=$$(cat /sys/fs/cgroup/cpu.max)
+        CPU_QUOTA=$$(echo $$CPU_MAX | cut -d' ' -f1)
+        CPU_PERIOD=$$(echo $$CPU_MAX | cut -d' ' -f2)
+      else
+        echo "Could not find CPU limit files"
+        exit 1
+      fi
+
+      if [ "$$CPU_QUOTA" != "-1" ] && [ "$$CPU_QUOTA" != "max" ]; then
+        CPU_CORES=$$((CPU_QUOTA * 1000 / CPU_PERIOD))
+        echo "CPU quota: $${CPU_QUOTA}, CPU period: $${CPU_PERIOD}"
+        echo "CPU limit: $${CPU_CORES}m cores"
+
+        # Check if CPU limit is approximately 1000m (allowing some variance)
+        if [ "$$CPU_CORES" -ge 900 ] && [ "$$CPU_CORES" -le 1100 ]; then
+          echo "✅ Pod-level CPU limit is correctly set to ~1000m"
+        else
+          echo "❌ Pod-level CPU limit is not as expected. Got $${CPU_CORES}m, expected ~1000m"
+          exit 1
+        fi
+      else
+        echo "❌ No CPU limit set"
+        exit 1
+      fi

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -127,6 +127,48 @@ func TestDefaultResourceClass(t *testing.T) {
 	tc.AssertLogsContain(build, "✅ CPU limit is correctly set to ~250m (from default resource class)")
 }
 
+func TestPodResourceClass(t *testing.T) {
+	tc := testcase{
+		T:       t,
+		Fixture: "pod-resource-class.yaml",
+		Repo:    repoHTTP,
+		GraphQL: api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
+	}.Init()
+	ctx := context.Background()
+
+	sv, err := tc.Kubernetes.Discovery().ServerVersion()
+	require.NoError(t, err)
+	minor, err := strconv.Atoi(strings.TrimRight(sv.Minor, "+"))
+	require.NoError(t, err)
+	if minor < 34 {
+		t.Skipf("Requires Kubernetes 1.34+ with PodLevelResources (cluster is %s.%s)", sv.Major, sv.Minor)
+	}
+
+	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)
+
+	testCfg := cfg
+	testCfg.ResourceClasses = map[string]*config.ResourceClass{
+		"pod-res": {
+			PodResource: &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("500m"),
+					corev1.ResourceMemory: resource.MustParse("256Mi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("512Mi"),
+				},
+			},
+		},
+	}
+
+	tc.StartController(ctx, testCfg)
+	build := tc.TriggerBuild(ctx, pipelineID)
+	tc.AssertSuccess(ctx, build)
+	tc.AssertLogsContain(build, "✅ Pod-level memory limit is correctly set to ~512MB")
+	tc.AssertLogsContain(build, "✅ Pod-level CPU limit is correctly set to ~1000m")
+}
+
 func TestPodTemplate(t *testing.T) {
 	tc := testcase{
 		T:       t,


### PR DESCRIPTION
Closes #835 .

Adds a podResource field to resource classes that sets resources at the pod level using the Kubernetes 1.34+ PodLevelResources feature (spec.resources on PodSpec). This gives the scheduler a complete view of the pod's resource footprint, unlike the existing resource field which only targets the command container.

The two fields can be combined: resource for command container sizing, podResource for the overall pod resource envelope. 