### PR TITLE
job_watcher: serve diagnostic event LIST from watch cache

### DIFF
--- a/internal/controller/scheduler/job_watcher.go
+++ b/internal/controller/scheduler/job_watcher.go
@@ -253,6 +253,10 @@ func (w *jobWatcher) fetchEvents(ctx context.Context, log *slog.Logger, kjob *ba
 	// diagnosing the problem.
 	events := w.k8s.CoreV1().Events(w.cfg.Namespace)
 	evlist, err := events.List(ctx, metav1.ListOptions{
+		// These events are only used for diagnostic messages, so serve the
+		// read from the API server's watch cache (ResourceVersion "0")
+		// instead of forcing a quorum read from etcd.
+		ResourceVersion: "0",
 		FieldSelector: fields.AndSelectors(
 			fields.OneTermEqualSelector("involvedObject.kind", "Job"),
 			fields.OneTermEqualSelector("involvedObject.name", kjob.Name),


### PR DESCRIPTION
## Change
`fetchEvents()` in `job_watcher.go` now lists Kubernetes Events with `ResourceVersion: "0"`, so the read is served from the API server's in-memory watch cache instead of a quorum read from etcd. 

## Context

One of our customers reported that fetchEvents() in job_watcher.go is causing API server latency spikes on busy clusters. The function LISTs Kubernetes events using the default quorum read (hitting etcd), but these events are only used for diagnostic failure messages. Adding ResourceVersion: "0" to the ListOptions would serve these reads from the API server's in-memory watch cache instead, eliminating the etcd round-trip and reducing cluster-wide contention.