### PR TITLE
SUP-6977: Expose reservation-expiry-seconds in Helm chart values

### DIFF
--- a/charts/agent-stack-k8s/values.schema.json
+++ b/charts/agent-stack-k8s/values.schema.json
@@ -355,6 +355,13 @@
           "maximum": 65535,
           "title": "Bind port to expose Prometheus /metrics; 0 disables it"
         },
+        "reservation-expiry-seconds": {
+          "type": "integer",
+          "default": 900,
+          "minimum": 0,
+          "maximum": 3600,
+          "title": "How long (in seconds) a job reservation is held while waiting for Kubernetes infrastructure to be ready. Defaults to 900 (15 minutes). Maximum 3600 (1 hour)."
+        },
         "allow-pod-spec-patch-unsafe-command-modification": {
           "type": "boolean",
           "default": false,

--- a/charts/agent-stack-k8s/values.yaml
+++ b/charts/agent-stack-k8s/values.yaml
@@ -7,6 +7,7 @@ tolerations: []
 
 config:
   prometheus-port: 9216
+  reservation-expiry-seconds: 900
 
 resources:
   requests:


### PR DESCRIPTION
## Description
Exposes `reservation-expiry-seconds` in the Helm chart, so users can configure how long a job reservation is held. The controller already supports this config option (added in #847) but it wasn't visible in the Helm chart.


## Changes

- Added `reservation-expiry-seconds: 900` to charts/agent-stack-k8s/values.yaml

- Added `reservation-expiry-seconds` schema entry to charts/agent-stack-k8s/values.schema.json with `default: 900`, `minimum: 0`, `maximum: 3600`