### PR TITLE
A-1202 part 2: handle pod failed before agent start

### DIFF
--- a/internal/controller/scheduler/job_watcher.go
+++ b/internal/controller/scheduler/job_watcher.go
@@ -154,42 +154,73 @@ func (w *jobWatcher) runChecks(ctx context.Context, kjob *batchv1.Job) {
 
 	if model.JobFinished(kjob) {
 		w.removeFromStalling(jobUUID)
-		w.checkFinishedWithoutPod(ctx, log, kjob)
+		w.checkFinished(ctx, log, jobUUID, kjob)
 	} else {
 		w.checkStalledWithoutPod(log, jobUUID, kjob)
 	}
 }
 
-func (w *jobWatcher) checkFinishedWithoutPod(ctx context.Context, log *slog.Logger, kjob *batchv1.Job) {
-	log.Debug("Checking job for finishing without a pod")
+// checkFinished inspects a finished K8s Job and, when needed, fails the
+// corresponding Buildkite job to release its reservation.
+func (w *jobWatcher) checkFinished(ctx context.Context, log *slog.Logger, jobUUID uuid.UUID, kjob *batchv1.Job) {
+	log.Debug("Checking finished job")
 
-	// If the job is finished, there should be one finished pod.
-	if kjob.Status.Failed+kjob.Status.Succeeded > 0 {
-		// All's well with the world.
+	// Successful: the agent ran and reported job state to BK itself.
+	if kjob.Status.Succeeded > 0 {
 		return
 	}
 
-	jobWatcherFinishedWithoutPodCounter.Inc()
-
-	// Check if job has failed with reason DeadlineExceeded
+	// Pods were terminated due to ActiveDeadlineSeconds being set on the
+	// k8s Job. completionsWatcher (or cleanupStalledJob) sets that to clean
+	// up after the agent has already reported job state to BK.
 	for _, cond := range kjob.Status.Conditions {
-		switch cond.Reason {
-		case batchv1.JobReasonDeadlineExceeded:
-			// Job event has reason of DeadlineExceeded
-			if kjob.Spec.ActiveDeadlineSeconds != nil {
-				// Pods have been terminated due to activeDeadlineSeconds being configured
-				// No need to run failJob()
-				return
-			}
+		if cond.Reason == batchv1.JobReasonDeadlineExceeded && kjob.Spec.ActiveDeadlineSeconds != nil {
+			return
 		}
 	}
 
-	// Because no pod has been created, the agent hasn't started.
-	// We can acquire the Buildkite job and fail it ourselves.
+	// A pod was created and failed. If BK still has the job in Reserved state,
+	// the agent never acquired it - fail the BK job ourselves
+	// to release the reservation immediately rather than waiting for the BK
+	// reservation TTL (~15 min).
+	if kjob.Status.Failed > 0 {
+		w.failBeforeAgentAcquire(ctx, log, jobUUID, kjob)
+		return
+	}
+
+	// No pod was ever created.
+	jobWatcherFinishedWithoutPodCounter.Inc()
 	log.Info("The Kubernetes job ended without starting a pod. Failing the corresponding Buildkite job")
 	message := "The Kubernetes job ended without starting a pod.\n"
 	message += w.fetchEvents(ctx, log, kjob)
 	w.failJob(ctx, log, kjob, message)
+}
+
+// failBeforeAgentAcquire is called when a k8s Job has finished with a failed
+// pod. If BK still has the job in Reserved state, the agent
+// never acquired it - so we fail the BK job to release the reservation.
+func (w *jobWatcher) failBeforeAgentAcquire(ctx context.Context, log *slog.Logger, jobUUID uuid.UUID, kjob *batchv1.Job) {
+	state, _, err := w.agentClient.GetJobState(ctx, jobUUID.String())
+	if err != nil {
+		log.Warn("Failed to fetch BK job state; skipping pre-agent failure check", "error", err)
+		return
+	}
+
+	if state.State != api.JobStateReserved {
+		// Only act when the job is still in the Reserved state. This stack
+		// reserved it; the agent never got far enough to acquire. Any other
+		// state means either the agent took it (Running, Finished etc.) or
+		// the reservation was already released (Scheduled), in which case
+		// BK is the source of truth and we shouldn't interfere.
+		return
+	}
+
+	jobWatcherFailedBeforeAgentAcquireCounter.Inc()
+	log.Info("Kubernetes pod failed before the buildkite-agent acquired the Buildkite job. Failing the BK job to release the reservation.", "bk_job_state", string(state.State))
+	message := "The Kubernetes pod failed before the buildkite-agent acquired this Buildkite job. The pod was likely killed by Kubernetes (eviction, OOM, node failure) or terminated externally before the agent could start.\n"
+	message += w.fetchEvents(ctx, log, kjob)
+	w.failJob(ctx, log, kjob, message)
+	w.ignoreJob(jobUUID)
 }
 
 func (w *jobWatcher) checkStalledWithoutPod(log *slog.Logger, jobUUID uuid.UUID, kjob *batchv1.Job) {

--- a/internal/controller/scheduler/metrics.go
+++ b/internal/controller/scheduler/metrics.go
@@ -97,6 +97,12 @@ var (
 		Name:      "jobs_finished_without_pod_total",
 		Help:      "Count of jobs that entered a terminal state (Failed or Succeeded) without a pod",
 	})
+	jobWatcherFailedBeforeAgentAcquireCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: "job_watcher",
+		Name:      "jobs_failed_before_agent_acquire_total",
+		Help:      "Count of jobs whose pod failed before the buildkite-agent acquired the Buildkite job",
+	})
 	jobWatcherStalledWithoutPodCounter = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: promNamespace,
 		Subsystem: "job_watcher",

--- a/internal/integration/fixtures/pod-killed-before-agent.yaml
+++ b/internal/integration/fixtures/pod-killed-before-agent.yaml
@@ -1,0 +1,16 @@
+steps:
+  - label: ":skull:"
+    command: "echo this should not run"
+    agents:
+      queue: "{{.queue}}"
+    plugins:
+      - kubernetes:
+          podSpec:
+            initContainers:
+              - name: slowpoke
+                image: buildkite/agent:latest
+                command:
+                  - "/bin/sh"
+                args:
+                  - "-c"
+                  - "sleep 30"

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -913,6 +913,67 @@ func TestCancelCheckerDeletePod(t *testing.T) {
 	}
 }
 
+// TestPodKilledBeforeAgentReleasesBKJob exercises the jobWatcher path that
+// fails the corresponding Buildkite job when a K8s pod fails before the
+// buildkite-agent gets a chance to acquire it (e.g. OOM, eviction, external
+// `kubectl delete pod`). Without this, the BK job would sit in `reserved`
+// state until the reservation TTL (~15 min) expires.
+func TestPodKilledBeforeAgentReleasesBKJob(t *testing.T) {
+	tc := testcase{
+		T:       t,
+		Fixture: "pod-killed-before-agent.yaml",
+		Repo:    repoHTTP,
+		GraphQL: api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
+	}.Init()
+	ctx := context.Background()
+	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)
+	tc.StartController(ctx, cfg)
+	build := tc.TriggerBuild(ctx, pipelineID)
+
+	job := build.Jobs.Edges[0].Node.(*api.JobJobTypeCommand)
+	jobName := cfg.JobPrefix + job.Uuid
+	opts := metav1.ListOptions{
+		LabelSelector: fields.OneTermEqualSelector("batch.kubernetes.io/job-name", jobName).String(),
+	}
+
+	// Wait for the pod to exist (init container will be sleeping).
+	var pods *corev1.PodList
+	if err := roko.NewRetrier(
+		roko.WithMaxAttempts(10),
+		roko.WithStrategy(roko.Exponential(2*time.Second, 0)),
+	).DoWithContext(ctx, func(r *roko.Retrier) error {
+		got, err := tc.Kubernetes.CoreV1().Pods(cfg.Namespace).List(ctx, opts)
+		if err != nil {
+			return err
+		}
+		if len(got.Items) == 0 {
+			return fmt.Errorf("found no pod, waiting for pod start")
+		}
+		pods = got
+		return nil
+	}); err != nil {
+		t.Fatalf("waiting for pod to exist: %v", err)
+	}
+
+	// Force-delete the pod with grace=0 to simulate an external kill before
+	// the agent container has a chance to start.
+	gracePeriod := int64(0)
+	for _, p := range pods.Items {
+		if err := tc.Kubernetes.CoreV1().Pods(cfg.Namespace).Delete(ctx, p.Name, metav1.DeleteOptions{
+			GracePeriodSeconds: &gracePeriod,
+		}); err != nil {
+			t.Fatalf("deleting pod %q: %v", p.Name, err)
+		}
+	}
+
+	tc.AssertFail(ctx, build)
+	jobID := tc.FirstCommandJobID(build)
+	fm := tc.FailureMessage(jobID)
+	if want := "pod failed before the buildkite-agent acquired"; !strings.Contains(fm, want) {
+		t.Errorf("FailureMessage = %q, want substring %q", fm, want)
+	}
+}
+
 func hasJobPod(tc testcase, ctx context.Context, opts metav1.ListOptions) (bool, error) {
 	pods, err := tc.Kubernetes.CoreV1().Pods(cfg.Namespace).List(ctx, opts)
 	if err != nil {


### PR DESCRIPTION
## Problem

When a Kubernetes pod fails before the `buildkite-agent` container has a chance to acquire the Buildkite job (e.g. OOMKill, eviction, node failure, external `kubectl delete pod`), the BK job stays in `reserved` state until the reservation TTL (~15 min) expires. Re-dispatch is delayed by the full TTL.

Fixes #873 (ask #3).

Alternative, a theoretically more correct solution would be moving the `agent` container to `initContainer` as a sidecar too, but this will have an impact on how exit signal is handled, so it need a bit of more thinking. 

Even if we were going to make the `agent` as `initContainer`, this change won't harm. 

## Change

Extend `jobWatcher`'s finished-job handling: when the K8s Job ends with `Status.Failed > 0`, query BK for the job state. If still `reserved`, call `FailJob` to release the reservation immediately.

Only acts on `reserved` state — `scheduled` (no reservation made) and any post-acquire state are left to BK.