### PR TITLE
feat: add workspace-mount-sub-path-expr config option

### DIFF
--- a/charts/agent-stack-k8s/values.schema.json
+++ b/charts/agent-stack-k8s/values.schema.json
@@ -364,6 +364,12 @@
         "workspaceVolume": {
           "$ref": "https://raw.githubusercontent.com/buildkite/kubernetes-json-schema/master/v1.35.0/_definitions.json#/definitions/io.k8s.api.core.v1.Volume"
         },
+        "workspace-mount-sub-path-expr": {
+          "type": "string",
+          "default": "",
+          "title": "When set, applied as `subPathExpr` to every /workspace VolumeMount the controller creates, so a shared workspace volume can be sliced into per-pod subdirectories. Typically `$(POD_NAME)`, with POD_NAME supplied via downward API.",
+          "examples": ["", "$(POD_NAME)"]
+        },
         "agent-config": {
           "type": "object",
           "default": null,

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -95,6 +95,10 @@ type Config struct {
 	// an EmptyDir volume is created for it.
 	WorkspaceVolume *corev1.Volume `json:"workspace-volume" validate:"omitempty"`
 
+	// WorkspaceMountSubPathExpr, when set, is applied as `subPathExpr` to
+	// every /workspace VolumeMount the controller creates.
+	WorkspaceMountSubPathExpr string `json:"workspace-mount-sub-path-expr" validate:"omitempty"`
+
 	AgentConfig            *AgentConfig    `json:"agent-config"             validate:"omitempty"`
 	DefaultCheckoutParams  *CheckoutParams `json:"default-checkout-params"  validate:"omitempty"`
 	DefaultCommandParams   *CommandParams  `json:"default-command-params"   validate:"omitempty"`

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -179,6 +179,7 @@ func Run(ctx context.Context, logger *slog.Logger, k8sClient kubernetes.Interfac
 		DefaultTerminationGracePeriodSeconds: cfg.DefaultTerminationGracePeriodSeconds,
 		AdditionalRedactedVars:               cfg.AdditionalRedactedVars,
 		WorkspaceVolume:                      cfg.WorkspaceVolume,
+		WorkspaceMountSubPathExpr:            cfg.WorkspaceMountSubPathExpr,
 		AgentConfig:                          cfg.AgentConfig,
 		DefaultCheckoutParams:                cfg.DefaultCheckoutParams,
 		DefaultCommandParams:                 cfg.DefaultCommandParams,

--- a/internal/controller/scheduler/imagecheck.go
+++ b/internal/controller/scheduler/imagecheck.go
@@ -175,6 +175,7 @@ func makeImageCheckContainers(
 	w *worker,
 	preflightImageChecks preflightImageCheckMap,
 	workspaceVolumeName string,
+	workspaceMountSubPathExpr string,
 ) []corev1.Container {
 	// Use default resource limits for pre-flight image check containers, if not provided
 	imageCheckContainerCPULimit, err := resource.ParseQuantity(w.cfg.ImageCheckContainerCPULimit)
@@ -210,8 +211,9 @@ func makeImageCheckContainers(
 			Command: []string{"/workspace/tini-static"},
 			Args:    []string{"--version"},
 			VolumeMounts: []corev1.VolumeMount{{
-				Name:      workspaceVolumeName,
-				MountPath: "/workspace",
+				Name:        workspaceVolumeName,
+				MountPath:   "/workspace",
+				SubPathExpr: workspaceMountSubPathExpr,
 			}},
 			// Apply container resource requests to imagecheck containers
 			Resources: corev1.ResourceRequirements{

--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -64,6 +64,7 @@ type Config struct {
 	JobActiveDeadlineSeconds             int
 	AdditionalRedactedVars               []string
 	WorkspaceVolume                      *corev1.Volume
+	WorkspaceMountSubPathExpr            string
 	AgentConfig                          *config.AgentConfig
 	DefaultCheckoutParams                *config.CheckoutParams
 	DefaultCommandParams                 *config.CommandParams
@@ -365,7 +366,7 @@ func (w *worker) Build(podSpec *corev1.PodSpec, skipCheckout bool, inputs buildI
 
 	// Volume mounts shared among most containers: the workspace volume, and
 	// any others supplied with ExtraVolumeMounts.
-	volumeMounts := []corev1.VolumeMount{{Name: workspaceVolume.Name, MountPath: "/workspace"}}
+	volumeMounts := []corev1.VolumeMount{w.workspaceVolumeMount(workspaceVolume.Name)}
 	if inputs.k8sPlugin != nil {
 		volumeMounts = append(volumeMounts, inputs.k8sPlugin.ExtraVolumeMounts...)
 	}
@@ -729,7 +730,7 @@ func (w *worker) Build(podSpec *corev1.PodSpec, skipCheckout bool, inputs buildI
 	// Init containers run before the agent, so we can acquire and fail the job
 	// if an init container stays in ImagePullBackOff for too long.
 	if !w.cfg.SkipImageCheckContainers {
-		imageCheckInitContainers := makeImageCheckContainers(w, preflightImageChecks, workspaceVolume.Name)
+		imageCheckInitContainers := makeImageCheckContainers(w, preflightImageChecks, workspaceVolume.Name, w.cfg.WorkspaceMountSubPathExpr)
 		initContainers = append(initContainers, imageCheckInitContainers...)
 	}
 
@@ -921,6 +922,16 @@ func PatchPodSpec(original *corev1.PodSpec, patch *corev1.PodSpec, cmdParams *co
 	return &patchedSpec, nil
 }
 
+// workspaceVolumeMount returns the standard /workspace VolumeMount with
+// the configured SubPathExpr applied.
+func (w *worker) workspaceVolumeMount(volumeName string) corev1.VolumeMount {
+	return corev1.VolumeMount{
+		Name:        volumeName,
+		MountPath:   "/workspace",
+		SubPathExpr: w.cfg.WorkspaceMountSubPathExpr,
+	}
+}
+
 func (w *worker) createWorkspaceSetupContainer(podSpec *corev1.PodSpec, workspaceVolume *corev1.Volume) corev1.Container {
 	podUser, podGroup := int64(0), int64(0)
 	if podSpec.SecurityContext != nil {
@@ -1000,10 +1011,7 @@ fi
 		Command:         []string{"/bin/sh"},
 		Args:            []string{"-cefx", containerArgs.String()},
 		SecurityContext: securityContext,
-		VolumeMounts: []corev1.VolumeMount{{
-			Name:      workspaceVolume.Name,
-			MountPath: "/workspace",
-		}},
+		VolumeMounts:    []corev1.VolumeMount{w.workspaceVolumeMount(workspaceVolume.Name)},
 	}
 }
 

--- a/internal/controller/scheduler/scheduler_test.go
+++ b/internal/controller/scheduler/scheduler_test.go
@@ -595,6 +595,94 @@ func TestBuild(t *testing.T) {
 	}
 }
 
+func TestBuildWorkspaceMountSubPathExpr(t *testing.T) {
+	t.Parallel()
+
+	job := &api.AgentJob{
+		ID:      "abc",
+		Command: "echo hello world",
+	}
+	sjob := &api.AgentScheduledJob{}
+	worker := New(
+		slog.Default(),
+		nil,
+		nil,
+		Config{
+			Namespace:                 "buildkite",
+			Image:                     "buildkite/agent:latest",
+			AgentTokenSecretName:      "bkcq_1234567890",
+			WorkspaceMountSubPathExpr: "$(POD_NAME)",
+		},
+	)
+	inputs, err := worker.ParseJob(job, sjob)
+	require.NoError(t, err)
+	kjob, err := worker.Build(&corev1.PodSpec{}, false, inputs)
+	require.NoError(t, err)
+
+	const wantMountPath = "/workspace"
+	const wantSubPathExpr = "$(POD_NAME)"
+
+	checkWorkspaceMount := func(t *testing.T, label, containerName string, mounts []corev1.VolumeMount) {
+		t.Helper()
+		var found bool
+		for _, m := range mounts {
+			if m.MountPath != wantMountPath {
+				continue
+			}
+			found = true
+			if m.SubPathExpr != wantSubPathExpr {
+				t.Errorf("%s container %q: workspace mount SubPathExpr = %q, want %q",
+					label, containerName, m.SubPathExpr, wantSubPathExpr)
+			}
+		}
+		if !found {
+			t.Errorf("%s container %q: no /workspace mount found", label, containerName)
+		}
+	}
+
+	for _, c := range kjob.Spec.Template.Spec.Containers {
+		checkWorkspaceMount(t, "container", c.Name, c.VolumeMounts)
+	}
+	for _, c := range kjob.Spec.Template.Spec.InitContainers {
+		checkWorkspaceMount(t, "initContainer", c.Name, c.VolumeMounts)
+	}
+}
+
+// TestBuildWorkspaceMountSubPathExprDefault verifies the previous behavior
+// (no SubPathExpr) is preserved when the new field is unset.
+func TestBuildWorkspaceMountSubPathExprDefault(t *testing.T) {
+	t.Parallel()
+
+	job := &api.AgentJob{
+		ID:      "abc",
+		Command: "echo hello world",
+	}
+	sjob := &api.AgentScheduledJob{}
+	worker := New(slog.Default(), nil, nil, Config{
+		Image: "buildkite/agent:latest",
+	})
+	inputs, err := worker.ParseJob(job, sjob)
+	require.NoError(t, err)
+	kjob, err := worker.Build(&corev1.PodSpec{}, false, inputs)
+	require.NoError(t, err)
+
+	checkNoSubPath := func(t *testing.T, label, containerName string, mounts []corev1.VolumeMount) {
+		t.Helper()
+		for _, m := range mounts {
+			if m.MountPath == "/workspace" && m.SubPathExpr != "" {
+				t.Errorf("%s container %q: workspace mount SubPathExpr = %q, want empty",
+					label, containerName, m.SubPathExpr)
+			}
+		}
+	}
+	for _, c := range kjob.Spec.Template.Spec.Containers {
+		checkNoSubPath(t, "container", c.Name, c.VolumeMounts)
+	}
+	for _, c := range kjob.Spec.Template.Spec.InitContainers {
+		checkNoSubPath(t, "initContainer", c.Name, c.VolumeMounts)
+	}
+}
+
 func TestBuildSkipCheckout(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
### What it is

When set, applies a `subPathExpr` to every /workspace VolumeMount the controller creates (workspace setup init container, image check init containers, agent + checkout system containers, and command containers). 

This allows a shared workspace volume — e.g. a hostPath rooted at the node's /var/lib/buildkite-workspaces — to be sliced into per-pod subdirectories so concurrent jobs on the same node don't collide on /workspace/build, /workspace/sockets, etc.

### Why 

this enables a per-node shared-cache pattern for `docker run` workloads that Plaid is using — a single dockerd DaemonSet on each node bind-mounts the shared workspace hostPath, and per-pod subdirectories prevent concurrent jobs from clobbering each other's workspace state. 
Without this option, per-pod isolation is impossible because the workspace mount is hardcoded with no SubPath.

### Usage

The canonical setup Plaid is using this in is `workspace-mount-sub-path-expr: $(POD_NAME)` paired with a downward-API POD_NAME env var on the relevant containers (via pod-spec-patch or the chart's checkout-params / command-params).

Default ("") preserves the previous behavior.

Tests cover both the configured-value-propagates-everywhere case and the default-no-subPath case.
