### PR TITLE
A-1673: Fix stale CI caches by keying them per branch and commit

### DIFF
--- a/.buildkite/cache.yml
+++ b/.buildkite/cache.yml
@@ -3,7 +3,9 @@ caches:
     cache_key:
       - agent: os
       - {agent: arch, fallback_limit: true}
-      - checksum: go.mod
+      - env: BUILDKITE_STEP_KEY
+      - env: BUILDKITE_BRANCH
+      - env: BUILDKITE_COMMIT
     target_paths:
       - /root/.cache/go-build
   - name: go_mod
@@ -17,6 +19,7 @@ caches:
     cache_key:
       - agent: os
       - {agent: arch, fallback_limit: true}
-      - checksum: .golangci.yaml
+      - env: BUILDKITE_BRANCH
+      - env: BUILDKITE_COMMIT
     target_paths:
       - /root/.cache/golangci-lint

--- a/.buildkite/cache.yml
+++ b/.buildkite/cache.yml
@@ -3,6 +3,7 @@ caches:
     cache_key:
       - agent: os
       - {agent: arch, fallbackLimit: true}
+      - env: BUILDKITE_STEP_KEY
       - env: BUILDKITE_BRANCH
       - env: BUILDKITE_COMMIT
     target_paths:

--- a/.buildkite/cache.yml
+++ b/.buildkite/cache.yml
@@ -3,7 +3,8 @@ caches:
     cache_key:
       - agent: os
       - {agent: arch, fallbackLimit: true}
-      - checksum: go.mod
+      - env: BUILDKITE_BRANCH
+      - env: BUILDKITE_COMMIT
     target_paths:
       - /root/.cache/go-build
   - name: go_mod
@@ -17,6 +18,7 @@ caches:
     cache_key:
       - agent: os
       - {agent: arch, fallbackLimit: true}
-      - checksum: .golangci.yaml
+      - env: BUILDKITE_BRANCH
+      - env: BUILDKITE_COMMIT
     target_paths:
       - /root/.cache/golangci-lint

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -29,6 +29,7 @@ steps:
     command:
       - . .buildkite/steps/assume-role.sh
       - buildkite-agent cache restore --name go_mod
+      - 'echo "--- :broom: Tidy"'
       - .buildkite/steps/tidy.sh
       - buildkite-agent cache save --name go_mod
 
@@ -39,6 +40,7 @@ steps:
     command:
       - . .buildkite/steps/assume-role.sh
       - buildkite-agent cache restore
+      - 'echo "--- :lint-roller: Lint"'
       - golangci-lint run -v ./...
       - buildkite-agent cache save
 
@@ -50,6 +52,7 @@ steps:
     command:
       - . .buildkite/steps/assume-role.sh
       - buildkite-agent cache restore --name go_mod --name go_build
+      - 'echo "--- :robot_face: Check code generation"'
       - .buildkite/steps/check-code-generation.sh
       - buildkite-agent cache save --name go_mod --name go_build
 
@@ -76,6 +79,7 @@ steps:
     command:
       - . .buildkite/steps/assume-role.sh
       - buildkite-agent cache restore --name go_mod --name go_build
+      - 'echo "--- :test_tube: Tests"'
       - .buildkite/steps/tests.sh
       - buildkite-agent cache save --name go_mod --name go_build
     plugins:
@@ -98,6 +102,7 @@ steps:
     command:
       - . .buildkite/steps/assume-role.sh
       - buildkite-agent cache restore --name go_mod --name go_build
+      - 'echo "--- :docker: Build and push controller image"'
       - .buildkite/steps/build-and-push-controller.sh
       - buildkite-agent cache save --name go_mod --name go_build
 
@@ -161,6 +166,7 @@ steps:
     command:
       - . .buildkite/steps/assume-role.sh
       - buildkite-agent cache restore --name go_mod --name go_build
+      - 'echo "--- :rocket: Release"'
       - .buildkite/steps/release.sh
       - buildkite-agent cache save --name go_mod --name go_build
     plugins:

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -29,6 +29,7 @@ steps:
     command:
       - . .buildkite/steps/assume-role.sh
       - buildkite-agent cache restore --name go_mod
+      - 'echo "--- :broom: Tidy"'
       - .buildkite/steps/tidy.sh
       - buildkite-agent cache save --name go_mod
 
@@ -39,6 +40,7 @@ steps:
     command:
       - . .buildkite/steps/assume-role.sh
       - buildkite-agent cache restore
+      - 'echo "--- :lint-roller: Lint"'
       - golangci-lint run -v ./...
       - go tool assertzapper ./...
       - buildkite-agent cache save
@@ -50,6 +52,7 @@ steps:
     command:
       - . .buildkite/steps/assume-role.sh
       - buildkite-agent cache restore --name go_mod --name go_build
+      - 'echo "--- :robot_face: Check code generation"'
       - .buildkite/steps/check-code-generation.sh
       - buildkite-agent cache save --name go_mod --name go_build
 
@@ -75,6 +78,7 @@ steps:
     command:
       - . .buildkite/steps/assume-role.sh
       - buildkite-agent cache restore --name go_mod --name go_build
+      - 'echo "--- :test_tube: Tests"'
       - .buildkite/steps/tests.sh
       - buildkite-agent cache save --name go_mod --name go_build
     plugins:
@@ -97,6 +101,7 @@ steps:
     command:
       - . .buildkite/steps/assume-role.sh
       - buildkite-agent cache restore --name go_mod --name go_build
+      - 'echo "--- :docker: Build and push controller image"'
       - .buildkite/steps/build-and-push-controller.sh
       - buildkite-agent cache save --name go_mod --name go_build
 
@@ -160,6 +165,7 @@ steps:
     command:
       - . .buildkite/steps/assume-role.sh
       - buildkite-agent cache restore --name go_mod --name go_build
+      - 'echo "--- :rocket: Release"'
       - .buildkite/steps/release.sh
       - buildkite-agent cache save --name go_mod --name go_build
     plugins:


### PR DESCRIPTION
## Problem

The `go_build` and `golangci_lint` caches were keyed on checksums of `go.mod` and `.golangci.yaml`. Since `cache save` never overwrites an existing entry, each cache was saved once and then never updated. As the code changed the caches went stale, hits dropped to near zero, and every build still paid the restore and save overhead.

## Fix

Key the evolving caches on `BUILDKITE_BRANCH` + `BUILDKITE_COMMIT`. Every commit saves a fresh entry, and restores fall back in order:

1. same commit
2. latest entry from the same branch
3. latest entry from any branch
4. anything with the same os/arch

`go_build` also gets `BUILDKITE_STEP_KEY` in its key. Each step builds a different Go cache (lint compiles under golangci-lint's toolchain, tests add test binaries and results, the controller build cross compiles). With a shared key, whichever step saved first claimed the commit's entry and the rest skipped saving. With the step key, each step keeps its own cache warm.

Both caches validate their own contents, so a stale restore only means some recompilation, never wrong results.

`go_mod` stays checksum keyed: the module cache is fully determined by the dependency graph, so it only needs to change when `go.mod` does.

## Also

`cache restore` opens a log group without closing it, which swallows the output that follows. Add an explicit log group heading after each restore.
