### PR TITLE
limiter: sort the work queue, not the input batch

### DIFF
--- a/internal/controller/limiter/limiter.go
+++ b/internal/controller/limiter/limiter.go
@@ -171,7 +171,7 @@ func (l *Limiter) HandleMany(ctx context.Context, jobs []*api.AgentScheduledJob)
 
 	// Sort by priority, preserving existing ordering between jobs with equal
 	// priority.
-	slices.SortStableFunc(jobs, func(a, b *api.AgentScheduledJob) int {
+	slices.SortStableFunc(l.queue, func(a, b *api.AgentScheduledJob) int {
 		// Higher number = higher priority.
 		// See https://buildkite.com/docs/pipelines/configure/workflows/managing-priorities
 		return cmp.Compare(b.Priority, a.Priority)

--- a/internal/controller/limiter/limiter.go
+++ b/internal/controller/limiter/limiter.go
@@ -14,10 +14,11 @@ import (
 	"github.com/buildkite/agent-stack-k8s/v2/internal/controller/config"
 	"github.com/buildkite/agent-stack-k8s/v2/internal/controller/model"
 
+	"log/slog"
+
 	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
-	"log/slog"
 )
 
 // Limiter manages a queue of jobs. While there are jobs available and less
@@ -90,14 +91,18 @@ func New(ctx context.Context, logger *slog.Logger, scheduler model.JobHandler, m
 			l.tokenBucket <- struct{}{}
 		}
 	}
-	// Rather than calling gauge.Set, get the number of tokens during scrape.
-	// Provide a callback for tokensAvailableGauge.
-	tokensAvailableFunc = func() int { return len(l.tokenBucket) }
-	workQueueLengthFunc = func() int {
-		l.queueMu.Lock()
-		defer l.queueMu.Unlock()
-		return len(l.queue)
-	}
+	func() {
+		metricCallbackMu.Lock()
+		defer metricCallbackMu.Unlock()
+		// Rather than calling gauge.Set, get the number of tokens during scrape.
+		// Provide callbacks for tokens_available and work_queue_length gauges.
+		tokensAvailableFunc = func() int { return len(l.tokenBucket) }
+		workQueueLengthFunc = func() int {
+			l.queueMu.Lock()
+			defer l.queueMu.Unlock()
+			return len(l.queue)
+		}
+	}()
 
 	l.workerWG.Add(concurrency)
 	for range concurrency {

--- a/internal/controller/limiter/limiter_priority_test.go
+++ b/internal/controller/limiter/limiter_priority_test.go
@@ -1,0 +1,234 @@
+package limiter_test
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+	"log/slog"
+	"math/rand"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/buildkite/agent-stack-k8s/v2/api"
+	"github.com/buildkite/agent-stack-k8s/v2/internal/controller/limiter"
+
+	"github.com/google/uuid"
+)
+
+// Sorting the parameter slice never reorders the destination slice, at any
+// capacity. Pins the Go-semantics premise behind the limiter fix.
+func TestSortingSrcDoesNotReorderDst(t *testing.T) {
+	check := func(t *testing.T, dstCap int) {
+		t.Helper()
+
+		dst := make([]*api.AgentScheduledJob, 2, dstCap)
+		dst[0] = &api.AgentScheduledJob{ID: "dst-A", Priority: 10}
+		dst[1] = &api.AgentScheduledJob{ID: "dst-B", Priority: 20}
+
+		src := []*api.AgentScheduledJob{
+			{ID: "src-X", Priority: 1},
+			{ID: "src-Y", Priority: 99},
+			{ID: "src-Z", Priority: 50},
+		}
+
+		dst = append(dst, src...)
+		slices.SortStableFunc(src, func(a, b *api.AgentScheduledJob) int {
+			return cmp.Compare(b.Priority, a.Priority)
+		})
+
+		gotDst := []int{dst[0].Priority, dst[1].Priority, dst[2].Priority, dst[3].Priority, dst[4].Priority}
+		wantDst := []int{10, 20, 1, 99, 50}
+		if !slices.Equal(gotDst, wantDst) {
+			t.Errorf("dst = %v, want %v", gotDst, wantDst)
+		}
+	}
+
+	t.Run("sufficient_capacity", func(t *testing.T) { check(t, 10) })
+	t.Run("forced_realloc", func(t *testing.T) { check(t, 2) })
+}
+
+type drainOrderHandler struct {
+	out chan *api.AgentScheduledJob
+}
+
+func (d *drainOrderHandler) Handle(_ context.Context, job *api.AgentScheduledJob) error {
+	d.out <- job
+	return nil
+}
+
+// A high-priority job in a mixed batch should drain first.
+func TestHandleMany_SortsBatchByPriority(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	const n = 10
+	rec := &drainOrderHandler{out: make(chan *api.AgentScheduledJob, n)}
+	lim := limiter.New(ctx, slog.Default(), rec, n, 1, -1)
+
+	jobs := []*api.AgentScheduledJob{
+		{ID: uuid.NewString(), Priority: 0},
+		{ID: uuid.NewString(), Priority: 0},
+		{ID: uuid.NewString(), Priority: 0},
+		{ID: uuid.NewString(), Priority: 0},
+		{ID: uuid.NewString(), Priority: 0},
+		{ID: uuid.NewString(), Priority: 99},
+		{ID: uuid.NewString(), Priority: 0},
+		{ID: uuid.NewString(), Priority: 0},
+		{ID: uuid.NewString(), Priority: 0},
+		{ID: uuid.NewString(), Priority: 0},
+	}
+	highID := jobs[5].ID
+
+	if err := lim.HandleMany(ctx, jobs); err != nil {
+		t.Fatalf("HandleMany: %v", err)
+	}
+
+	for i := range n {
+		j := <-rec.out
+		if j.ID == highID {
+			if i != 0 {
+				t.Errorf("priority=99 drained at position %d, want 0", i)
+			}
+			return
+		}
+	}
+	t.Errorf("priority=99 job not observed")
+}
+
+// A high-priority job in a later batch should drain ahead of low-priority
+// jobs that arrived earlier.
+func TestHandleMany_SortsAcrossBatches(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	const lowN = 200
+	rec := &drainOrderHandler{out: make(chan *api.AgentScheduledJob, lowN+1)}
+	lim := limiter.New(ctx, slog.Default(), rec, lowN+1, 1, lowN+10)
+
+	batchA := make([]*api.AgentScheduledJob, 0, lowN)
+	for range lowN {
+		batchA = append(batchA, &api.AgentScheduledJob{ID: uuid.NewString(), Priority: 0})
+	}
+	if err := lim.HandleMany(ctx, batchA); err != nil {
+		t.Fatalf("HandleMany A: %v", err)
+	}
+
+	highID := uuid.NewString()
+	if err := lim.HandleMany(ctx, []*api.AgentScheduledJob{{ID: highID, Priority: 5}}); err != nil {
+		t.Fatalf("HandleMany B: %v", err)
+	}
+
+	first := <-rec.out
+	if first.ID != highID {
+		t.Errorf("first drained job = %s, want high-priority %s", first.ID, highID)
+	}
+}
+
+// When the queue exceeds WorkQueueLimit, low-priority jobs should be the ones
+// truncated, not the most recently appended.
+func TestHandleMany_WorkQueueLimitDropsByPriority(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	const (
+		lowN     = 100
+		highN    = 50
+		queueCap = 100
+		maxFlt   = lowN + highN
+	)
+
+	rec := &drainOrderHandler{out: make(chan *api.AgentScheduledJob, maxFlt)}
+	lim := limiter.New(ctx, slog.Default(), rec, maxFlt, 1, queueCap)
+	lim.Pause(true)
+
+	highIDs := make(map[string]bool, highN)
+	batchA := make([]*api.AgentScheduledJob, 0, lowN)
+	for range lowN {
+		batchA = append(batchA, &api.AgentScheduledJob{ID: uuid.NewString(), Priority: 0})
+	}
+	if err := lim.HandleMany(ctx, batchA); err != nil {
+		t.Fatalf("HandleMany A: %v", err)
+	}
+
+	batchB := make([]*api.AgentScheduledJob, 0, highN)
+	for range highN {
+		id := uuid.NewString()
+		batchB = append(batchB, &api.AgentScheduledJob{ID: id, Priority: 5})
+		highIDs[id] = true
+	}
+	if err := lim.HandleMany(ctx, batchB); err != nil {
+		t.Fatalf("HandleMany B: %v", err)
+	}
+
+	lim.Pause(false)
+
+	highDrained := 0
+	for range queueCap {
+		j := <-rec.out
+		if highIDs[j.ID] {
+			highDrained++
+		}
+	}
+	if highDrained != highN {
+		t.Errorf("priority=5 drained: %d, want %d", highDrained, highN)
+	}
+}
+
+// Concurrent HandleMany callers + multiple workers must not race or lose
+// jobs. Run with -race.
+func TestHandleMany_ConcurrentProducersRaceFree(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	const (
+		producers    = 16
+		batchesEach  = 25
+		jobsPerBatch = 50
+		totalJobs    = producers * batchesEach * jobsPerBatch
+	)
+
+	rec := &drainOrderHandler{out: make(chan *api.AgentScheduledJob, totalJobs)}
+	lim := limiter.New(ctx, slog.Default(), rec, totalJobs, 8, totalJobs)
+
+	var wg sync.WaitGroup
+	for p := range producers {
+		wg.Add(1)
+		go func(pid int) {
+			defer wg.Done()
+			r := rand.New(rand.NewSource(int64(pid)))
+			for b := range batchesEach {
+				batch := make([]*api.AgentScheduledJob, 0, jobsPerBatch)
+				for j := range jobsPerBatch {
+					batch = append(batch, &api.AgentScheduledJob{
+						ID:       fmt.Sprintf("p%d-b%d-j%d", pid, b, j),
+						Priority: r.Intn(6),
+					})
+				}
+				if err := lim.HandleMany(ctx, batch); err != nil {
+					t.Errorf("HandleMany p%d b%d: %v", pid, b, err)
+					return
+				}
+			}
+		}(p)
+	}
+	wg.Wait()
+
+	got := 0
+	timeout := time.After(30 * time.Second)
+	for got < totalJobs {
+		select {
+		case <-rec.out:
+			got++
+		case <-timeout:
+			t.Fatalf("timeout: drained %d of %d", got, totalJobs)
+		}
+	}
+}

--- a/internal/controller/limiter/limiter_priority_test.go
+++ b/internal/controller/limiter/limiter_priority_test.go
@@ -1,12 +1,10 @@
 package limiter_test
 
 import (
-	"cmp"
 	"context"
 	"fmt"
 	"log/slog"
-	"math/rand"
-	"slices"
+	"math/rand/v2"
 	"sync"
 	"testing"
 	"time"
@@ -16,38 +14,6 @@ import (
 
 	"github.com/google/uuid"
 )
-
-// Sorting the parameter slice never reorders the destination slice, at any
-// capacity. Pins the Go-semantics premise behind the limiter fix.
-func TestSortingSrcDoesNotReorderDst(t *testing.T) {
-	check := func(t *testing.T, dstCap int) {
-		t.Helper()
-
-		dst := make([]*api.AgentScheduledJob, 2, dstCap)
-		dst[0] = &api.AgentScheduledJob{ID: "dst-A", Priority: 10}
-		dst[1] = &api.AgentScheduledJob{ID: "dst-B", Priority: 20}
-
-		src := []*api.AgentScheduledJob{
-			{ID: "src-X", Priority: 1},
-			{ID: "src-Y", Priority: 99},
-			{ID: "src-Z", Priority: 50},
-		}
-
-		dst = append(dst, src...)
-		slices.SortStableFunc(src, func(a, b *api.AgentScheduledJob) int {
-			return cmp.Compare(b.Priority, a.Priority)
-		})
-
-		gotDst := []int{dst[0].Priority, dst[1].Priority, dst[2].Priority, dst[3].Priority, dst[4].Priority}
-		wantDst := []int{10, 20, 1, 99, 50}
-		if !slices.Equal(gotDst, wantDst) {
-			t.Errorf("dst = %v, want %v", gotDst, wantDst)
-		}
-	}
-
-	t.Run("sufficient_capacity", func(t *testing.T) { check(t, 10) })
-	t.Run("forced_realloc", func(t *testing.T) { check(t, 2) })
-}
 
 type drainOrderHandler struct {
 	out chan *api.AgentScheduledJob
@@ -62,8 +28,7 @@ func (d *drainOrderHandler) Handle(_ context.Context, job *api.AgentScheduledJob
 func TestHandleMany_SortsBatchByPriority(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	const n = 10
 	rec := &drainOrderHandler{out: make(chan *api.AgentScheduledJob, n)}
@@ -104,8 +69,7 @@ func TestHandleMany_SortsBatchByPriority(t *testing.T) {
 func TestHandleMany_SortsAcrossBatches(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	const lowN = 200
 	rec := &drainOrderHandler{out: make(chan *api.AgentScheduledJob, lowN+1)}
@@ -135,8 +99,7 @@ func TestHandleMany_SortsAcrossBatches(t *testing.T) {
 func TestHandleMany_WorkQueueLimitDropsByPriority(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	const (
 		lowN     = 100
@@ -185,8 +148,7 @@ func TestHandleMany_WorkQueueLimitDropsByPriority(t *testing.T) {
 // Concurrent HandleMany callers + multiple workers must not race or lose
 // jobs. Run with -race.
 func TestHandleMany_ConcurrentProducersRaceFree(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	const (
 		producers    = 16
@@ -199,17 +161,14 @@ func TestHandleMany_ConcurrentProducersRaceFree(t *testing.T) {
 	lim := limiter.New(ctx, slog.Default(), rec, totalJobs, 8, totalJobs)
 
 	var wg sync.WaitGroup
-	for p := range producers {
-		wg.Add(1)
-		go func(pid int) {
-			defer wg.Done()
-			r := rand.New(rand.NewSource(int64(pid)))
+	for pid := range producers {
+		wg.Go(func() {
 			for b := range batchesEach {
 				batch := make([]*api.AgentScheduledJob, 0, jobsPerBatch)
 				for j := range jobsPerBatch {
 					batch = append(batch, &api.AgentScheduledJob{
 						ID:       fmt.Sprintf("p%d-b%d-j%d", pid, b, j),
-						Priority: r.Intn(6),
+						Priority: rand.N(6),
 					})
 				}
 				if err := lim.HandleMany(ctx, batch); err != nil {
@@ -217,7 +176,7 @@ func TestHandleMany_ConcurrentProducersRaceFree(t *testing.T) {
 					return
 				}
 			}
-		}(p)
+		})
 	}
 	wg.Wait()
 

--- a/internal/controller/limiter/limiter_test.go
+++ b/internal/controller/limiter/limiter_test.go
@@ -16,8 +16,7 @@ import (
 func TestLimiter(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx, cancel := context.WithCancel(t.Context())
 
 	fakeSched := model.NewFakeScheduler(1, nil)
 	limiter := limiter.New(ctx, slog.Default(), fakeSched, 1, 1, -1)
@@ -52,8 +51,7 @@ func TestLimiter(t *testing.T) {
 func TestLimiter_SchedulerErrors(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx, cancel := context.WithCancel(t.Context())
 
 	fakeSched := model.NewFakeScheduler(0, errors.New("invalid"))
 	limiter := limiter.New(ctx, slog.Default(), fakeSched, 1, 1, -1)

--- a/internal/controller/limiter/metrics.go
+++ b/internal/controller/limiter/metrics.go
@@ -1,6 +1,8 @@
 package limiter
 
 import (
+	"sync"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
@@ -11,7 +13,11 @@ const (
 )
 
 var (
-	// Overridden by New to return len(tokenBucket).
+	// These callbacks are overriden by New.
+	// The mutex is required to prevent data races during parallelised
+	// tests. Note, though, that calling New multiple times in parallel
+	// still makes the metrics totally unreliable.
+	metricCallbackMu    sync.RWMutex
 	tokensAvailableFunc = func() int { return 0 }
 	workQueueLengthFunc = func() int { return 0 }
 )
@@ -28,13 +34,21 @@ var (
 		Subsystem: promSubsystem,
 		Name:      "tokens_available",
 		Help:      "Limiter tokens currently available",
-	}, func() float64 { return float64(tokensAvailableFunc()) })
+	}, func() float64 {
+		metricCallbackMu.RLock()
+		defer metricCallbackMu.RUnlock()
+		return float64(tokensAvailableFunc())
+	})
 	_ = promauto.NewGaugeFunc(prometheus.GaugeOpts{
 		Namespace: promNamespace,
 		Subsystem: promSubsystem,
 		Name:      "work_queue_length",
 		Help:      "Amount of enqueued work in the limiter",
-	}, func() float64 { return float64(workQueueLengthFunc()) })
+	}, func() float64 {
+		metricCallbackMu.RLock()
+		defer metricCallbackMu.RUnlock()
+		return float64(workQueueLengthFunc())
+	})
 
 	tokenWaitDurationHistogram = promauto.NewHistogram(prometheus.HistogramOpts{
 		Namespace:                    promNamespace,


### PR DESCRIPTION
## Change

One-character fix in `Limiter.HandleMany`: switch the `slices.SortStableFunc` target from the `jobs` parameter to `l.queue`. Plus five new tests in `internal/controller/limiter/limiter_priority_test.go`.

## Context

In `HandleMany`, the post-append `SortStableFunc` call sorted the `jobs` parameter instead of `l.queue`. After `l.queue = append(l.queue, jobs...)` copies the pointers into `l.queue`'s backing array, sorting `jobs` no longer affects `l.queue` — they're independent slice headers backed by independent arrays. Net effect:

- Workers pop `l.queue[0]`, so dequeue was insertion-order (FIFO) regardless of priority.
- The `WorkQueueLimit` truncation dropped by arrival recency, not by lowest priority — so the *newest* arrivals got evicted, often including high-priority jobs that just landed.
- `Priority` only influenced ordering at the BK API → controller boundary (because `getScheduledJobs` returns priority-sorted pages); once a wave was buffered inside the controller, priority did nothing.

Both callers — `Reserver.HandleMany` and `Monitor` — only use `len()` of the slice after `HandleMany` returns, so the in-place side effect on `jobs` was invisible upstream and the wrong behavior had no failing test.

Targeting `l.queue` instead makes the two adjacent comments ("Sort by priority…", "highest priority jobs are more likely to remain") describe what the code actually does.

**Tests added:**
- `TestSortingSrcDoesNotReorderDst` pins the Go-semantics premise (deterministic at both sufficient and forced-realloc capacities).
- `TestHandleMany_SortsBatchByPriority` covers single-batch ordering.
- `TestHandleMany_SortsAcrossBatches` covers a later high-priority job jumping ahead of earlier low-priority jobs.
- `TestHandleMany_WorkQueueLimitDropsByPriority` covers the truncation side of the fix.
- `TestHandleMany_ConcurrentProducersRaceFree` exercises the now-shared sort target under `-race`.

**Test plan:**
- `go test ./internal/controller/limiter/...` — all pass.
- `go test -race -run TestHandleMany_ConcurrentProducersRaceFree ./internal/controller/limiter/` — passes.
- Note: running multiple limiter tests in parallel under `-race` trips a pre-existing race on the package-level `tokensAvailableFunc` / `workQueueLengthFunc` closures in `metrics.go`, unrelated to this change.

**Performance note:** the fix now sorts the entire `l.queue` on each `HandleMany` call. For a queue of several thousand entries this stays sub-millisecond inside the mutex critical section, so I don't think it warrants a data-structure change for this PR — but a heap-based priority queue would be more elegant if you wanted to revisit it separately.

## Affiliation (optional, external contributors)

Meta — found this while debugging a high-priority job that took unexpectedly long to be picked up by an agent during a large CI burst.

## Disclosures / Credits

Investigation and patch developed with assistance from Claude (Anthropic).