### PR TITLE
A-1202 part 1: documenting pod-pending-timeout via helm chart

### DIFF
--- a/charts/agent-stack-k8s/values.schema.json
+++ b/charts/agent-stack-k8s/values.schema.json
@@ -318,6 +318,12 @@
           "title": "Duration after starting a pod that the controller will wait before considering cancelling a job due to ImagePullBackOff (e.g. when the podSpec specifies container images that cannot be pulled). Must be a Go duration string",
           "examples": ["60s"]
         },
+        "pod-pending-timeout": {
+          "type": "string",
+          "default": "15m",
+          "title": "Duration after a pod enters Pending state that the controller will wait before failing the corresponding Buildkite job and forcefully deleting the pod. Must be a Go duration string",
+          "examples": ["5m", "10m", "15m"]
+        },
         "k8s-client-rate-limiter-qps": {
           "type": "integer",
           "default": 10,

--- a/charts/agent-stack-k8s/values.yaml
+++ b/charts/agent-stack-k8s/values.yaml
@@ -9,6 +9,7 @@ config:
   prometheus-port: 9216
   reservation-expiry-seconds: 900
   enable-completion-watcher: true
+  pod-pending-timeout: 15m
 
 resources:
   requests:


### PR DESCRIPTION
Explosing pod-pending-timeout config via helm chart. This is one of the asks from #873, we have a few follow up PRs incoming. 