### PR TITLE
chore: update values with agentStackSecret

### DIFF
--- a/charts/agent-stack-k8s/values.yaml
+++ b/charts/agent-stack-k8s/values.yaml
@@ -1,5 +1,7 @@
 agentToken: ""
 
+agentStackSecret: ""
+
 nodeSelector: {}
 tolerations: []
 


### PR DESCRIPTION
This adds the `agentStackSecret` value to the `values.yaml` file to make it more explicit that a token can be defined within a secret instead of passed in directly via `agentToken`