### PR TITLE
Dogfood agent v4

### DIFF
--- a/.buildkite/steps/deploy.sh
+++ b/.buildkite/steps/deploy.sh
@@ -20,4 +20,8 @@ helm upgrade agent-stack-k8s "${helm_repo_pecr}/agent-stack-k8s" \
   --wait \
   -f .buildkite/production-helm-values.yaml \
   --set agentToken="${DEFAULT_CLUSTER_TOKEN}" \
-  --set config.image="${agent_image}"
+  --set config.image=buildkite/agent:beta
+
+# Note: using :beta to test v4 with agent-stack-k8s prior to v4 hitting stable.
+# In case of problems with v4 or the beta image, set this back to use:
+#  --set config.image="${agent_image}"


### PR DESCRIPTION
## Change

When the pipeline redeploys the stack to itself (the stack running the pipeline that builds the stack 🥴 ), use `buildkite/agent:beta` for the agent image, so that subsequent builds will use agent v4.

Note that this does **not** change the default image for the next release - that will still be v3.

## Context

To gain more confidence that agent v4 won't break stuff.

https://linear.app/buildkite/issue/A-1543/use-v4-in-agent-stack-k8s-pipeline