### PR TITLE
[SUP- 7058]: Expose git-skip-fetch-existing-commits in agent-config helm values

### DIFF
--- a/charts/agent-stack-k8s/values.schema.json
+++ b/charts/agent-stack-k8s/values.schema.json
@@ -466,6 +466,9 @@
             "debug-signing": {
               "type": "boolean"
             },
+            "git-skip-fetch-existing-commits": {
+              "type": "boolean"
+            },
             "container-start-timeout": {
               "type": "string",
               "title": "Timeout for waiting for all containers to start in a pod (e.g. 5m, 10m)"

--- a/internal/controller/config/agent_config.go
+++ b/internal/controller/config/agent_config.go
@@ -28,6 +28,7 @@ type AgentConfig struct {
 	TraceContextEncoding      *string  `json:"trace-context-encoding,omitempty"`       // BUILDKITE_TRACE_CONTEXT_ENCODING
 	DisableWarningsFor              []string       `json:"disable-warnings-for,omitempty"`               // BUILDKITE_AGENT_DISABLE_WARNINGS_FOR
 	DebugSigning                    *bool          `json:"debug-signing,omitempty"`                      // BUILDKITE_AGENT_DEBUG_SIGNING
+	GitSkipFetchExistingCommits     *bool          `json:"git-skip-fetch-existing-commits,omitempty"`    // BUILDKITE_GIT_SKIP_FETCH_EXISTING_COMMITS
 	ContainerStartTimeout *time.Duration `json:"container-start-timeout,omitempty"` // BUILDKITE_KUBERNETES_CONTAINER_START_TIMEOUT
 
 	// Applies differently depending on the container
@@ -105,6 +106,7 @@ func (a *AgentConfig) ApplyToAgentStart(ctr *corev1.Container) {
 	setEnvOpt(ctr, "BUILDKITE_TRACE_CONTEXT_ENCODING", a.TraceContextEncoding)
 	setEnvCommaSep(ctr, "BUILDKITE_AGENT_DISABLE_WARNINGS_FOR", a.DisableWarningsFor)
 	setEnvBoolOpt(ctr, "BUILDKITE_AGENT_DEBUG_SIGNING", a.DebugSigning)
+	setEnvBoolOpt(ctr, "BUILDKITE_GIT_SKIP_FETCH_EXISTING_COMMITS", a.GitSkipFetchExistingCommits)
 	setEnvDurationOpt(ctr, "BUILDKITE_KUBERNETES_CONTAINER_START_TIMEOUT", a.ContainerStartTimeout)
 
 	a.applyHooksVolumeTo(ctr)


### PR DESCRIPTION
## Change
Expose `git-skip-fetch-existing-commits` in the `agent-config` helm chart values by adding the field to the `AgentConfig` struct.

## Context
`git-skip-fetch-existing-commits` was added in buildkite/agent#3725, released in agent `3.119.0`. The field was missing from the `AgentConfig` struct, so setting `config.agent-config.git-skip-fetch-existing-commits` was silently ignored. This PR Closes #886.

## Usage
Can set it in their `values.yaml`:
```yaml
config:
  agent-config:
    git-skip-fetch-existing-commits: true
```
Or via `--set`:
```shell
helm upgrade agent-stack-k8s oci://ghcr.io/buildkite/helm/agent-stack-k8s \
  --set agentToken= \
  --set config.agent-config.git-skip-fetch-existing-commits=true
```
