### PR TITLE
fix: excess memory use in list-throttle condition

### DIFF
--- a/charts/agent-stack-k8s/values.schema.json
+++ b/charts/agent-stack-k8s/values.schema.json
@@ -262,7 +262,7 @@
           "type": "string",
           "default": "buildkite-",
           "title": "The prefix to use when creating Kubernetes job names",
-          "examples": ["kubekite-","buildkube-"]
+          "examples": ["kubekite-", "buildkube-"]
         },
         "job-active-deadline-seconds": {
           "type": "integer",
@@ -347,6 +347,12 @@
           "default": false,
           "title": "Allow controller to pause processing the jobs when queue is paused on Buildkite",
           "examples": [false]
+        },
+        "enable-completion-watcher": {
+          "type": "boolean",
+          "default": true,
+          "title": "Runs an extra loop that checks for and terminates pods that are still running but with a terminated agent container",
+          "examples": [false, true]
         },
         "prometheus-port": {
           "type": "integer",

--- a/charts/agent-stack-k8s/values.yaml
+++ b/charts/agent-stack-k8s/values.yaml
@@ -8,6 +8,7 @@ tolerations: []
 config:
   prometheus-port: 9216
   reservation-expiry-seconds: 900
+  enable-completion-watcher: true
 
 resources:
   requests:

--- a/cmd/controller/controller_test.go
+++ b/cmd/controller/controller_test.go
@@ -49,6 +49,7 @@ func TestReadAndParseConfig(t *testing.T) {
 		DefaultImagePullPolicy:               "Never",
 		DefaultImageCheckPullPolicy:          "IfNotPresent",
 		EnableQueuePause:                     true,
+		EnableCompletionWatcher:              true,
 		WorkQueueLimit:                       2_000_000,
 		ImageCheckContainerCPULimit:          "201m",
 		ImageCheckContainerMemoryLimit:       "129Mi",

--- a/cmd/controller/flags.go
+++ b/cmd/controller/flags.go
@@ -54,6 +54,7 @@ type CLI struct {
 	PaginationDepthLimit     *int           `kong:"help='Sets the maximum number of pages when retrieving Buildkite Jobs to be Scheduled. Increasing this value will increase the number of requests made to the Buildkite API and number of Jobs to be scheduled on the Kubernetes Cluster (default: 2)'"`
 	QueryResetInterval       *time.Duration `kong:"help='Controls the interval between pagination cursor resets. Increasing this value will increase the number of jobs to be scheduled but also delay picking up any jobs that were missed from the start of the query (default: 10s)'"`
 	EnableQueuePause         *bool          `kong:"help='Allow controller to pause processing the jobs when queue is paused on Buildkite'"`
+	EnableCompletionWatcher  *bool          `kong:"help='Runs an extra loop that checks for and terminates pods that are still running but with a terminated agent container (default: true)'"`
 	WorkQueueLimit           *int           `kong:"help='Sets the maximum number of Jobs the controller will hold in the work queue (default: 1000000)'"`
 	ReservationExpirySeconds *int           `kong:"help='Number of seconds until a job reservation expires. If the job is not started within this time, Buildkite will make it available for reservation again (default: 900, max: 3600)'"`
 
@@ -159,6 +160,7 @@ func newConfigWithDefaults() *config.Config {
 		PaginationDepthLimit:                 2,
 		QueryResetInterval:                   10 * time.Second,
 		WorkQueueLimit:                       1000000,
+		EnableCompletionWatcher:              true,
 		ImageCheckContainerCPULimit:          "200m",
 		ImageCheckContainerMemoryLimit:       "128Mi",
 		LogFormat:                            "logfmt",
@@ -232,9 +234,9 @@ func convertDurations(m map[string]any) {
 		"query-reset-interval":             {},
 		"image-pull-backoff-grace-period":  {},
 		"job-cancel-checker-poll-interval": {},
-		"empty-job-grace-period":                {},
-		"pod-pending-timeout":                   {},
-		"container-start-timeout":              {},
+		"empty-job-grace-period":           {},
+		"pod-pending-timeout":              {},
+		"container-start-timeout":          {},
 	}
 
 	for key, value := range m {

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -20,6 +20,7 @@ prometheus-port: 9216
 default-image-pull-policy: Never
 default-image-check-pull-policy: IfNotPresent
 enable-queue-pause: true
+enable-completion-watcher: true
 pagination-page-size: 1000
 pagination-depth-limit: 5
 query-reset-interval: 10s

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -51,27 +51,27 @@ type Config struct {
 	PodSpecPatch                         *corev1.PodSpec `json:"pod-spec-patch"                           validate:"omitempty"`
 
 	// Controller settings
-	JobCreationConcurrency int           `json:"job-creation-concurrency" validate:"omitempty"`
-	AgentTokenSecret       string        `json:"agent-token-secret"       validate:"required"`
-	Image                  string        `json:"image"                    validate:"required"`
-	MaxInFlight            int           `json:"max-in-flight"            validate:"min=0"`
-	Tags                   []string      `json:"tags"`
-	Queue                  string        `json:"queue"`
-	PrometheusPort         uint16        `json:"prometheus-port"          validate:"omitempty"`
-	ProfilerAddress        string        `json:"profiler-address"         validate:"omitempty,hostname_port"`
-	PollInterval           time.Duration `json:"poll-interval"`
-	HTTPTimeout            time.Duration `json:"http-timeout"             validate:"omitempty"`
-	PaginationPageSize     int           `json:"pagination-page-size"     validate:"min=1,max=1000"`
-	PaginationDepthLimit   int           `json:"pagination-depth-limit"   validate:"min=1,max=20"`
-	QueryResetInterval     time.Duration `json:"query-reset-interval"     validate:"omitempty"`
-	EnableQueuePause       bool          `json:"enable-queue-pause"       validate:"omitempty"`
-	WorkQueueLimit         int           `json:"work-queue-limit"         validate:"omitempty"`
+	JobCreationConcurrency  int           `json:"job-creation-concurrency"  validate:"omitempty"`
+	AgentTokenSecret        string        `json:"agent-token-secret"        validate:"required"`
+	Image                   string        `json:"image"                     validate:"required"`
+	MaxInFlight             int           `json:"max-in-flight"             validate:"min=0"`
+	Tags                    []string      `json:"tags"`
+	Queue                   string        `json:"queue"`
+	PrometheusPort          uint16        `json:"prometheus-port"           validate:"omitempty"`
+	ProfilerAddress         string        `json:"profiler-address"          validate:"omitempty,hostname_port"`
+	PollInterval            time.Duration `json:"poll-interval"`
+	HTTPTimeout             time.Duration `json:"http-timeout"              validate:"omitempty"`
+	PaginationPageSize      int           `json:"pagination-page-size"      validate:"min=1,max=1000"`
+	PaginationDepthLimit    int           `json:"pagination-depth-limit"    validate:"min=1,max=20"`
+	QueryResetInterval      time.Duration `json:"query-reset-interval"      validate:"omitempty"`
+	EnableQueuePause        bool          `json:"enable-queue-pause"        validate:"omitempty"`
+	WorkQueueLimit          int           `json:"work-queue-limit"          validate:"omitempty"`
+	EnableCompletionWatcher bool          `json:"enable-completion-watcher" validate:"omitempty"`
 	// ReservationExpirySeconds controls how long (in seconds) a job reservation
 	// is held before it expires. If the job is not started within this time,
 	// Buildkite will make it available for reservation again.
 	// Defaults to 900 (15 minutes) if not set. Maximum is 3600 (1 hour).
 	ReservationExpirySeconds int `json:"reservation-expiry-seconds" validate:"omitempty,min=0,max=3600"`
-	// Agent endpoint is set in agent-config.
 
 	// ID is an optional unique identifier for the controller instance.
 	// It is used as both a Kubernetes label (buildkite.com/controller-id) to filter

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -22,6 +22,8 @@ import (
 	"github.com/buildkite/stacksapi"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
@@ -336,7 +338,95 @@ func NewInformerFactory(
 		informers.WithTweakListOptions(func(opt *metav1.ListOptions) {
 			opt.LabelSelector = labels.NewSelector().Add(requirements...).String()
 		}),
+		informers.WithTransform(informerTransform),
 	), nil
+}
+
+// informerTransform strips unused fields from objects prior to caching.
+// Per the informer docs, this needs to be fast and idempotent.
+func informerTransform(obj any) (any, error) {
+	switch obj := obj.(type) {
+	case *corev1.Pod:
+		// Pod metadata we care about:
+		// - Name
+		// - Labels
+		// Pod metadata we don't care about:
+		obj.DeletionTimestamp = nil
+		obj.DeletionGracePeriodSeconds = nil
+		obj.Annotations = nil
+		obj.OwnerReferences = nil
+		obj.Finalizers = nil
+		obj.ManagedFields = nil
+
+		// Once created, we don't look at the pod spec ever again
+		obj.Spec = corev1.PodSpec{}
+
+		// Pod status fields we care about include:
+		// - Phase
+		// - ContainerStatuses
+		// Various pod status fields we don't care about:
+		obj.Status.NominatedNodeName = ""
+		obj.Status.HostIP = ""
+		obj.Status.HostIPs = nil
+		obj.Status.PodIP = ""
+		obj.Status.PodIPs = nil
+		obj.Status.QOSClass = ""
+		obj.Status.EphemeralContainerStatuses = nil
+		obj.Status.Resize = ""
+		obj.Status.ResourceClaimStatuses = nil
+		obj.Status.ExtendedResourceClaimStatus = nil
+		obj.Status.AllocatedResources = nil
+		obj.Status.Resources = nil
+		return obj, nil
+
+	case *batchv1.Job:
+		// Job metadata we care about:
+		// - Name
+		// - Labels
+		// Job metadata we don't care about:
+		obj.DeletionTimestamp = nil
+		obj.DeletionGracePeriodSeconds = nil
+		obj.Annotations = nil
+		obj.OwnerReferences = nil
+		obj.Finalizers = nil
+		obj.ManagedFields = nil
+
+		// Job spec fields we might care about after creation:
+		// - ActiveDeadlineSeconds
+		// - TTLSecondsAfterFinished
+
+		// Job spec fields we don't care about after creation:
+		obj.Spec.Parallelism = nil
+		obj.Spec.Completions = nil
+		obj.Spec.PodFailurePolicy = nil
+		obj.Spec.SuccessPolicy = nil
+		obj.Spec.BackoffLimit = nil
+		obj.Spec.BackoffLimitPerIndex = nil
+		obj.Spec.MaxFailedIndexes = nil
+		obj.Spec.Selector = nil
+		obj.Spec.ManualSelector = nil
+		obj.Spec.Template = corev1.PodTemplateSpec{}
+		obj.Spec.CompletionMode = nil
+		obj.Spec.Suspend = nil
+		obj.Spec.PodReplacementPolicy = nil
+		obj.Spec.ManagedBy = nil
+
+		// Job status fields we (might) care about:
+		// - Conditions
+		// - StartTime
+		// - CompletionTime
+		// - Active
+		// - Succeeded
+		// - Failed
+		// - Terminating
+		// - UncountedTerminatedPods
+		// - Ready
+		// Status fields we don't care about:
+		obj.Status.CompletedIndexes = ""
+		obj.Status.FailedIndexes = nil
+		return obj, nil
+	}
+	return obj, nil
 }
 
 // fetchAgentToken fetches the agent token from the agent token secret.

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -232,14 +232,16 @@ func Run(ctx context.Context, logger *slog.Logger, k8sClient kubernetes.Interfac
 	// But it does bring a trade-off of more likely reservation expiration.
 	reserver := reserver.New(logger.With("component", "reserver"), agentClient, limiter, cfg.ReservationExpirySeconds)
 
-	// PodCompletionWatcher watches k8s for pods where the agent has terminated,
-	// in order to clean up the pod. This is necessary for cleaning up unmanaged
-	// containers added via podSpecPatch, and also provides backward compatibility
-	// with legacy sidecars from older controller versions (pre-KEP-753).
-	completions := scheduler.NewPodCompletionWatcher(logger.With("component", "completions"), k8sClient, cfg.DefaultTerminationGracePeriodSeconds)
-	if err := completions.RegisterInformer(ctx, informerFactory); err != nil {
-		logger.Error("failed to register completions informer", "error", err)
-		return
+	if cfg.EnableCompletionWatcher {
+		// PodCompletionWatcher watches k8s for pods where the agent has terminated,
+		// in order to clean up the pod. This is necessary for cleaning up unmanaged
+		// containers added via podSpecPatch, and also provides backward compatibility
+		// with legacy sidecars from older controller versions (pre-KEP-753).
+		completions := scheduler.NewPodCompletionWatcher(logger.With("component", "completions"), k8sClient, cfg.DefaultTerminationGracePeriodSeconds)
+		if err := completions.RegisterInformer(ctx, informerFactory); err != nil {
+			logger.Error("failed to register completions informer", "error", err)
+			return
+		}
 	}
 
 	// JobWatcher watches for jobs in bad conditions to clean up:

--- a/internal/controller/scheduler/completions.go
+++ b/internal/controller/scheduler/completions.go
@@ -112,6 +112,16 @@ func (w *completionsWatcher) OnUpdate(old any, new any) {
 // Always), this cleanup is redundant but harmless as Kubernetes already handles
 // their termination automatically.
 func (w *completionsWatcher) cleanupSidecars(ctx context.Context, pod *corev1.Pod) {
+	// Ignore completed (succeeded or failed) and unknown status pods.
+	// Most of the time, the remaining logic applies to "Running" pods.
+	// ("Pending" is dubious... one or more of the containers haven't started,
+	// but the agent has run and terminated? still, it seems theoretically
+	// possible.)
+	switch pod.Status.Phase {
+	case corev1.PodSucceeded, corev1.PodFailed, corev1.PodUnknown:
+		return
+	}
+	// Ignore pods where the agent hasn't terminated.
 	terminated := getAgentTermination(pod)
 	if terminated == nil {
 		return


### PR DESCRIPTION
### What

- Strip pod and job objects with an informer transform, which should cut down on some memory usage in the informer cache and notification queue
- Make the completion watcher opt-out, so a source of memory consumption can be completely disabled if the completion watcher isn't needed (e.g. because no unmanaged containers are added via a podSpecPatch)
- Ignore succeeded, failed, and unknown phase pods in `cleanupSidecars`, since these are already completed.

### What not

- Filtering objects in the informer: this can be done with a label or field selector, but adding a filter on `status.phase` seems to break the controller entirely (that field doesn't exist for jobs)
- A bounded work queue for events in the completion watcher: that would bound the memory consumption, but when the limit is reached, cleanups will stop being set, which would then cause a pod leak instead. 

### Why

Fixes #874 

