### PR TITLE
fix: Init controller-runtime logger before GetConfigOrDie

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -12,6 +12,7 @@ import (
 	"github.com/buildkite/agent-stack-k8s/v2/cmd/version"
 	"github.com/buildkite/agent-stack-k8s/v2/internal/controller"
 	"github.com/buildkite/agent-stack-k8s/v2/internal/controller/config"
+	"github.com/go-logr/logr"
 	"github.com/go-playground/locales/en"
 	ut "github.com/go-playground/universal-translator"
 	"github.com/go-playground/validator/v10"
@@ -20,6 +21,7 @@ import (
 	"github.com/mattn/go-isatty"
 	"k8s.io/client-go/kubernetes"
 	restconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
+	klog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 )
 
@@ -147,6 +149,7 @@ func runController(cfg *config.Config) error {
 	}
 
 	logger := slog.New(handler)
+	klog.SetLogger(logr.FromSlogHandler(handler))
 	logger.Debug("configuration loaded", "config", cfg)
 
 	clientConfig := restconfig.GetConfigOrDie()

--- a/go.mod
+++ b/go.mod
@@ -134,7 +134,7 @@ require (
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.13 // indirect
 	github.com/go-chi/chi/v5 v5.2.5 // indirect
-	github.com/go-logr/logr v1.4.3 // indirect
+	github.com/go-logr/logr v1.4.3
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect


### PR DESCRIPTION
## Summary
- `GetConfigOrDie()` is currently silently failing because the controller-runtime internal logger defaults to a no-op
- Initialize the logger via `klog.SetLogger` before calling `GetConfigOrDie()` so errors and warnings (e.g. missing kubeconfig) are surfaced through our configured slog handler

## Test plan
Verify `go run .` output

Before:
```
> go run .
exit status 1
```
After fix:
```
> go run .
Apr 20 10:51:05.906 ERR config/config.go:132 unable to load in-cluster config logger=controller-runtime/client/config err="unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined"
Apr 20 10:51:05.906 ERR config/config.go:179 unable to get kubeconfig logger=controller-runtime/client/config err="invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable"
exit status 1
```