### PR TITLE
chore: bump agent to v3.129.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.0
 require (
 	github.com/Khan/genqlient v0.8.1
 	github.com/alecthomas/kong v1.15.0
-	github.com/buildkite/agent/v3 v3.128.0
+	github.com/buildkite/agent/v3 v3.129.0
 	github.com/buildkite/go-buildkite/v3 v3.13.0
 	github.com/buildkite/roko v1.4.0
 	github.com/buildkite/stacksapi v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -158,8 +158,8 @@ github.com/bradleyjkemp/cupaloy/v2 v2.6.0 h1:knToPYa2xtfg42U3I6punFEjaGFKWQRXJwj
 github.com/bradleyjkemp/cupaloy/v2 v2.6.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
 github.com/brunoscheufler/aws-ecs-metadata-go v0.0.0-20221221133751-67e37ae746cd h1:C0dfBzAdNMqxokqWUysk2KTJSMmqvh9cNW1opdy5+0Q=
 github.com/brunoscheufler/aws-ecs-metadata-go v0.0.0-20221221133751-67e37ae746cd/go.mod h1:CeKhh8xSs3WZAc50xABMxu+FlfAAd5PNumo7NfOv7EE=
-github.com/buildkite/agent/v3 v3.128.0 h1:z6ZjtXzU7no/S1XwTDdHBHzxsHyILEzAuClhrOdf1Vw=
-github.com/buildkite/agent/v3 v3.128.0/go.mod h1:vdR/SLbzWakWhK4wQO7SRW1YrMGQvP+5ARNXgVXw0LE=
+github.com/buildkite/agent/v3 v3.129.0 h1:ohpw+ofP29jtfToBbSfdCH6lR7xDwYRIdn+zX/olVIk=
+github.com/buildkite/agent/v3 v3.129.0/go.mod h1:vdR/SLbzWakWhK4wQO7SRW1YrMGQvP+5ARNXgVXw0LE=
 github.com/buildkite/bintest/v3 v3.3.0 h1:RTWcSaJRlOT6t/K311ejPf+0J3LE/QEODzVG3vlLnWo=
 github.com/buildkite/bintest/v3 v3.3.0/go.mod h1:btqpTsVODiJcb0NMdkkmtMQ6xoFc2W/nY5yy+3I0zcs=
 github.com/buildkite/go-buildkite/v3 v3.13.0 h1:8DxSmai9UND0n81BlKqNyCuLmiUSDroMhXq+BF28e7E=


### PR DESCRIPTION
## Change

Bump the agent version to v3.129.0
<!-- What does this PR change? -->

## Context
Contributes to A-1413
<!-- Why is this change needed? Link to relevant issues or discussions. -->

## Affiliation (optional, external contributors)

<!--
If you're contributing from outside Buildkite and are comfortable sharing, let us know your company or organisation — it helps us prioritise review and may accelerate a response.
-->

## Disclosures / Credits

<!-- Disclose any AI assistance, prior art, or contributors who deserve credit. -->
