### PR TITLE
Add additional hooks configuration

### DIFF
--- a/.buildkite/fixtures/additional-hooks.yaml
+++ b/.buildkite/fixtures/additional-hooks.yaml
@@ -1,0 +1,12 @@
+# This configmap is used by TestAdditionalHooks.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: integration-tests-fixture-additional-hooks
+  namespace: buildkite-k8s-integration-test
+data:
+  environment: echo 'Hello from the additional environment hook'
+  pre-checkout: echo 'Hello from the additional pre-checkout hook'
+  post-checkout: echo 'Hello from the additional post-checkout hook'
+  pre-command: echo 'Hello from the additional pre-command hook'
+  post-command: echo 'Hello from the additional post-command hook'

--- a/charts/agent-stack-k8s/values.schema.json
+++ b/charts/agent-stack-k8s/values.schema.json
@@ -454,6 +454,36 @@
             "hooks-path": {
               "type": "string"
             },
+            "additional-hooks-paths": {
+              "type": "array",
+              "default": [],
+              "title": "Additional hook directories already present in agent and bootstrap containers",
+              "items": {
+                "type": "string"
+              },
+              "examples": [
+                ["/buildkite/baked-in-hooks"],
+                ["/opt/buildkite/hooks", "/usr/local/share/buildkite/hooks"]
+              ]
+            },
+            "additional-hooks": {
+              "type": "array",
+              "default": [],
+              "title": "Additional hook directories to mount into agent, checkout, and command containers",
+              "items": {
+                "type": "object",
+                "required": ["path", "volume"],
+                "properties": {
+                  "path": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "volume": {
+                    "$ref": "https://raw.githubusercontent.com/buildkite/kubernetes-json-schema/master/v1.35.0/_definitions.json#/definitions/io.k8s.api.core.v1.Volume"
+                  }
+                }
+              }
+            },
             "plugins-path": {
               "type": "string"
             },

--- a/cmd/controller/controller_test.go
+++ b/cmd/controller/controller_test.go
@@ -89,7 +89,24 @@ func TestReadAndParseConfig(t *testing.T) {
 			},
 		},
 		AgentConfig: &config.AgentConfig{
-			Endpoint: ptr("http://agent.buildkite.localhost/v3"),
+			Endpoint:             ptr("http://agent.buildkite.localhost/v3"),
+			AdditionalHooksPaths: []string{"/buildkite/baked-in-hooks"},
+			AdditionalHooks: []config.AdditionalHook{
+				{
+					Path: "/buildkite/extra-hooks",
+					Volume: &corev1.Volume{
+						Name: "extra-hooks",
+						VolumeSource: corev1.VolumeSource{
+							ConfigMap: &corev1.ConfigMapVolumeSource{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "extra-hooks",
+								},
+								DefaultMode: ptr[int32](493),
+							},
+						},
+					},
+				},
+			},
 		},
 		DefaultCommandParams: &config.CommandParams{
 			Interposer: config.InterposerVector,
@@ -202,6 +219,57 @@ resource-classes:
 default-resource-class-name: small
 `,
 			wantErr: `default-resource-class-name "small" specified but no resource-classes defined`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cleanTestEnv(t)
+			configFile := createTempConfigFile(t, tt.configYAML)
+
+			_, err := controller.BuildConfigFromArgs([]string{"--config=" + configFile})
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestParseAndValidateConfig_AdditionalHooksValidation(t *testing.T) {
+	tests := []struct {
+		name       string
+		configYAML string
+		wantErr    string
+	}{
+		{
+			name: "missing path",
+			configYAML: `
+agent-config:
+  additional-hooks:
+    - volume:
+        name: additional-hooks
+        emptyDir: {}
+`,
+			wantErr: `agent-config.additional-hooks[0].path is required`,
+		},
+		{
+			name: "missing volume",
+			configYAML: `
+agent-config:
+  additional-hooks:
+    - path: /buildkite/additional-hooks
+`,
+			wantErr: `agent-config.additional-hooks[0].volume is required`,
+		},
+		{
+			name: "missing volume name",
+			configYAML: `
+agent-config:
+  additional-hooks:
+    - path: /buildkite/additional-hooks
+      volume:
+        emptyDir: {}
+`,
+			wantErr: `agent-config.additional-hooks[0].volume.name is required`,
 		},
 	}
 

--- a/cmd/controller/controller_test.go
+++ b/cmd/controller/controller_test.go
@@ -238,7 +238,7 @@ func TestParseAndValidateConfig_AdditionalHooksValidation(t *testing.T) {
 	tests := []struct {
 		name       string
 		configYAML string
-		wantErr    string
+		wantErrs   []string
 	}{
 		{
 			name: "missing path",
@@ -249,7 +249,7 @@ agent-config:
         name: additional-hooks
         emptyDir: {}
 `,
-			wantErr: `agent-config.additional-hooks[0].path is required`,
+			wantErrs: []string{`agent-config.additional-hooks[0].path is required`},
 		},
 		{
 			name: "missing volume",
@@ -258,7 +258,7 @@ agent-config:
   additional-hooks:
     - path: /buildkite/additional-hooks
 `,
-			wantErr: `agent-config.additional-hooks[0].volume is required`,
+			wantErrs: []string{`agent-config.additional-hooks[0].volume is required`},
 		},
 		{
 			name: "missing volume name",
@@ -269,7 +269,26 @@ agent-config:
       volume:
         emptyDir: {}
 `,
-			wantErr: `agent-config.additional-hooks[0].volume.name is required`,
+			wantErrs: []string{`agent-config.additional-hooks[0].volume.name is required`},
+		},
+		{
+			name: "multiple validation failures",
+			configYAML: `
+agent-config:
+  additional-hooks:
+    - volume:
+        emptyDir: {}
+    - path: /buildkite/additional-hooks
+    - volume:
+        name: additional-hooks
+        emptyDir: {}
+`,
+			wantErrs: []string{
+				`agent-config.additional-hooks[0].path is required`,
+				`agent-config.additional-hooks[0].volume.name is required`,
+				`agent-config.additional-hooks[1].volume is required`,
+				`agent-config.additional-hooks[2].path is required`,
+			},
 		},
 	}
 
@@ -280,7 +299,9 @@ agent-config:
 
 			_, err := controller.BuildConfigFromArgs([]string{"--config=" + configFile})
 			require.Error(t, err)
-			require.Contains(t, err.Error(), tt.wantErr)
+			for _, wantErr := range tt.wantErrs {
+				require.Contains(t, err.Error(), wantErr)
+			}
 		})
 	}
 }

--- a/cmd/controller/flags.go
+++ b/cmd/controller/flags.go
@@ -280,6 +280,10 @@ func validateConfig(cfg *config.Config) error {
 		return err
 	}
 
+	if err := validateAgentConfig(cfg.AgentConfig); err != nil {
+		return err
+	}
+
 	if cfg.PodSpecPatch != nil {
 		if err := validatePodSpecPatch(cfg.PodSpecPatch, cfg.AllowPodSpecPatchUnsafeCmdMod); err != nil {
 			return fmt.Errorf("invalid pod spec patch: %w", err)
@@ -300,6 +304,25 @@ func validateConfig(cfg *config.Config) error {
 		}
 		if _, exists := cfg.ResourceClasses[cfg.DefaultResourceClassName]; !exists {
 			return fmt.Errorf("default-resource-class-name %q not found in resource-classes", cfg.DefaultResourceClassName)
+		}
+	}
+
+	return nil
+}
+
+func validateAgentConfig(agentConfig *config.AgentConfig) error {
+	if agentConfig == nil {
+		return nil
+	}
+
+	for i, h := range agentConfig.AdditionalHooks {
+		switch {
+		case h.Path == "":
+			return fmt.Errorf("agent-config.additional-hooks[%d].path is required", i)
+		case h.Volume == nil:
+			return fmt.Errorf("agent-config.additional-hooks[%d].volume is required", i)
+		case h.Volume.Name == "":
+			return fmt.Errorf("agent-config.additional-hooks[%d].volume.name is required", i)
 		}
 	}
 

--- a/cmd/controller/flags.go
+++ b/cmd/controller/flags.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"reflect"
@@ -315,18 +316,21 @@ func validateAgentConfig(agentConfig *config.AgentConfig) error {
 		return nil
 	}
 
+	var errs []error
 	for i, h := range agentConfig.AdditionalHooks {
-		switch {
-		case h.Path == "":
-			return fmt.Errorf("agent-config.additional-hooks[%d].path is required", i)
-		case h.Volume == nil:
-			return fmt.Errorf("agent-config.additional-hooks[%d].volume is required", i)
-		case h.Volume.Name == "":
-			return fmt.Errorf("agent-config.additional-hooks[%d].volume.name is required", i)
+		if h.Path == "" {
+			errs = append(errs, fmt.Errorf("agent-config.additional-hooks[%d].path is required", i))
+		}
+		if h.Volume == nil {
+			errs = append(errs, fmt.Errorf("agent-config.additional-hooks[%d].volume is required", i))
+			continue
+		}
+		if h.Volume.Name == "" {
+			errs = append(errs, fmt.Errorf("agent-config.additional-hooks[%d].volume.name is required", i))
 		}
 	}
 
-	return nil
+	return errors.Join(errs...)
 }
 
 func validatePodSpecPatch(podSpec *corev1.PodSpec, allowCmdMod bool) error {

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -65,6 +65,15 @@ agent-config:
   # Setting a custom Agent REST API endpoint is usually only useful if you have
   # a different instance of Buildkite itself available to run.
   endpoint: http://agent.buildkite.localhost/v3
+  additional-hooks-paths:
+    - /buildkite/baked-in-hooks
+  additional-hooks:
+    - path: /buildkite/extra-hooks
+      volume:
+        name: extra-hooks
+        configMap:
+          defaultMode: 493
+          name: extra-hooks
 
 # Applies to the checkout container in all spawned pods
 default-checkout-params:

--- a/internal/controller/config/agent_config.go
+++ b/internal/controller/config/agent_config.go
@@ -46,16 +46,23 @@ type AgentConfig struct {
 	SigningJWKSVolume *corev1.Volume `json:"signingJWKSVolume,omitempty"`
 
 	// Hooks and plugins can be supplied with a volume source.
-	HooksPath     *string        `json:"hooks-path,omitempty"` // BUILDKITE_HOOKS_PATH
-	HooksVolume   *corev1.Volume `json:"hooksVolume,omitempty"`
-	PluginsPath   *string        `json:"plugins-path,omitempty"` // BUILDKITE_PLUGINS_PATH
-	PluginsVolume *corev1.Volume `json:"pluginsVolume,omitempty"`
+	HooksPath            *string          `json:"hooks-path,omitempty"` // BUILDKITE_HOOKS_PATH
+	HooksVolume          *corev1.Volume   `json:"hooksVolume,omitempty"`
+	AdditionalHooksPaths []string         `json:"additional-hooks-paths,omitempty"` // BUILDKITE_ADDITIONAL_HOOKS_PATHS
+	AdditionalHooks      []AdditionalHook `json:"additional-hooks,omitempty"`
+	PluginsPath          *string          `json:"plugins-path,omitempty"` // BUILDKITE_PLUGINS_PATH
+	PluginsVolume        *corev1.Volume   `json:"pluginsVolume,omitempty"`
 
 	// Applies only to the "buildkite-agent start" container.
 	// Keys can be supplied with a volume.
 	VerificationJWKSFile        *string        `json:"verification-jwks-file,omitempty"`        // BUILDKITE_AGENT_VERIFICATION_JWKS_FILE
 	VerificationFailureBehavior *string        `json:"verification-failure-behavior,omitempty"` // BUILDKITE_AGENT_JOB_VERIFICATION_NO_SIGNATURE_BEHAVIOR
 	VerificationJWKSVolume      *corev1.Volume `json:"verificationJWKSVolume,omitempty"`
+}
+
+type AdditionalHook struct {
+	Path   string         `json:"path,omitempty"`
+	Volume *corev1.Volume `json:"volume,omitempty"`
 }
 
 func (a *AgentConfig) ControllerOptions() []agentcore.ControllerOption {
@@ -79,6 +86,11 @@ func (a *AgentConfig) ApplyVolumesTo(podSpec *corev1.PodSpec) {
 	}
 	if a.HooksVolume != nil {
 		podSpec.Volumes = append(podSpec.Volumes, *a.HooksVolume)
+	}
+	for _, h := range a.AdditionalHooks {
+		if h.Volume != nil {
+			podSpec.Volumes = append(podSpec.Volumes, *h.Volume)
+		}
 	}
 	if a.PluginsVolume != nil {
 		podSpec.Volumes = append(podSpec.Volumes, *a.PluginsVolume)
@@ -111,6 +123,8 @@ func (a *AgentConfig) ApplyToAgentStart(ctr *corev1.Container) {
 
 	a.applyHooksVolumeTo(ctr)
 	setEnvOpt(ctr, "BUILDKITE_HOOKS_PATH", a.HooksPath)
+	a.applyAdditionalHooksVolumesTo(ctr)
+	setEnvCommaSep(ctr, "BUILDKITE_ADDITIONAL_HOOKS_PATHS", a.additionalHooksPaths())
 
 	a.applyPluginsVolumeTo(ctr)
 	setEnvOpt(ctr, "BUILDKITE_PLUGINS_PATH", a.PluginsPath)
@@ -169,6 +183,7 @@ func (a *AgentConfig) ApplyToCommand(ctr *corev1.Container) {
 		return
 	}
 	a.applyHooksVolumeTo(ctr)
+	a.applyAdditionalHooksVolumesTo(ctr)
 	a.applyPluginsVolumeTo(ctr)
 	// Signing happens either with "pipeline upload" or "tool sign", so the
 	// signing side of any key needs to be attached to the command container,
@@ -188,6 +203,7 @@ func (a *AgentConfig) ApplyToCheckout(ctr *corev1.Container) {
 		return
 	}
 	a.applyHooksVolumeTo(ctr)
+	a.applyAdditionalHooksVolumesTo(ctr)
 	a.applyPluginsVolumeTo(ctr)
 }
 
@@ -202,6 +218,35 @@ func (a *AgentConfig) applyHooksVolumeTo(ctr *corev1.Container) {
 		Name:      a.HooksVolume.Name,
 		MountPath: *a.HooksPath,
 	})
+}
+
+func (a *AgentConfig) additionalHooksPaths() []string {
+	if a == nil {
+		return nil
+	}
+	paths := []string{}
+	paths = append(paths, a.AdditionalHooksPaths...)
+	for _, h := range a.AdditionalHooks {
+		if h.Path != "" {
+			paths = append(paths, h.Path)
+		}
+	}
+	return paths
+}
+
+func (a *AgentConfig) applyAdditionalHooksVolumesTo(ctr *corev1.Container) {
+	if a == nil || ctr == nil {
+		return
+	}
+	for _, h := range a.AdditionalHooks {
+		if h.Volume == nil || h.Path == "" {
+			continue
+		}
+		ctr.VolumeMounts = append(ctr.VolumeMounts, corev1.VolumeMount{
+			Name:      h.Volume.Name,
+			MountPath: h.Path,
+		})
+	}
 }
 
 func (a *AgentConfig) applyPluginsVolumeTo(ctr *corev1.Container) {

--- a/internal/controller/scheduler/scheduler_test.go
+++ b/internal/controller/scheduler/scheduler_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"log/slog"
-	"slices"
 	"strings"
 	"testing"
 
@@ -1555,6 +1554,147 @@ func TestImagePullPolicies(t *testing.T) {
 	}
 }
 
+func TestAdditionalHooksOptions(t *testing.T) {
+	additionalHooksVolume := &corev1.Volume{
+		Name: "additional-hooks",
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+	}
+
+	tests := []struct {
+		name                     string
+		agentConfig              *config.AgentConfig
+		wantAdditionalHooksEnv   string
+		wantPodVolumes           []string
+		wantNotPodVolumes        []string
+		wantAdditionalHookMounts map[string]string
+	}{
+		{
+			name:                   "sets additional hooks env when only image-baked paths are configured",
+			agentConfig:            &config.AgentConfig{AdditionalHooksPaths: []string{"/image/hooks", "/image/more-hooks"}},
+			wantAdditionalHooksEnv: "/image/hooks,/image/more-hooks",
+			wantNotPodVolumes: []string{
+				additionalHooksVolume.Name,
+			},
+		},
+		{
+			name: "mounts volume-backed additional hooks and adds their path to the env",
+			agentConfig: &config.AgentConfig{
+				AdditionalHooks: []config.AdditionalHook{
+					{
+						Path:   "/buildkite/additional-hooks",
+						Volume: additionalHooksVolume,
+					},
+				},
+			},
+			wantAdditionalHooksEnv: "/buildkite/additional-hooks",
+			wantPodVolumes:         []string{additionalHooksVolume.Name},
+			wantAdditionalHookMounts: map[string]string{
+				additionalHooksVolume.Name: "/buildkite/additional-hooks",
+			},
+		},
+		{
+			name: "combines image-baked and volume-backed additional hook paths",
+			agentConfig: &config.AgentConfig{
+				AdditionalHooksPaths: []string{"/image/hooks"},
+				AdditionalHooks: []config.AdditionalHook{
+					{
+						Path:   "/buildkite/additional-hooks",
+						Volume: additionalHooksVolume,
+					},
+				},
+			},
+			wantAdditionalHooksEnv: "/image/hooks,/buildkite/additional-hooks",
+			wantPodVolumes:         []string{additionalHooksVolume.Name},
+			wantAdditionalHookMounts: map[string]string{
+				additionalHooksVolume.Name: "/buildkite/additional-hooks",
+			},
+		},
+		{
+			name:              "does not set additional hook config when agent config is nil",
+			agentConfig:       nil,
+			wantNotPodVolumes: []string{additionalHooksVolume.Name},
+		},
+		{
+			name:              "does not set additional hook config when agent config is empty",
+			agentConfig:       &config.AgentConfig{},
+			wantNotPodVolumes: []string{additionalHooksVolume.Name},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			worker := New(
+				slog.Default(),
+				nil,
+				nil,
+				Config{
+					Namespace:            "buildkite",
+					AgentTokenSecretName: "bkcq_1234567890",
+					Image:                "buildkite/agent:latest",
+					AgentConfig:          test.agentConfig,
+				},
+			)
+			kjob, err := worker.Build(
+				&corev1.PodSpec{},
+				false,
+				buildInputs{
+					uuid:            "1234",
+					command:         "echo shell",
+					agentQueryRules: []string{"queue=kubernetes"},
+				},
+			)
+			require.NoError(t, err)
+
+			// Check pod volumes.
+			podSpec := kjob.Spec.Template.Spec
+			for _, wantName := range test.wantPodVolumes {
+				if !hasVolumeNamed(podSpec.Volumes, wantName) {
+					t.Errorf("podSpec.Volumes = %v, is missing volume named %q", podSpec.Volumes, wantName)
+				}
+			}
+			for _, wantNotName := range test.wantNotPodVolumes {
+				if hasVolumeNamed(podSpec.Volumes, wantNotName) {
+					t.Errorf("podSpec.Volumes = %v, has unwanted volume named %q", podSpec.Volumes, wantNotName)
+				}
+			}
+
+			// Check agent env.
+			agent := findContainer(t, podSpec.Containers, "agent")
+			env := findEnv(t, agent.Env, "BUILDKITE_ADDITIONAL_HOOKS_PATHS")
+			if test.wantAdditionalHooksEnv == "" {
+				if env != nil {
+					t.Errorf("agent.Env = %v, has unwanted BUILDKITE_ADDITIONAL_HOOKS_PATHS env var", agent.Env)
+				}
+			} else if env == nil || env.Value != test.wantAdditionalHooksEnv {
+				t.Errorf("agent.Env[BUILDKITE_ADDITIONAL_HOOKS_PATHS] = %v, want %q", env, test.wantAdditionalHooksEnv)
+			}
+
+			// Check container mounts.
+			containers := []corev1.Container{
+				agent,
+				findContainer(t, podSpec.Containers, "checkout"),
+				findContainer(t, podSpec.Containers, "container-0"),
+			}
+			for _, ctr := range containers {
+				for _, wantNotName := range test.wantNotPodVolumes {
+					if hasMountNamed(ctr.VolumeMounts, wantNotName) {
+						t.Errorf("%s.VolumeMounts = %v, has unwanted mount %q", ctr.Name, ctr.VolumeMounts, wantNotName)
+					}
+				}
+				for wantName, wantPath := range test.wantAdditionalHookMounts {
+					if !hasMountAt(ctr.VolumeMounts, wantName, wantPath) {
+						t.Errorf("%s.VolumeMounts = %v, missing mount %q at %q", ctr.Name, ctr.VolumeMounts, wantName, wantPath)
+					}
+				}
+			}
+		})
+	}
+}
+
 func TestPipelineSigningOptions(t *testing.T) {
 	verificationVol := &corev1.Volume{Name: "verification-key-volume"}
 	signingVol := &corev1.Volume{Name: "signing-key-volume"}
@@ -1698,18 +1838,12 @@ func TestPipelineSigningOptions(t *testing.T) {
 			// Check volumes on the pod
 			podSpec := kjob.Spec.Template.Spec
 			for _, wantName := range test.wantPodVolumes {
-				volNameEql := func(v corev1.Volume) bool {
-					return v.Name == wantName
-				}
-				if !slices.ContainsFunc(podSpec.Volumes, volNameEql) {
+				if !hasVolumeNamed(podSpec.Volumes, wantName) {
 					t.Errorf("podSpec.Volumes = %v, is missing volume named %q", podSpec.Volumes, wantName)
 				}
 			}
 			for _, wantNotName := range test.wantNotPodVolumes {
-				volNameEql := func(v corev1.Volume) bool {
-					return v.Name == wantNotName
-				}
-				if slices.ContainsFunc(podSpec.Volumes, volNameEql) {
+				if hasVolumeNamed(podSpec.Volumes, wantNotName) {
 					t.Errorf("podSpec.Volumes = %v, has unwanted volume named %q", podSpec.Volumes, wantNotName)
 				}
 			}
@@ -1736,10 +1870,7 @@ func TestPipelineSigningOptions(t *testing.T) {
 
 			// Check agent container mounts
 			for _, wantName := range test.wantAgentMounts {
-				mountNameEql := func(v corev1.VolumeMount) bool {
-					return v.Name == wantName
-				}
-				if !slices.ContainsFunc(agent.VolumeMounts, mountNameEql) {
+				if !hasMountNamed(agent.VolumeMounts, wantName) {
 					t.Errorf("agent.VolumeMounts = %v, missing volume mount %q", agent.VolumeMounts, wantName)
 				}
 			}
@@ -1747,10 +1878,7 @@ func TestPipelineSigningOptions(t *testing.T) {
 			// Check command container mounts
 			command := findContainer(t, kjob.Spec.Template.Spec.Containers, "container-0")
 			for _, wantName := range test.wantCommandMounts {
-				mountNameEql := func(v corev1.VolumeMount) bool {
-					return v.Name == wantName
-				}
-				if !slices.ContainsFunc(command.VolumeMounts, mountNameEql) {
+				if !hasMountNamed(command.VolumeMounts, wantName) {
 					t.Errorf("command.VolumeMounts = %v, missing volume mount %q", command.VolumeMounts, wantName)
 				}
 			}
@@ -1781,6 +1909,33 @@ func findEnv(t *testing.T, envs []corev1.EnvVar, name string) *corev1.EnvVar {
 	}
 
 	return nil
+}
+
+func hasVolumeNamed(volumes []corev1.Volume, name string) bool {
+	for _, volume := range volumes {
+		if volume.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func hasMountNamed(mounts []corev1.VolumeMount, name string) bool {
+	for _, mount := range mounts {
+		if mount.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func hasMountAt(mounts []corev1.VolumeMount, name, path string) bool {
+	for _, mount := range mounts {
+		if mount.Name == name && mount.MountPath == path {
+			return true
+		}
+	}
+	return false
 }
 
 func TestBuildSafeToEvictDefault(t *testing.T) {

--- a/internal/integration/fixtures/additional-hooks.yaml
+++ b/internal/integration/fixtures/additional-hooks.yaml
@@ -1,0 +1,5 @@
+agents:
+  queue: "{{.queue}}"
+steps:
+  - label: ":fishing_pole_and_fish: Additional Hooks"
+    command: echo 'Hello from the additional hooks command!'

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -1044,6 +1044,52 @@ func TestHooksAndPlugins(t *testing.T) {
 	}
 }
 
+func TestAdditionalHooks(t *testing.T) {
+	tc := testcase{
+		T:       t,
+		Fixture: "additional-hooks.yaml",
+		Repo:    repoHTTP,
+		GraphQL: api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
+	}.Init()
+	ctx := context.Background()
+	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)
+	cfg := cfg
+	cfg.AgentConfig = &config.AgentConfig{
+		AdditionalHooks: []config.AdditionalHook{
+			{
+				Path: "/buildkite/additional-hooks",
+				Volume: &corev1.Volume{
+					Name: "additional-hooks",
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "integration-tests-fixture-additional-hooks",
+							},
+							DefaultMode: ptr.To[int32](0o755),
+						},
+					},
+				},
+			},
+		},
+	}
+	tc.StartController(ctx, cfg)
+	build := tc.TriggerBuild(ctx, pipelineID)
+	tc.AssertSuccess(ctx, build)
+
+	logs := tc.FetchLogs(build)
+	t.Logf("tc.FetchLogs(build) = %s", logs)
+	for _, hook := range []string{"environment", "pre-checkout", "post-checkout", "pre-command", "post-command"} {
+		want := fmt.Sprintf("Hello from the additional %s hook", hook)
+		if !strings.Contains(logs, want) {
+			t.Errorf("Logs did not contain %q", want)
+		}
+		unwanted := fmt.Sprintf("Hello from the %s hook", hook)
+		if strings.Contains(logs, unwanted) {
+			t.Errorf("Logs contained %q, which should only come from the standard hooks fixture", unwanted)
+		}
+	}
+}
+
 func TestSkipCheckoutContainer(t *testing.T) {
 	tc := testcase{
 		T:       t,


### PR DESCRIPTION

## Change

- Adds first-class `agent-config.additional-hooks-paths` and `agent-config.additional-hooks` config/schema support for image-baked and volume-backed hook directories.
- Mounts additional hook volumes into agent, checkout, and command containers, and sets `BUILDKITE_ADDITIONAL_HOOKS_PATHS` for the agent start container.
- Validates `additional-hooks` entries and updates the example config.
- Adds controller/scheduler unit coverage plus an integration fixture and test for additional lifecycle hooks.

## Context

Linear: [A-1349: [canva] Unable to set BUILDKITE_ADDITIONAL_HOOKS_PATHS on agent](https://linear.app/buildkite/issue/A-1349/canva-unable-to-set-buildkite-additional-hooks-paths-on-agent)

[#3975](https://github.com/buildkite/agent/issues/3975)  reported a regression from agent `v3.127.1` where `BUILDKITE_ADDITIONAL_HOOKS_PATHS` set through a container env var was overwritten with an empty string. This change gives agent-stack-k8s a supported configuration path for additional hooks instead of relying on container-level env overrides.

Buildkite Agent supports `BUILDKITE_ADDITIONAL_HOOKS_PATHS`; this exposes that through agent-stack-k8s config for hook directories already present in images, plus hook directories mounted from Kubernetes volumes.

### Verification

- Tested a locally running controller against local bk/bk with additional hooks from:
  - an image-baked path: `/opt/buildkite/additional-hooks-image`
  - a ConfigMap-mounted path: `/buildkite/additional-hooks/configmap`
  - a Secret-mounted path: `/buildkite/additional-hooks/secret`
- Confirmed the job output ran the image, ConfigMap, and Secret `pre-command` hooks before the repository hook.
- Tested a Helm-deployed controller with `additional-hooks-paths` plus ConfigMap and Secret backed `additional-hooks`; triggered another build and confirmed the hooks ran correctly.
- Applied the new `.buildkite/fixtures/additional-hooks.yaml` fixture to the shared EKS-backed integration cluster.

### Deployment

The new config is opt-in. Existing installs are unchanged unless they set `agent-config.additional-hooks-paths` or `agent-config.additional-hooks`.

### Rollback

Revert this PR. It only adds config fields, volume mounts, env wiring, schema/example updates, and tests; there are no migrations or feature flags. If the CI fixture is no longer needed, remove the `integration-tests-fixture-additional-hooks` ConfigMap from `buildkite-k8s-integration-test`.

## Affiliation (optional, external contributors)

N/A

## Disclosures / Credits

Drafted with Codex.
