### PR TITLE
Surface ImagePullBackOff as a notification when agent owns the job

### DIFF
--- a/internal/controller/scheduler/pod_watcher.go
+++ b/internal/controller/scheduler/pod_watcher.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"slices"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -49,6 +50,13 @@ type podWatcher struct {
 	// ErrImageNeverPull, etc)
 	watchingForImageFailureMu sync.Mutex
 	watchingForImageFailure   map[uuid.UUID]*corev1.Pod
+
+	// Jobs we've already sent an image-pull-failure stack notification for.
+	// When an agent already owns the job we can't fail it ourselves, so we
+	// surface the reason as a notification instead - but only once, to avoid
+	// repeating it on every informer re-sync while the agent times out.
+	imageFailureNotifiedMu sync.Mutex
+	imageFailureNotified   map[uuid.UUID]struct{}
 
 	// Pods being watched for exceeding the pending timeout
 	watchingForPendingTimeoutMu sync.Mutex
@@ -105,6 +113,7 @@ func NewPodWatcher(logger *slog.Logger, k8s kubernetes.Interface, agentClient *a
 		podPendingTimeout:           podPendingTimeout,
 		ignoredJobs:                 make(map[uuid.UUID]struct{}),
 		watchingForImageFailure:     make(map[uuid.UUID]*corev1.Pod),
+		imageFailureNotified:        make(map[uuid.UUID]struct{}),
 		watchingForPendingTimeout:   make(map[uuid.UUID]*corev1.Pod),
 	}
 	pw.batchBkJobChecker = NewBatchBuildkiteJobChecker(logger, agentClient, k8s, jobCancelCheckerInterval)
@@ -456,6 +465,27 @@ func (w *podWatcher) formatImagePullFailureMessage(statuses []corev1.ContainerSt
 	return "The following containers could not be created or their images could not be pulled:\n\n" + tw.Render()
 }
 
+// formatImagePullFailureNotification produces a compact, single-line summary of
+// image pull failures for a stack notification. Notifications have a small
+// length limit (the full table goes to the job log via FailJob instead), so
+// this keeps to "container: Reason (message)" per failing container.
+func formatImagePullFailureNotification(statuses []corev1.ContainerStatus) string {
+	slices.SortFunc(statuses, func(a, b corev1.ContainerStatus) int {
+		return cmp.Compare(a.Name, b.Name)
+	})
+
+	parts := make([]string, 0, len(statuses))
+	for _, status := range statuses {
+		waiting := status.State.Waiting
+		part := fmt.Sprintf("%s: %s", status.Name, waiting.Reason)
+		if waiting.Message != "" {
+			part += " (" + waiting.Message + ")"
+		}
+		parts = append(parts, part)
+	}
+	return "Image pull failure; the job will fail once the agent times out. " + strings.Join(parts, "; ")
+}
+
 func (w *podWatcher) stopCheckingBuildkiteJob(jobUUID uuid.UUID) {
 	w.batchBkJobChecker.StopCheckingJob(jobUUID)
 }
@@ -736,8 +766,16 @@ func (w *podWatcher) failForImageFailure(ctx context.Context, log *slog.Logger, 
 		w.ignoreJob(jobUUID)
 
 	case api.JobStateAccepted, api.JobStateAssigned, api.JobStateRunning:
-		// An agent is already doing something with the job. Let it fail.
-		log.Debug("Job is the responsibility of an agent")
+		// An agent is already doing something with the job, so we let it fail
+		// rather than acquiring it ourselves. But the agent can't see why a
+		// sibling container won't start - it only reports a generic
+		// container-start timeout. Surface the image pull failure as a stack
+		// notification so the reason shows up in the build UI. Send it once
+		// per job to avoid repeating on every re-sync.
+		log.Debug("Job is the responsibility of an agent; surfacing image pull failure as a notification")
+		if w.markImageFailureNotified(jobUUID) {
+			w.agentClient.CreateStackNotification(ctx, jobUUID.String(), formatImagePullFailureNotification(statuses))
+		}
 
 	case api.JobStateCanceling, api.JobStateCanceled, api.JobStateFinished, api.JobStateSkipped:
 		// If the job is in one of these states, we can neither acquire nor
@@ -781,8 +819,27 @@ func (w *podWatcher) watchForImageFailure(jobUUID uuid.UUID, pod *corev1.Pod) {
 
 func (w *podWatcher) stopWatchingForImageFailure(jobUUID uuid.UUID) {
 	w.watchingForImageFailureMu.Lock()
-	defer w.watchingForImageFailureMu.Unlock()
 	delete(w.watchingForImageFailure, jobUUID)
+	w.watchingForImageFailureMu.Unlock()
+
+	// Once we stop watching (pod gone or terminal), forget that we notified so
+	// a retried pod for the same job can notify again.
+	w.imageFailureNotifiedMu.Lock()
+	delete(w.imageFailureNotified, jobUUID)
+	w.imageFailureNotifiedMu.Unlock()
+}
+
+// markImageFailureNotified records that an image-failure notification has been
+// sent for the job. It returns true the first time (caller should send), false
+// on subsequent calls.
+func (w *podWatcher) markImageFailureNotified(jobUUID uuid.UUID) bool {
+	w.imageFailureNotifiedMu.Lock()
+	defer w.imageFailureNotifiedMu.Unlock()
+	if _, done := w.imageFailureNotified[jobUUID]; done {
+		return false
+	}
+	w.imageFailureNotified[jobUUID] = struct{}{}
+	return true
 }
 
 func (w *podWatcher) watchForPendingTimeout(jobUUID uuid.UUID, pod *corev1.Pod) {

--- a/internal/controller/scheduler/pod_watcher_test.go
+++ b/internal/controller/scheduler/pod_watcher_test.go
@@ -160,3 +160,90 @@ func TestIsSidecarInitContainer(t *testing.T) {
 	assert.False(t, isSidecarInitContainer(pod, "imagecheck-0"))
 	assert.False(t, isSidecarInitContainer(pod, "nonexistent"))
 }
+
+func TestFormatImagePullFailureNotification(t *testing.T) {
+	t.Parallel()
+
+	waiting := func(name, reason, message string) corev1.ContainerStatus {
+		return corev1.ContainerStatus{
+			Name: name,
+			State: corev1.ContainerState{
+				Waiting: &corev1.ContainerStateWaiting{Reason: reason, Message: message},
+			},
+		}
+	}
+
+	tests := []struct {
+		name     string
+		statuses []corev1.ContainerStatus
+		want     string
+	}{
+		{
+			name:     "single container with message",
+			statuses: []corev1.ContainerStatus{waiting("container-0", "ImagePullBackOff", `Back-off pulling image "nope:latest"`)},
+			want:     "Image pull failure; the job will fail once the agent times out. container-0: ImagePullBackOff (Back-off pulling image \"nope:latest\")",
+		},
+		{
+			name:     "reason without message",
+			statuses: []corev1.ContainerStatus{waiting("container-0", "ErrImageNeverPull", "")},
+			want:     "Image pull failure; the job will fail once the agent times out. container-0: ErrImageNeverPull",
+		},
+		{
+			name: "multiple containers sorted by name",
+			statuses: []corev1.ContainerStatus{
+				waiting("container-1", "ErrImagePull", "pull failed"),
+				waiting("container-0", "ImagePullBackOff", "backing off"),
+			},
+			want: "Image pull failure; the job will fail once the agent times out. container-0: ImagePullBackOff (backing off); container-1: ErrImagePull (pull failed)",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, formatImagePullFailureNotification(tt.statuses))
+		})
+	}
+}
+
+// TestPodHasFailingImages_RunningPod confirms the detection logic itself works
+// on a Running pod whose command container is in ImagePullBackOff (the scenario
+// in SUP-6708). A failure here would mean Option A's notification can never
+// fire, since failForImageFailure is only reached when this returns non-empty.
+func TestPodHasFailingImages_RunningPod(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	w := &podWatcher{imagePullBackOffGracePeriod: 30 * time.Second}
+
+	newRunningPod := func(startedAgo time.Duration) *corev1.Pod {
+		start := metav1.NewTime(time.Now().Add(-startedAgo))
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+			Status: corev1.PodStatus{
+				Phase:     corev1.PodRunning,
+				StartTime: &start,
+				ContainerStatuses: []corev1.ContainerStatus{{
+					Name: "container-0",
+					State: corev1.ContainerState{
+						Waiting: &corev1.ContainerStateWaiting{
+							Reason:  "ImagePullBackOff",
+							Message: `Back-off pulling image "nope:latest"`,
+						},
+					},
+				}},
+			},
+		}
+	}
+
+	// Within the grace period: not failing yet.
+	got := w.podHasFailingImages(logger, newRunningPod(5*time.Second))
+	assert.Empty(t, got, "should respect grace period")
+
+	// Past the grace period: the command container's ImagePullBackOff is detected.
+	got = w.podHasFailingImages(logger, newRunningPod(time.Minute))
+	require.Len(t, got, 1)
+	assert.Equal(t, "container-0", got[0].Name)
+	assert.Equal(t, "ImagePullBackOff", got[0].State.Waiting.Reason)
+}

--- a/internal/integration/api/generated.go
+++ b/internal/integration/api/generated.go
@@ -1390,6 +1390,8 @@ type GetJobEventsJobJobTypeCommandEventsJobEventConnectionEdgesJobEventEdgeNodeJ
 	Type JobEventType `json:"type"`
 	// The time when the event occurred
 	Timestamp time.Time `json:"timestamp"`
+	// Message from the stack notification
+	Message string `json:"message"`
 }
 
 // GetTypename returns GetJobEventsJobJobTypeCommandEventsJobEventConnectionEdgesJobEventEdgeNodeJobEventStackNotification.Typename, and is useful for accessing the field via an interface.
@@ -1410,6 +1412,11 @@ func (v *GetJobEventsJobJobTypeCommandEventsJobEventConnectionEdgesJobEventEdgeN
 // GetTimestamp returns GetJobEventsJobJobTypeCommandEventsJobEventConnectionEdgesJobEventEdgeNodeJobEventStackNotification.Timestamp, and is useful for accessing the field via an interface.
 func (v *GetJobEventsJobJobTypeCommandEventsJobEventConnectionEdgesJobEventEdgeNodeJobEventStackNotification) GetTimestamp() time.Time {
 	return v.Timestamp
+}
+
+// GetMessage returns GetJobEventsJobJobTypeCommandEventsJobEventConnectionEdgesJobEventEdgeNodeJobEventStackNotification.Message, and is useful for accessing the field via an interface.
+func (v *GetJobEventsJobJobTypeCommandEventsJobEventConnectionEdgesJobEventEdgeNodeJobEventStackNotification) GetMessage() string {
+	return v.Message
 }
 
 // GetJobEventsJobJobTypeCommandEventsJobEventConnectionEdgesJobEventEdgeNodeJobEventTimedOut includes the requested fields of the GraphQL type JobEventTimedOut.
@@ -2217,6 +2224,9 @@ query GetJobEvents ($jobId: ID!) {
 						timestamp
 						... on JobEventStackError {
 							errorDetail
+						}
+						... on JobEventStackNotification {
+							message
 						}
 					}
 				}

--- a/internal/integration/api/genqlient.graphql
+++ b/internal/integration/api/genqlient.graphql
@@ -67,6 +67,9 @@ query GetJobEvents($jobId: ID!) {
             ... on JobEventStackError {
               errorDetail
             }
+            ... on JobEventStackNotification {
+              message
+            }
           }
         }
       }

--- a/internal/integration/fixtures/image-pull-back-off-running.yaml
+++ b/internal/integration/fixtures/image-pull-back-off-running.yaml
@@ -1,0 +1,11 @@
+steps:
+  - label: ":x:"
+    agents:
+      queue: "{{.queue}}"
+    plugins:
+      - kubernetes:
+          podSpec:
+            containers:
+              - image: buildkite/non-existant-image:latest
+                command:
+                  - "true"

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -702,6 +702,50 @@ func TestImagePullBackOffFailed(t *testing.T) {
 	tc.AssertLogsContain(build, "other job has run")
 }
 
+// TestImagePullBackOffRunningSurfacesNotification reproduces SUP-6708: when a
+// command container's image can't be pulled but the failure only manifests
+// after the pod is Running, the controller can't fail the job itself because an
+// agent already owns it. Without surfacing, the build shows only the agent's
+// generic "timed out waiting ... for all containers to connect". The pod
+// watcher instead emits the ImagePullBackOff reason as a stack notification.
+//
+// The Running scenario is forced by skipping the imagecheck preflight, so the
+// bad image isn't caught while the pod is Pending. (When it is caught while
+// Pending, the reason is reported via FailureMessage - see
+// TestImagePullBackOffFailed.)
+func TestImagePullBackOffRunningSurfacesNotification(t *testing.T) {
+	tc := testcase{
+		T:       t,
+		Fixture: "image-pull-back-off-running.yaml",
+		Repo:    repoHTTP,
+		GraphQL: api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
+	}.Init()
+	ctx := context.Background()
+	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)
+
+	containerStartTimeout := 60 * time.Second
+	testCfg := cfg
+	// Skip the imagecheck so the bad image isn't caught while Pending; the
+	// agent acquires the job and the pull fails while the pod is Running.
+	testCfg.SkipImageCheckContainers = true
+	// Detect the image failure well before the agent's container-start timeout,
+	// so the notification is sent while the job is still the agent's.
+	testCfg.ImagePullBackOffGracePeriod = 5 * time.Second
+	testCfg.AgentConfig = &config.AgentConfig{
+		ContainerStartTimeout: &containerStartTimeout,
+	}
+
+	tc.StartController(ctx, testCfg)
+	build := tc.TriggerBuild(ctx, pipelineID)
+	tc.AssertFail(ctx, build)
+
+	jobID := tc.FirstCommandJobID(build)
+	messages := strings.Join(tc.NotificationMessages(jobID), "\n")
+	assert.Regexp(t, regexp.MustCompile("ErrImagePull|ImagePullBackOff"), messages,
+		"expected the image pull failure reason to be surfaced as a stack notification, got: %q", messages)
+	assert.Contains(t, messages, "container-0")
+}
+
 func TestCreateContainerConfigErrorFailed(t *testing.T) {
 	tc := testcase{
 		T:       t,

--- a/internal/integration/testcase_test.go
+++ b/internal/integration/testcase_test.go
@@ -395,6 +395,33 @@ func (t testcase) FailureMessage(jobID string) string {
 	return stackErrorEvents[0]
 }
 
+// NotificationMessages returns the messages from all JobEventStackNotification
+// events for the job. The controller emits these (e.g. when a container's image
+// pull fails while an agent already owns the job) so the reason is visible in
+// the build UI without the controller failing the job itself.
+func (t testcase) NotificationMessages(jobID string) []string {
+	t.Helper()
+
+	time.Sleep(1 * time.Second) // Wait for job events to be available (quicker than logs)
+	jobEvents, err := api.GetJobEvents(t.Context(), t.GraphQL, jobID)
+	if err != nil {
+		t.Fatalf("failed to get job events: %v", err)
+	}
+
+	cj, ok := jobEvents.Job.(*api.GetJobEventsJobJobTypeCommand)
+	if !ok {
+		t.Fatalf("unexpected job type: %T", jobEvents.Job)
+	}
+
+	var messages []string
+	for _, edge := range cj.Events.Edges {
+		if event, ok := edge.Node.(*api.GetJobEventsJobJobTypeCommandEventsJobEventConnectionEdgesJobEventEdgeNodeJobEventStackNotification); ok {
+			messages = append(messages, event.Message)
+		}
+	}
+	return messages
+}
+
 func (t testcase) waitForBuild(ctx context.Context, build api.Build) api.BuildStates {
 	t.Helper()
 


### PR DESCRIPTION
## Change

Surface `ImagePullBackOff` / `ErrImagePull` as a stack notification when an agent already owns the job.

Previously, when a command container's image pull failed only after the pod reached `Running`, the pod watcher saw that an agent had already acquired the job and deferred to it (`failForImageFailure` logged "Job is the responsibility of an agent" and did nothing). The agent has no visibility into why a sibling container won't start, so the build surfaced only a generic "timed out waiting for all containers to connect" and the real reason was reachable only via `kubectl describe pod`.

In that branch the watcher now calls `CreateStackNotification` with a compact, single-line summary of the failing containers (`container: Reason (message)`), so the actual pull failure shows up in the build UI. The notification is sent once per job, guarded by a new `imageFailureNotified` set, to avoid repeating it on every informer re-sync while the agent times out. The entry is cleared when the watcher stops watching the job (pod gone or terminal) so a retried pod can notify again. The existing detailed-table path via `FailJob` is unchanged for the `Scheduled`/`Reserved` states where the controller can still fail the job itself.

Specifics:
- `formatImagePullFailureNotification` builds the compact summary, sorted by container name, kept short to fit the notification length limit (the full table still goes to the job log via `FailJob`).
- `markImageFailureNotified` returns true only on the first call per job.
- GraphQL `GetJobEvents` query now selects `message` on `JobEventStackNotification` so the integration test can read it back.

Tests:
- Integration test `TestImagePullBackOffRunningSurfacesNotification` reproduces the `Running` scenario by setting `SkipImageCheckContainers` (so the bad image isn't caught while `Pending`) with a short `ImagePullBackOffGracePeriod` and a longer agent `ContainerStartTimeout`, then asserts the notification carries the pull-failure reason. Adds the `image-pull-back-off-running.yaml` fixture and a `NotificationMessages` test helper.
- Unit test `TestFormatImagePullFailureNotification` covers single/no-message/multi-container formatting.
- Unit test `TestPodHasFailingImages_RunningPod` confirms detection fires on a `Running` pod past the grace period (and respects it within), since the notification can only fire when this returns non-empty.

## Context

Fixes SUP-6708, where a customer experienced `ImagePullBackOff` on a command container that only failed after the pod was `Running`. The customer's build gave them no indication of the cause, only the agent's generic container-start timeout. This makes the controller surface the reason in the build UI in the one case where it can't fail the job itself because an agent already owns it.

## Disclosures / Credits

Drafted with AI assistance (Claude Code, Opus 4.8).