### PR TITLE
use go.mod for cache keys

### DIFF
--- a/.buildkite/cache.yml
+++ b/.buildkite/cache.yml
@@ -3,14 +3,14 @@ caches:
     cache_key:
       - agent: os
       - {agent: arch, fallbackLimit: true}
-      - checksum: go.sum
+      - checksum: go.mod
     target_paths:
       - /root/.cache/go-build
   - name: go_mod
     cache_key:
       - agent: os
       - {agent: arch, fallbackLimit: true}
-      - checksum: go.sum
+      - checksum: go.mod
     target_paths:
       - /root/.cache/go-mod
   - name: golangci_lint


### PR DESCRIPTION
## Change

Use go.mod for cache key.
<!-- What does this PR change? -->

## Context

https://github.com/buildkite/agent-stack-k8s/pull/899#discussion_r3457516130

<!-- Why is this change needed? Link to relevant issues or discussions. -->

## Affiliation (optional, external contributors)

<!--
If you're contributing from outside Buildkite and are comfortable sharing, let us know your company or organisation — it helps us prioritise review and may accelerate a response.
-->

## Disclosures / Credits

<!-- Disclose any AI assistance, prior art, or contributors who deserve credit. -->
