### PR TITLE
Report signal_reason when failing jobs via the Stacks API

### DIFF
--- a/api/agent_client.go
+++ b/api/agent_client.go
@@ -333,12 +333,16 @@ func (c *AgentClient) DeregisterStack(ctx context.Context) error {
 	return err
 }
 
-func (c *AgentClient) FailJob(ctx context.Context, jobUUID string, errorDetail string) error {
+// FailJob marks the job as finished with exit status -1, recording
+// errorDetail in the job log and signalReason (e.g. "stack_error") as the
+// job's machine-readable signal reason.
+func (c *AgentClient) FailJob(ctx context.Context, jobUUID string, errorDetail string, signalReason string) error {
 	req := stacksapi.FinishJobRequest{
-		StackKey:   c.stack.Key,
-		JobUUID:    jobUUID,
-		ExitStatus: -1,
-		Detail:     errorDetail,
+		StackKey:     c.stack.Key,
+		JobUUID:      jobUUID,
+		ExitStatus:   -1,
+		Detail:       errorDetail,
+		SignalReason: signalReason,
 	}
 
 	_, err := c.stacksAPIClient.FinishJob(ctx, req)

--- a/internal/controller/scheduler/fail_job.go
+++ b/internal/controller/scheduler/fail_job.go
@@ -26,7 +26,6 @@ func failForK8sObject(ctx context.Context, logger *slog.Logger, obj metav1.Objec
 		"name", obj.GetName(),
 	)
 
-	// Matching tags are required order to connect the temporary agent.
 	labels := obj.GetLabels()
 	jobUUID := labels[config.UUIDLabel]
 	if jobUUID == "" {
@@ -34,5 +33,5 @@ func failForK8sObject(ctx context.Context, logger *slog.Logger, obj metav1.Objec
 		return errors.New("missing UUID label")
 	}
 
-	return agentClient.FailJob(ctx, jobUUID, failureInfo.Message)
+	return agentClient.FailJob(ctx, jobUUID, failureInfo.Message, failureInfo.Reason)
 }

--- a/internal/controller/scheduler/pod_watcher.go
+++ b/internal/controller/scheduler/pod_watcher.go
@@ -736,7 +736,10 @@ func (w *podWatcher) failForImageFailure(ctx context.Context, log *slog.Logger, 
 		message := w.formatImagePullFailureMessage(statuses)
 		failureInfo := FailureInfo{
 			Message: message,
-			// Do we have a better status code to report here?
+			// Image-pull failures are infrastructure provisioning failures,
+			// so report them with the same signal reason as other stack
+			// errors.
+			Reason: agent.SignalReasonStackError,
 		}
 		if err := failForK8sObject(ctx, log, pod, failureInfo, w.agentClient); err != nil {
 			podWatcherBuildkiteJobFailErrorsCounter.Inc()

--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -1173,7 +1173,7 @@ func (w *worker) failJob(ctx context.Context, inputs buildInputs, message string
 		Reason: agent.SignalReasonStackError,
 	}
 
-	if err := w.agentClient.FailJob(ctx, inputs.uuid, failureInfo.Message); err != nil {
+	if err := w.agentClient.FailJob(ctx, inputs.uuid, failureInfo.Message, failureInfo.Reason); err != nil {
 		w.logger.Error("failed to fail the job via Buildkite Stack API", "error", err)
 		schedulerBuildkiteJobFailErrorsCounter.Inc()
 		return err


### PR DESCRIPTION
## Problem

When the controller fails a Buildkite job for infrastructure reasons — pod pending timeout, init container failure, podSpec rejection, image-pull failure — the job lands in Buildkite as a bare `failed` / `exit_status: -1` with **no `signal_reason`**.

Every failure site already constructs `FailureInfo{Reason: agent.SignalReasonStackError}`, but `failForK8sObject` only forwards `failureInfo.Message`, and `stacksapi.FinishJobRequest` has no field to carry a reason — so `FailureInfo.Reason` is currently dead code.

This appears to be a regression from the temporary-agent era (a leftover comment in `fail_job.go` still referenced connecting "the temporary agent"): an agent finishing a job could report `signal_reason: stack_error`, which is why the [retry docs](https://buildkite.com/docs/pipelines/configure/retry) document matching on it and the v0.29.0 release notes advertise it for stack-level visibility. The Stacks API finish path lost it.

## Impact

- `retry: automatic: [{signal_reason: stack_error}]` — the documented way to auto-retry infra failures — can't match jobs failed by this controller.
- Observability: stack-failed jobs are indistinguishable from ordinary agent-lost jobs (`exit -1`) in the REST API, webhooks, EventBridge, and OpenTelemetry notification payloads, except by parsing free-text detail. (We found this while trying to build an infra-failure metric for our CI: jobs killed by pod-scheduling failures had no machine-readable marker at all.)

## Change

- Plumb `FailureInfo.Reason` through `failForK8sObject` → `AgentClient.FailJob` → `FinishJobRequest.SignalReason`.
- Set `SignalReasonStackError` on the image-pull-failure path, which previously sent no reason (it carried a `// Do we have a better status code to report here?` comment).
- Remove the stale temporary-agent comment.

## Dependencies

Depends on buildkite/stacksapi#7 adding `SignalReason` to `FinishJobRequest` — and on the `/stacks/.../finish` endpoint accepting the parameter server-side. If the server already supports it, only these client changes are needed; if not, please treat the pair of PRs as the feature request. The go.mod bump is intentionally omitted until stacksapi tags a release containing #7.

## Testing

`go build ./...` and `go test ./internal/controller/scheduler/...` pass with a local `replace` pointing at the stacksapi branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
