### PR TITLE
fix(build): use name flag for cache commands

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -28,9 +28,9 @@ steps:
     image: public.ecr.aws/docker/library/golang:1.26.4-alpine@sha256:f1ddd9fe14fffc091dd98cb4bfa999f32c5fc77d2f2305ea9f0e2595c5437c14
     command:
       - . .buildkite/steps/assume-role.sh
-      - buildkite-agent cache restore --names go_mod
+      - buildkite-agent cache restore --name go_mod
       - .buildkite/steps/tidy.sh
-      - buildkite-agent cache save --names go_mod
+      - buildkite-agent cache save --name go_mod
 
   - label: ":go::lint-roller: lint"
     key: lint
@@ -49,9 +49,9 @@ steps:
     image: public.ecr.aws/docker/library/golang:1.26.4-alpine@sha256:f1ddd9fe14fffc091dd98cb4bfa999f32c5fc77d2f2305ea9f0e2595c5437c14
     command:
       - . .buildkite/steps/assume-role.sh
-      - buildkite-agent cache restore --names go_mod --names go_build
+      - buildkite-agent cache restore --name go_mod --name go_build
       - .buildkite/steps/check-code-generation.sh
-      - buildkite-agent cache save --names go_mod --names go_build
+      - buildkite-agent cache save --name go_mod --name go_build
 
 
   - label: ":helm: lint chart"
@@ -75,9 +75,9 @@ steps:
     image: public.ecr.aws/docker/library/golang:1.26.4@sha256:792443b89f65105abba56b9bd5e97f680a80074ac62fc844a584212f8c8102c3
     command:
       - . .buildkite/steps/assume-role.sh
-      - buildkite-agent cache restore --names go_mod --names go_build
+      - buildkite-agent cache restore --name go_mod --name go_build
       - .buildkite/steps/tests.sh
-      - buildkite-agent cache save --names go_mod --names go_build
+      - buildkite-agent cache save --name go_mod --name go_build
     plugins:
       - kubernetes:
           podSpecPatch:
@@ -97,9 +97,9 @@ steps:
     image: public.ecr.aws/docker/library/golang:1.26.4@sha256:792443b89f65105abba56b9bd5e97f680a80074ac62fc844a584212f8c8102c3
     command:
       - . .buildkite/steps/assume-role.sh
-      - buildkite-agent cache restore --names go_mod --names go_build
+      - buildkite-agent cache restore --name go_mod --name go_build
       - .buildkite/steps/build-and-push-controller.sh
-      - buildkite-agent cache save --names go_mod --names go_build
+      - buildkite-agent cache save --name go_mod --name go_build
 
   # On feature branches, don't wait for tests. We may want to deploy
   # to a test cluster to debug the feature branch.
@@ -160,9 +160,9 @@ steps:
     image: public.ecr.aws/docker/library/golang:1.26.4-alpine@sha256:f1ddd9fe14fffc091dd98cb4bfa999f32c5fc77d2f2305ea9f0e2595c5437c14 # Note goreleaser shells out to go!
     command:
       - . .buildkite/steps/assume-role.sh
-      - buildkite-agent cache restore --names go_mod --names go_build
+      - buildkite-agent cache restore --name go_mod --name go_build
       - .buildkite/steps/release.sh
-      - buildkite-agent cache save --names go_mod --names go_build
+      - buildkite-agent cache save --name go_mod --name go_build
     plugins:
       - kubernetes:
           checkout:


### PR DESCRIPTION
## Change

<!-- What does this PR change? -->
Fixes usage of cache cli command flag `--name`

## Context

Contributes to A-1413
<!-- Why is this change needed? Link to relevant issues or discussions. -->

## Affiliation (optional, external contributors)

<!--
If you're contributing from outside Buildkite and are comfortable sharing, let us know your company or organisation — it helps us prioritise review and may accelerate a response.
-->

## Disclosures / Credits

<!-- Disclose any AI assistance, prior art, or contributors who deserve credit. -->
