### PR TITLE
A-1244 agent stack k8s: add affiliation field to issue template and a simple PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -29,5 +29,8 @@ A clear and concise description of what you expected to happen.
 # Include relevant logs if applicable
 ```
 
+## Affiliation (optional)
+If you're comfortable sharing, let us know your company or organisation — it helps us prioritise and may accelerate a response.
+
 ## Additional context
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -16,5 +16,8 @@ A clear and concise description of what you want to happen.
 ## Describe alternatives you've considered
 A clear and concise description of any alternative solutions or features you've considered.
 
+## Affiliation (optional)
+If you're comfortable sharing, let us know your company or organisation — it helps us prioritise and may accelerate a response.
+
 ## Additional context
 Add any other context or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Change
+
+<!-- What does this PR change? -->
+
+## Context
+
+<!-- Why is this change needed? Link to relevant issues or discussions. -->
+
+## Affiliation (optional, external contributors)
+
+<!--
+If you're contributing from outside Buildkite and are comfortable sharing, let us know your company or organisation — it helps us prioritise review and may accelerate a response.
+-->
+
+## Disclosures / Credits
+
+<!-- Disclose any AI assistance, prior art, or contributors who deserve credit. -->


### PR DESCRIPTION
## Change

Add an "Affiliation (optional)" section to the bug report and feature request issue templates, and introduce a new pull request template with Change, Context, Affiliation, and Disclosures / Credits sections.

## Context

A-1244

## Disclosures / Credits

Drafted with assistance from Amp.