### PR TITLE
A-1565: Add a guard to prevent false positive in stalled job detection

### DIFF
--- a/api/fake_agent_server.go
+++ b/api/fake_agent_server.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 
 	"github.com/buildkite/stacksapi"
@@ -37,19 +38,51 @@ type FakeAgentServer struct {
 
 	// NotificationCalls records all notification batches sent to the server.
 	NotificationCalls [][]stacksapi.StackNotification
+
+	// JobStates maps job UUIDs to their state strings for GetJobStates.
+	JobStates map[string]string
+
+	// GetJobStateCalls records the job UUIDs from each GetJobStates call.
+	GetJobStateCalls [][]string
+
+	// GetJobStatesStatusCode configures the HTTP status code for GetJobStates.
+	// Default is 200.
+	GetJobStatesStatusCode int
+
+	// GetJobStatesError configures an error message to return for GetJobStates.
+	GetJobStatesError string
+
+	// FinishJobCalls records the job UUIDs from each FinishJob call.
+	FinishJobCalls []string
+
+	// FinishJobStatusCode configures the HTTP status code for FinishJob.
+	// Default is 200.
+	FinishJobStatusCode int
+
+	// OnFinishJob is an optional callback invoked after recording a FinishJob
+	// call but before sending the response. Useful for simulating state changes
+	// that happen between API calls (e.g., an agent acquiring a job).
+	OnFinishJob func(jobUUID string)
+
+	// FinishJobError configures an error message to return for FinishJob.
+	FinishJobError string
 }
 
 // NewFakeAgentServer creates and starts a fake agent API server.
 // Use server.URL() to get the endpoint for creating a real AgentClient.
 func NewFakeAgentServer() *FakeAgentServer {
 	fake := &FakeAgentServer{
-		ReserveStatusCode: http.StatusOK,
+		ReserveStatusCode:      http.StatusOK,
+		GetJobStatesStatusCode: http.StatusOK,
+		FinishJobStatusCode:    http.StatusOK,
 	}
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/stacks/register", fake.handleRegisterStack)
 	mux.HandleFunc("/stacks/test-stack/scheduled-jobs/batch-reserve", fake.handleReserveJobs)
 	mux.HandleFunc("/stacks/test-stack/notifications", fake.handleNotifications)
+	mux.HandleFunc("/stacks/test-stack/jobs/get-states", fake.handleGetJobStates)
+	mux.HandleFunc("/stacks/test-stack/jobs/", fake.handleFinishJob)
 
 	fake.server = httptest.NewServer(mux)
 	return fake
@@ -152,6 +185,112 @@ func (f *FakeAgentServer) handleReserveJobs(w http.ResponseWriter, r *http.Reque
 	w.WriteHeader(f.ReserveStatusCode)
 	if _, err := w.Write(buf.Bytes()); err != nil {
 		log.Printf("fake: failed to write reserve jobs response: %v", err)
+	}
+}
+
+func (f *FakeAgentServer) handleGetJobStates(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req struct {
+		StackKey string   `json:"stack_key"`
+		JobUUIDs []string `json:"job_uuids"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	f.mu.Lock()
+	f.GetJobStateCalls = append(f.GetJobStateCalls, req.JobUUIDs)
+
+	if f.GetJobStatesError != "" {
+		f.mu.Unlock()
+		var buf bytes.Buffer
+		if err := json.NewEncoder(&buf).Encode(map[string]string{
+			"message": f.GetJobStatesError,
+		}); err != nil {
+			http.Error(w, "fake: failed to encode error response: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(f.GetJobStatesStatusCode)
+		if _, err := w.Write(buf.Bytes()); err != nil {
+			log.Printf("fake: failed to write get job states error response: %v", err)
+		}
+		return
+	}
+
+	states := make(map[string]string)
+	for _, id := range req.JobUUIDs {
+		if s, ok := f.JobStates[id]; ok {
+			states[id] = s
+		}
+	}
+	f.mu.Unlock()
+
+	resp := struct {
+		States map[string]string `json:"states"`
+	}{States: states}
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(resp); err != nil {
+		http.Error(w, "fake: failed to encode response: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(f.GetJobStatesStatusCode)
+	if _, err := w.Write(buf.Bytes()); err != nil {
+		log.Printf("fake: failed to write get job states response: %v", err)
+	}
+}
+
+func (f *FakeAgentServer) handleFinishJob(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Path: /stacks/test-stack/jobs/{uuid}/finish
+	path := r.URL.Path
+	const prefix = "/stacks/test-stack/jobs/"
+	const suffix = "/finish"
+	if !strings.HasPrefix(path, prefix) || !strings.HasSuffix(path, suffix) {
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
+	jobUUID := path[len(prefix) : len(path)-len(suffix)]
+
+	f.mu.Lock()
+	f.FinishJobCalls = append(f.FinishJobCalls, jobUUID)
+	if f.OnFinishJob != nil {
+		f.OnFinishJob(jobUUID)
+	}
+	f.mu.Unlock()
+
+	if f.FinishJobError != "" {
+		var buf bytes.Buffer
+		if err := json.NewEncoder(&buf).Encode(map[string]string{
+			"message": f.FinishJobError,
+		}); err != nil {
+			http.Error(w, "fake: failed to encode error response: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(f.FinishJobStatusCode)
+		if _, err := w.Write(buf.Bytes()); err != nil {
+			log.Printf("fake: failed to write finish job error response: %v", err)
+		}
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(f.FinishJobStatusCode)
+	if _, err := w.Write([]byte("{}\n")); err != nil {
+		log.Printf("fake: failed to write finish job response: %v", err)
 	}
 }
 

--- a/api/fake_agent_server.go
+++ b/api/fake_agent_server.go
@@ -42,9 +42,6 @@ type FakeAgentServer struct {
 	// JobStates maps job UUIDs to their state strings for GetJobStates.
 	JobStates map[string]string
 
-	// GetJobStateCalls records the job UUIDs from each GetJobStates call.
-	GetJobStateCalls [][]string
-
 	// GetJobStatesStatusCode configures the HTTP status code for GetJobStates.
 	// Default is 200.
 	GetJobStatesStatusCode int
@@ -58,11 +55,6 @@ type FakeAgentServer struct {
 	// FinishJobStatusCode configures the HTTP status code for FinishJob.
 	// Default is 200.
 	FinishJobStatusCode int
-
-	// OnFinishJob is an optional callback invoked after recording a FinishJob
-	// call but before sending the response. Useful for simulating state changes
-	// that happen between API calls (e.g., an agent acquiring a job).
-	OnFinishJob func(jobUUID string)
 
 	// FinishJobError configures an error message to return for FinishJob.
 	FinishJobError string
@@ -99,6 +91,21 @@ func (f *FakeAgentServer) Close() {
 	f.server.Close()
 }
 
+// writeJSONResponse encodes payload as JSON and writes it with the given
+// status code.
+func writeJSONResponse(w http.ResponseWriter, statusCode int, payload any) {
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(payload); err != nil {
+		http.Error(w, "fake: failed to encode response: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	if _, err := w.Write(buf.Bytes()); err != nil {
+		log.Printf("fake: failed to write response: %v", err)
+	}
+}
+
 func (f *FakeAgentServer) handleRegisterStack(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -116,17 +123,7 @@ func (f *FakeAgentServer) handleRegisterStack(w http.ResponseWriter, r *http.Req
 		ClusterQueueKey: req.QueueKey,
 		Metadata:        req.Metadata,
 	}
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(resp); err != nil {
-		http.Error(w, "fake: failed to encode response: "+err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	if _, err := w.Write(buf.Bytes()); err != nil {
-		log.Printf("fake: failed to write register stack response: %v", err)
-	}
+	writeJSONResponse(w, http.StatusOK, resp)
 }
 
 func (f *FakeAgentServer) handleReserveJobs(w http.ResponseWriter, r *http.Request) {
@@ -149,19 +146,7 @@ func (f *FakeAgentServer) handleReserveJobs(w http.ResponseWriter, r *http.Reque
 
 	// Return configured error if set
 	if f.ReserveError != "" {
-		var buf bytes.Buffer
-		if err := json.NewEncoder(&buf).Encode(map[string]string{
-			"message": f.ReserveError,
-		}); err != nil {
-			http.Error(w, "fake: failed to encode error response: "+err.Error(), http.StatusInternalServerError)
-			return
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(f.ReserveStatusCode)
-		if _, err := w.Write(buf.Bytes()); err != nil {
-			log.Printf("fake: failed to write error response: %v", err)
-		}
+		writeJSONResponse(w, f.ReserveStatusCode, map[string]string{"message": f.ReserveError})
 		return
 	}
 
@@ -174,18 +159,7 @@ func (f *FakeAgentServer) handleReserveJobs(w http.ResponseWriter, r *http.Reque
 			NotReserved: []string{},
 		}
 	}
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(resp); err != nil {
-		http.Error(w, "fake: failed to encode response: "+err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(f.ReserveStatusCode)
-	if _, err := w.Write(buf.Bytes()); err != nil {
-		log.Printf("fake: failed to write reserve jobs response: %v", err)
-	}
+	writeJSONResponse(w, f.ReserveStatusCode, resp)
 }
 
 func (f *FakeAgentServer) handleGetJobStates(w http.ResponseWriter, r *http.Request) {
@@ -203,23 +177,8 @@ func (f *FakeAgentServer) handleGetJobStates(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	f.mu.Lock()
-	f.GetJobStateCalls = append(f.GetJobStateCalls, req.JobUUIDs)
-
 	if f.GetJobStatesError != "" {
-		f.mu.Unlock()
-		var buf bytes.Buffer
-		if err := json.NewEncoder(&buf).Encode(map[string]string{
-			"message": f.GetJobStatesError,
-		}); err != nil {
-			http.Error(w, "fake: failed to encode error response: "+err.Error(), http.StatusInternalServerError)
-			return
-		}
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(f.GetJobStatesStatusCode)
-		if _, err := w.Write(buf.Bytes()); err != nil {
-			log.Printf("fake: failed to write get job states error response: %v", err)
-		}
+		writeJSONResponse(w, f.GetJobStatesStatusCode, map[string]string{"message": f.GetJobStatesError})
 		return
 	}
 
@@ -229,23 +188,11 @@ func (f *FakeAgentServer) handleGetJobStates(w http.ResponseWriter, r *http.Requ
 			states[id] = s
 		}
 	}
-	f.mu.Unlock()
 
 	resp := struct {
 		States map[string]string `json:"states"`
 	}{States: states}
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(resp); err != nil {
-		http.Error(w, "fake: failed to encode response: "+err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(f.GetJobStatesStatusCode)
-	if _, err := w.Write(buf.Bytes()); err != nil {
-		log.Printf("fake: failed to write get job states response: %v", err)
-	}
+	writeJSONResponse(w, f.GetJobStatesStatusCode, resp)
 }
 
 func (f *FakeAgentServer) handleFinishJob(w http.ResponseWriter, r *http.Request) {
@@ -266,32 +213,13 @@ func (f *FakeAgentServer) handleFinishJob(w http.ResponseWriter, r *http.Request
 
 	f.mu.Lock()
 	f.FinishJobCalls = append(f.FinishJobCalls, jobUUID)
-	if f.OnFinishJob != nil {
-		f.OnFinishJob(jobUUID)
-	}
 	f.mu.Unlock()
 
 	if f.FinishJobError != "" {
-		var buf bytes.Buffer
-		if err := json.NewEncoder(&buf).Encode(map[string]string{
-			"message": f.FinishJobError,
-		}); err != nil {
-			http.Error(w, "fake: failed to encode error response: "+err.Error(), http.StatusInternalServerError)
-			return
-		}
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(f.FinishJobStatusCode)
-		if _, err := w.Write(buf.Bytes()); err != nil {
-			log.Printf("fake: failed to write finish job error response: %v", err)
-		}
+		writeJSONResponse(w, f.FinishJobStatusCode, map[string]string{"message": f.FinishJobError})
 		return
 	}
-
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(f.FinishJobStatusCode)
-	if _, err := w.Write([]byte("{}\n")); err != nil {
-		log.Printf("fake: failed to write finish job response: %v", err)
-	}
+	writeJSONResponse(w, f.FinishJobStatusCode, struct{}{})
 }
 
 func (f *FakeAgentServer) handleNotifications(w http.ResponseWriter, r *http.Request) {
@@ -310,14 +238,5 @@ func (f *FakeAgentServer) handleNotifications(w http.ResponseWriter, r *http.Req
 	f.NotificationCalls = append(f.NotificationCalls, req.Notifications)
 	f.mu.Unlock()
 
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(stacksapi.CreateStackNotificationsResponse{}); err != nil {
-		http.Error(w, "fake: failed to encode response: "+err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	if _, err := w.Write(buf.Bytes()); err != nil {
-		log.Printf("fake: failed to write notifications response: %v", err)
-	}
+	writeJSONResponse(w, http.StatusOK, stacksapi.CreateStackNotificationsResponse{})
 }

--- a/internal/controller/scheduler/job_watcher.go
+++ b/internal/controller/scheduler/job_watcher.go
@@ -193,7 +193,7 @@ func (w *jobWatcher) checkFinished(ctx context.Context, log *slog.Logger, jobUUI
 	log.Info("The Kubernetes job ended without starting a pod. Failing the corresponding Buildkite job")
 	message := "The Kubernetes job ended without starting a pod.\n"
 	message += w.fetchEvents(ctx, log, kjob)
-	_ = w.failJob(ctx, log, kjob, message)
+	w.failJob(ctx, log, kjob, message)
 }
 
 // failBeforeAgentAcquire is called when a k8s Job has finished with a failed
@@ -219,7 +219,7 @@ func (w *jobWatcher) failBeforeAgentAcquire(ctx context.Context, log *slog.Logge
 	log.Info("Kubernetes pod failed before the buildkite-agent acquired the Buildkite job. Failing the BK job to release the reservation.", "bk_job_state", string(state.State))
 	message := "The Kubernetes pod failed before the buildkite-agent acquired this Buildkite job. The pod was likely killed by Kubernetes (eviction, OOM, node failure) or terminated externally before the agent could start.\n"
 	message += w.fetchEvents(ctx, log, kjob)
-	_ = w.failJob(ctx, log, kjob, message)
+	w.failJob(ctx, log, kjob, message)
 	w.ignoreJob(jobUUID)
 }
 
@@ -273,7 +273,7 @@ func (w *jobWatcher) fetchEvents(ctx context.Context, log *slog.Logger, kjob *ba
 	return w.formatEvents(evlist)
 }
 
-func (w *jobWatcher) failJob(ctx context.Context, log *slog.Logger, kjob *batchv1.Job, message string) error {
+func (w *jobWatcher) failJob(ctx context.Context, log *slog.Logger, kjob *batchv1.Job, message string) {
 	failureInfo := FailureInfo{
 		Message: message,
 		// We can know almost all failures triggered by job watcher are stack related error.
@@ -283,10 +283,9 @@ func (w *jobWatcher) failJob(ctx context.Context, log *slog.Logger, kjob *batchv
 		// Maybe the job was cancelled in the meantime?
 		log.Error("Could not fail Buildkite job", "error", err)
 		jobWatcherBuildkiteJobFailErrorsCounter.Inc()
-		return err
+		return
 	}
 	jobWatcherBuildkiteJobFailsCounter.Inc()
-	return nil
 }
 
 func (w *jobWatcher) formatEvents(evlist *corev1.EventList) string {
@@ -353,95 +352,95 @@ func (w *jobWatcher) stalledJobChecker(ctx context.Context) {
 			// continue below
 		}
 
-		// Gather stalled jobs
-		var stalled []*batchv1.Job
-		w.stallingJobsMu.Lock()
-		for jobUUID, kjob := range w.stallingJobs {
-			if time.Since(kjob.Status.StartTime.Time) < w.cfg.EmptyJobGracePeriod {
-				continue
-			}
+		w.cleanupStalledJobs(ctx)
+	}
+}
 
-			// ignore it from now until it is deleted
-			w.ignoreJob(jobUUID)
-
-			// Move it from w.stalling into stalled
-			stalled = append(stalled, kjob)
-			delete(w.stallingJobs, jobUUID)
+// cleanupStalledJobs runs one pass over the stalling jobs, cleaning up those
+// that have exceeded the grace period without starting a pod.
+func (w *jobWatcher) cleanupStalledJobs(ctx context.Context) {
+	// Gather jobs past the grace period. API calls happen after unlocking.
+	candidates := make(map[uuid.UUID]*batchv1.Job)
+	w.stallingJobsMu.Lock()
+	for jobUUID, kjob := range w.stallingJobs {
+		if time.Since(kjob.Status.StartTime.Time) < w.cfg.EmptyJobGracePeriod {
+			continue
 		}
-		w.stallingJobsMu.Unlock()
+		candidates[jobUUID] = kjob
+	}
+	w.stallingJobsMu.Unlock()
 
-		jobWatcherStalledWithoutPodCounter.Add(float64(len(stalled)))
+	var stalled []*batchv1.Job
+	for jobUUID, kjob := range candidates {
+		log := loggerForObject(w.logger, kjob)
 
-		// Fail BK jobs and delete k8s jobs.
-		for _, kjob := range stalled {
-			w.cleanupStalledJob(ctx, kjob)
+		// The informer cache may be stale — before doing anything destructive,
+		// ask Buildkite whether an agent is actually working on the job.
+		active, state, err := w.isJobActive(ctx, jobUUID)
+		switch {
+		case err != nil:
+			// Leave it in stallingJobs so the next cycle retries.
+			log.Warn("Failed to fetch BK job state; skipping stalled job cleanup to avoid killing a potentially running job", "error", err)
+			continue
+
+		case active:
+			// A pod must exist: the "stalled without pod" signal was a false
+			// positive from a stale informer cache. Once the cache catches
+			// up, the job leaves stallingJobs for good.
+			log.Info("Skipping stalled job cleanup: an agent is working on the Buildkite job (informer cache was likely stale)", "bk_job_state", string(state))
+			jobWatcherStalledCleanupSkippedCounter.Inc()
+			w.removeFromStalling(jobUUID)
+
+		default:
+			// The k8s Job is a zombie holding a slot: no pod after the grace
+			// period, and no agent working on the BK job. Two scenarios lead
+			// here:
+			// 1. The pod can't be scheduled (e.g. unsatisfiable constraints)
+			//    and the BK job hasn't started (reserved, scheduled).
+			// 2. The pod can't be scheduled, and the BK job was handled by
+			//    something else in the meantime and reached a terminal state
+			//    (canceled, expired, ...) or is no longer known to Buildkite.
+			// Reap it, and ignore it from now until it is deleted.
+			w.ignoreJob(jobUUID)
+			w.removeFromStalling(jobUUID)
+			stalled = append(stalled, kjob)
 		}
 	}
+
+	jobWatcherStalledWithoutPodCounter.Add(float64(len(stalled)))
+
+	// Fail BK jobs and delete k8s jobs.
+	for _, kjob := range stalled {
+		w.cleanupStalledJob(ctx, kjob)
+	}
+}
+
+// isJobActive reports whether an agent is actively working on the Buildkite
+// job, which implies a pod exists even if the informer cache says otherwise.
+// The job state is also returned for logging.
+func (w *jobWatcher) isJobActive(ctx context.Context, jobUUID uuid.UUID) (bool, api.JobState, error) {
+	state, _, err := w.agentClient.GetJobState(ctx, jobUUID.String())
+	if err != nil {
+		return false, "", err
+	}
+	switch state.State {
+	case api.JobStateAccepted, api.JobStateAssigned, api.JobStateRunning,
+		api.JobStateCanceling, api.JobStateTimingOut:
+		return true, state.State, nil
+	}
+	return false, state.State, nil
 }
 
 func (w *jobWatcher) cleanupStalledJob(ctx context.Context, kjob *batchv1.Job) {
 	log := loggerForObject(w.logger, kjob)
 
-	// Check BK job state before taking any destructive action.
-	// The informer cache may be stale — ask Buildkite directly.
-	jobUUID, err := jobUUIDForObject(kjob)
-	if err != nil {
-		log.Error("Job UUID label missing or invalid", "error", err)
-		return
-	}
-
-	state, _, err := w.agentClient.GetJobState(ctx, jobUUID.String())
-	if err != nil {
-		log.Warn("Failed to fetch BK job state; skipping stalled job cleanup to avoid killing a potentially running job", "error", err)
-		// Unignore so the stall-detection loop can retry on the next cycle.
-		w.unignoreJob(jobUUID)
-		return
-	}
-
-	// Only proceed if the job is still in a pre-agent state.
-	// If the agent has already acquired the job (Running, Accepted, etc.),
-	// the "stalled without pod" signal was a false positive from a stale cache.
-	//
-	// Unlike failBeforeAgentAcquire (which only acts on Reserved, because a
-	// Scheduled state there means BK reclaimed the reservation after a pod
-	// failure), this path handles the no-pod-ever case: the k8s Job exists
-	// but never created a pod. If the BK job reverted to Scheduled, there
-	// is still a zombie k8s Job consuming a slot that should be cleaned up.
-
-	// An empty state means the job UUID was not found in the API response
-	// (deleted, expired, or garbage-collected). Proceed with cleanup —
-	// an orphaned k8s Job whose BK job is gone is exactly what this
-	// cleanup should reap.
-	if state.State == "" {
-		log.Warn("BK job state is empty (job may have been deleted/expired); proceeding with cleanup")
-	} else if state.State != api.JobStateReserved && state.State != api.JobStateScheduled {
-		log.Info("Skipping stalled job cleanup: Buildkite job is no longer in a pre-agent state (informer cache was likely stale)", "bk_job_state", string(state.State))
-		jobWatcherStalledCleanupSkippedCounter.Inc()
-		return
-	}
-
 	// Fetch events for the failure message, and try to fail the job.
+	// failJob may fail (e.g. the BK job already finished); proceed anyway —
+	// the zombie k8s Job still needs to be reaped.
 	stallDuration := duration.HumanDuration(time.Since(kjob.Status.StartTime.Time))
 	message := fmt.Sprintf("The Kubernetes job spent %s without starting a pod.\n", stallDuration)
 	message += w.fetchEvents(ctx, log, kjob)
-	if err := w.failJob(ctx, log, kjob, message); err != nil {
-		// failJob failed — possibly a transient error, or the agent acquired
-		// the job in the narrow window since our last state check. Re-check
-		// before applying the destructive ActiveDeadlineSeconds patch.
-		recheck, _, recheckErr := w.agentClient.GetJobState(ctx, jobUUID.String())
-		if recheckErr != nil {
-			log.Warn("Failed to re-fetch BK job state after failJob error; aborting cleanup to avoid killing a potentially running job", "failJobError", err, "recheckError", recheckErr)
-			// Unignore so the stall-detection loop can retry on the next cycle.
-			w.unignoreJob(jobUUID)
-			return
-		}
-		if recheck.State != "" && recheck.State != api.JobStateReserved && recheck.State != api.JobStateScheduled {
-			log.Warn("Aborting stalled job cleanup: BK job state changed during cleanup", "failJobError", err, "bk_job_state", string(recheck.State))
-			jobWatcherStalledCleanupSkippedCounter.Inc()
-			return
-		}
-		log.Warn("Failed to fail BK job; proceeding with cleanup since job is still in pre-agent state", "error", err, "bk_job_state", string(recheck.State))
-	}
+	w.failJob(ctx, log, kjob, message)
 
 	// Use ActiveDeadlineSeconds to fail the job, which makes k8s delete the job
 	// in the future.

--- a/internal/controller/scheduler/job_watcher.go
+++ b/internal/controller/scheduler/job_watcher.go
@@ -193,7 +193,7 @@ func (w *jobWatcher) checkFinished(ctx context.Context, log *slog.Logger, jobUUI
 	log.Info("The Kubernetes job ended without starting a pod. Failing the corresponding Buildkite job")
 	message := "The Kubernetes job ended without starting a pod.\n"
 	message += w.fetchEvents(ctx, log, kjob)
-	w.failJob(ctx, log, kjob, message)
+	_ = w.failJob(ctx, log, kjob, message)
 }
 
 // failBeforeAgentAcquire is called when a k8s Job has finished with a failed
@@ -219,7 +219,7 @@ func (w *jobWatcher) failBeforeAgentAcquire(ctx context.Context, log *slog.Logge
 	log.Info("Kubernetes pod failed before the buildkite-agent acquired the Buildkite job. Failing the BK job to release the reservation.", "bk_job_state", string(state.State))
 	message := "The Kubernetes pod failed before the buildkite-agent acquired this Buildkite job. The pod was likely killed by Kubernetes (eviction, OOM, node failure) or terminated externally before the agent could start.\n"
 	message += w.fetchEvents(ctx, log, kjob)
-	w.failJob(ctx, log, kjob, message)
+	_ = w.failJob(ctx, log, kjob, message)
 	w.ignoreJob(jobUUID)
 }
 
@@ -273,7 +273,7 @@ func (w *jobWatcher) fetchEvents(ctx context.Context, log *slog.Logger, kjob *ba
 	return w.formatEvents(evlist)
 }
 
-func (w *jobWatcher) failJob(ctx context.Context, log *slog.Logger, kjob *batchv1.Job, message string) {
+func (w *jobWatcher) failJob(ctx context.Context, log *slog.Logger, kjob *batchv1.Job, message string) error {
 	failureInfo := FailureInfo{
 		Message: message,
 		// We can know almost all failures triggered by job watcher are stack related error.
@@ -283,9 +283,10 @@ func (w *jobWatcher) failJob(ctx context.Context, log *slog.Logger, kjob *batchv
 		// Maybe the job was cancelled in the meantime?
 		log.Error("Could not fail Buildkite job", "error", err)
 		jobWatcherBuildkiteJobFailErrorsCounter.Inc()
-		return
+		return err
 	}
 	jobWatcherBuildkiteJobFailsCounter.Inc()
+	return nil
 }
 
 func (w *jobWatcher) formatEvents(evlist *corev1.EventList) string {
@@ -381,11 +382,66 @@ func (w *jobWatcher) stalledJobChecker(ctx context.Context) {
 func (w *jobWatcher) cleanupStalledJob(ctx context.Context, kjob *batchv1.Job) {
 	log := loggerForObject(w.logger, kjob)
 
+	// Check BK job state before taking any destructive action.
+	// The informer cache may be stale — ask Buildkite directly.
+	jobUUID, err := jobUUIDForObject(kjob)
+	if err != nil {
+		log.Error("Job UUID label missing or invalid", "error", err)
+		return
+	}
+
+	state, _, err := w.agentClient.GetJobState(ctx, jobUUID.String())
+	if err != nil {
+		log.Warn("Failed to fetch BK job state; skipping stalled job cleanup to avoid killing a potentially running job", "error", err)
+		// Unignore so the stall-detection loop can retry on the next cycle.
+		w.unignoreJob(jobUUID)
+		return
+	}
+
+	// Only proceed if the job is still in a pre-agent state.
+	// If the agent has already acquired the job (Running, Accepted, etc.),
+	// the "stalled without pod" signal was a false positive from a stale cache.
+	//
+	// Unlike failBeforeAgentAcquire (which only acts on Reserved, because a
+	// Scheduled state there means BK reclaimed the reservation after a pod
+	// failure), this path handles the no-pod-ever case: the k8s Job exists
+	// but never created a pod. If the BK job reverted to Scheduled, there
+	// is still a zombie k8s Job consuming a slot that should be cleaned up.
+
+	// An empty state means the job UUID was not found in the API response
+	// (deleted, expired, or garbage-collected). Proceed with cleanup —
+	// an orphaned k8s Job whose BK job is gone is exactly what this
+	// cleanup should reap.
+	if state.State == "" {
+		log.Warn("BK job state is empty (job may have been deleted/expired); proceeding with cleanup")
+	} else if state.State != api.JobStateReserved && state.State != api.JobStateScheduled {
+		log.Info("Skipping stalled job cleanup: Buildkite job is no longer in a pre-agent state (informer cache was likely stale)", "bk_job_state", string(state.State))
+		jobWatcherStalledCleanupSkippedCounter.Inc()
+		return
+	}
+
 	// Fetch events for the failure message, and try to fail the job.
 	stallDuration := duration.HumanDuration(time.Since(kjob.Status.StartTime.Time))
 	message := fmt.Sprintf("The Kubernetes job spent %s without starting a pod.\n", stallDuration)
 	message += w.fetchEvents(ctx, log, kjob)
-	w.failJob(ctx, log, kjob, message)
+	if err := w.failJob(ctx, log, kjob, message); err != nil {
+		// failJob failed — possibly a transient error, or the agent acquired
+		// the job in the narrow window since our last state check. Re-check
+		// before applying the destructive ActiveDeadlineSeconds patch.
+		recheck, _, recheckErr := w.agentClient.GetJobState(ctx, jobUUID.String())
+		if recheckErr != nil {
+			log.Warn("Failed to re-fetch BK job state after failJob error; aborting cleanup to avoid killing a potentially running job", "failJobError", err, "recheckError", recheckErr)
+			// Unignore so the stall-detection loop can retry on the next cycle.
+			w.unignoreJob(jobUUID)
+			return
+		}
+		if recheck.State != "" && recheck.State != api.JobStateReserved && recheck.State != api.JobStateScheduled {
+			log.Warn("Aborting stalled job cleanup: BK job state changed during cleanup", "failJobError", err, "bk_job_state", string(recheck.State))
+			jobWatcherStalledCleanupSkippedCounter.Inc()
+			return
+		}
+		log.Warn("Failed to fail BK job; proceeding with cleanup since job is still in pre-agent state", "error", err, "bk_job_state", string(recheck.State))
+	}
 
 	// Use ActiveDeadlineSeconds to fail the job, which makes k8s delete the job
 	// in the future.

--- a/internal/controller/scheduler/job_watcher_test.go
+++ b/internal/controller/scheduler/job_watcher_test.go
@@ -1,0 +1,467 @@
+package scheduler
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/buildkite/agent-stack-k8s/v2/api"
+	"github.com/buildkite/agent-stack-k8s/v2/internal/controller/config"
+	"github.com/google/uuid"
+
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+const testJobUUID = "019f719c-0000-0000-0000-000000000000"
+
+func newTestJobWatcher(t *testing.T, fakeServer *api.FakeAgentServer) (*jobWatcher, *fake.Clientset) {
+	t.Helper()
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	agentClient, err := api.NewAgentClient(ctx, api.AgentClientOpts{
+		Token:    "fake-token",
+		Endpoint: fakeServer.URL(),
+		StackID:  "test-stack",
+		Logger:   logger,
+	})
+	if err != nil {
+		t.Fatalf("NewAgentClient: %v", err)
+	}
+
+	k8sClient := fake.NewSimpleClientset()
+
+	w := NewJobWatcher(logger, k8sClient, agentClient, &config.Config{
+		Namespace:           "default",
+		EmptyJobGracePeriod: 30 * time.Second,
+	})
+
+	return w, k8sClient
+}
+
+func newTestK8sJob(jobUUID string) *batchv1.Job {
+	now := metav1.Now()
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "buildkite-job-" + jobUUID[:8],
+			Namespace: "default",
+			Labels: map[string]string{
+				config.UUIDLabel: jobUUID,
+			},
+		},
+		Status: batchv1.JobStatus{
+			StartTime: &now,
+		},
+	}
+}
+
+func TestCleanupStalledJob(t *testing.T) {
+
+
+	t.Run("skips cleanup when BK job is running", func(t *testing.T) {
+	
+		ctx := context.Background()
+		server := api.NewFakeAgentServer()
+		defer server.Close()
+
+		server.JobStates = map[string]string{testJobUUID: "running"}
+		w, k8sClient := newTestJobWatcher(t, server)
+
+		kjob := newTestK8sJob(testJobUUID)
+		// Create the job in the fake K8s client so we can check it after
+		if _, err := k8sClient.BatchV1().Jobs("default").Create(ctx, kjob, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("Create job: %v", err)
+		}
+
+		w.cleanupStalledJob(ctx, kjob)
+
+		// Should NOT have called FinishJob
+		if got := len(server.FinishJobCalls); got != 0 {
+			t.Errorf("FinishJobCalls = %d, want 0", got)
+		}
+
+		// Should NOT have set ActiveDeadlineSeconds
+		updated, err := k8sClient.BatchV1().Jobs("default").Get(ctx, kjob.Name, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("Get job: %v", err)
+		}
+		if updated.Spec.ActiveDeadlineSeconds != nil {
+			t.Errorf("ActiveDeadlineSeconds = %d, want nil", *updated.Spec.ActiveDeadlineSeconds)
+		}
+	})
+
+	t.Run("skips cleanup when BK job is accepted", func(t *testing.T) {
+	
+		ctx := context.Background()
+		server := api.NewFakeAgentServer()
+		defer server.Close()
+
+		server.JobStates = map[string]string{testJobUUID: "accepted"}
+		w, k8sClient := newTestJobWatcher(t, server)
+
+		kjob := newTestK8sJob(testJobUUID)
+		if _, err := k8sClient.BatchV1().Jobs("default").Create(ctx, kjob, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("Create job: %v", err)
+		}
+
+		w.cleanupStalledJob(ctx, kjob)
+
+		if got := len(server.FinishJobCalls); got != 0 {
+			t.Errorf("FinishJobCalls = %d, want 0", got)
+		}
+
+		updated, err := k8sClient.BatchV1().Jobs("default").Get(ctx, kjob.Name, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("Get job: %v", err)
+		}
+		if updated.Spec.ActiveDeadlineSeconds != nil {
+			t.Errorf("ActiveDeadlineSeconds = %d, want nil", *updated.Spec.ActiveDeadlineSeconds)
+		}
+	})
+
+	t.Run("proceeds with cleanup when BK job is reserved", func(t *testing.T) {
+	
+		ctx := context.Background()
+		server := api.NewFakeAgentServer()
+		defer server.Close()
+
+		server.JobStates = map[string]string{testJobUUID: "reserved"}
+		w, k8sClient := newTestJobWatcher(t, server)
+
+		kjob := newTestK8sJob(testJobUUID)
+		if _, err := k8sClient.BatchV1().Jobs("default").Create(ctx, kjob, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("Create job: %v", err)
+		}
+
+		w.cleanupStalledJob(ctx, kjob)
+
+		// Should have called FinishJob
+		if got := len(server.FinishJobCalls); got != 1 {
+			t.Errorf("len(FinishJobCalls) = %d, want 1", got)
+		} else if server.FinishJobCalls[0] != testJobUUID {
+			t.Errorf("FinishJobCalls[0] = %q, want %q", server.FinishJobCalls[0], testJobUUID)
+		}
+
+		// Should have set ActiveDeadlineSeconds = 1
+		updated, err := k8sClient.BatchV1().Jobs("default").Get(ctx, kjob.Name, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("Get job: %v", err)
+		}
+		if updated.Spec.ActiveDeadlineSeconds == nil {
+			t.Fatal("ActiveDeadlineSeconds = nil, want 1")
+		}
+		if got := *updated.Spec.ActiveDeadlineSeconds; got != 1 {
+			t.Errorf("ActiveDeadlineSeconds = %d, want 1", got)
+		}
+	})
+
+	t.Run("proceeds with cleanup when BK job is scheduled", func(t *testing.T) {
+	
+		ctx := context.Background()
+		server := api.NewFakeAgentServer()
+		defer server.Close()
+
+		server.JobStates = map[string]string{testJobUUID: "scheduled"}
+		w, k8sClient := newTestJobWatcher(t, server)
+
+		kjob := newTestK8sJob(testJobUUID)
+		if _, err := k8sClient.BatchV1().Jobs("default").Create(ctx, kjob, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("Create job: %v", err)
+		}
+
+		w.cleanupStalledJob(ctx, kjob)
+
+		if got := len(server.FinishJobCalls); got != 1 {
+			t.Errorf("len(FinishJobCalls) = %d, want 1", got)
+		}
+
+		updated, err := k8sClient.BatchV1().Jobs("default").Get(ctx, kjob.Name, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("Get job: %v", err)
+		}
+		if updated.Spec.ActiveDeadlineSeconds == nil {
+			t.Fatal("ActiveDeadlineSeconds = nil, want 1")
+		}
+		if got := *updated.Spec.ActiveDeadlineSeconds; got != 1 {
+			t.Errorf("ActiveDeadlineSeconds = %d, want 1", got)
+		}
+	})
+
+	t.Run("skips cleanup when GetJobState fails", func(t *testing.T) {
+	
+		ctx := context.Background()
+		server := api.NewFakeAgentServer()
+		defer server.Close()
+
+		server.GetJobStatesStatusCode = 500
+		server.GetJobStatesError = "internal error"
+		w, k8sClient := newTestJobWatcher(t, server)
+
+		kjob := newTestK8sJob(testJobUUID)
+		if _, err := k8sClient.BatchV1().Jobs("default").Create(ctx, kjob, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("Create job: %v", err)
+		}
+
+		w.cleanupStalledJob(ctx, kjob)
+
+		if got := len(server.FinishJobCalls); got != 0 {
+			t.Errorf("FinishJobCalls = %d, want 0", got)
+		}
+
+		updated, err := k8sClient.BatchV1().Jobs("default").Get(ctx, kjob.Name, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("Get job: %v", err)
+		}
+		if updated.Spec.ActiveDeadlineSeconds != nil {
+			t.Errorf("ActiveDeadlineSeconds = %d, want nil", *updated.Spec.ActiveDeadlineSeconds)
+		}
+	})
+
+	t.Run("still patches ActiveDeadlineSeconds when failJob fails but recheck confirms reserved", func(t *testing.T) {
+	
+		ctx := context.Background()
+		server := api.NewFakeAgentServer()
+		defer server.Close()
+
+		// State is reserved (so both initial and recheck pass), but FinishJob returns 404
+		server.JobStates = map[string]string{testJobUUID: "reserved"}
+		server.FinishJobStatusCode = 404
+		server.FinishJobError = "not found"
+		w, k8sClient := newTestJobWatcher(t, server)
+
+		kjob := newTestK8sJob(testJobUUID)
+		if _, err := k8sClient.BatchV1().Jobs("default").Create(ctx, kjob, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("Create job: %v", err)
+		}
+
+		w.cleanupStalledJob(ctx, kjob)
+
+		// FinishJob WAS called (but it failed)
+		if got := len(server.FinishJobCalls); got != 1 {
+			t.Errorf("len(FinishJobCalls) = %d, want 1", got)
+		}
+
+		// Recheck confirmed still reserved, so ActiveDeadlineSeconds should be set.
+		updated, err := k8sClient.BatchV1().Jobs("default").Get(ctx, kjob.Name, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("Get job: %v", err)
+		}
+		if updated.Spec.ActiveDeadlineSeconds == nil {
+			t.Fatal("ActiveDeadlineSeconds = nil, want 1")
+		}
+		if got := *updated.Spec.ActiveDeadlineSeconds; got != 1 {
+			t.Errorf("ActiveDeadlineSeconds = %d, want 1", got)
+		}
+	})
+
+	t.Run("unignores job when GetJobState fails so retry is possible", func(t *testing.T) {
+
+		ctx := context.Background()
+		server := api.NewFakeAgentServer()
+		defer server.Close()
+
+		server.GetJobStatesStatusCode = 500
+		server.GetJobStatesError = "internal error"
+		w, k8sClient := newTestJobWatcher(t, server)
+
+		kjob := newTestK8sJob(testJobUUID)
+		if _, err := k8sClient.BatchV1().Jobs("default").Create(ctx, kjob, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("Create job: %v", err)
+		}
+
+		jobUUID := uuid.MustParse(testJobUUID)
+		w.ignoreJob(jobUUID) // simulate what stalledJobChecker does before calling cleanupStalledJob
+
+		w.cleanupStalledJob(ctx, kjob)
+
+		// Job should be unignored so it can be retried
+		if w.isIgnored(jobUUID) {
+			t.Error("job is still ignored after GetJobState failure; should have been unignored for retry")
+		}
+	})
+
+	t.Run("unignores job when recheck GetJobState fails so retry is possible", func(t *testing.T) {
+
+		ctx := context.Background()
+		server := api.NewFakeAgentServer()
+		defer server.Close()
+
+		// Initial state check succeeds (reserved), failJob fails, recheck fails
+		server.JobStates = map[string]string{testJobUUID: "reserved"}
+		server.FinishJobStatusCode = 404
+		server.FinishJobError = "not found"
+		server.OnFinishJob = func(jobUUID string) {
+			server.GetJobStatesError = "internal error"
+			server.GetJobStatesStatusCode = 500
+		}
+		w, k8sClient := newTestJobWatcher(t, server)
+
+		kjob := newTestK8sJob(testJobUUID)
+		if _, err := k8sClient.BatchV1().Jobs("default").Create(ctx, kjob, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("Create job: %v", err)
+		}
+
+		jobUUID := uuid.MustParse(testJobUUID)
+		w.ignoreJob(jobUUID)
+
+		w.cleanupStalledJob(ctx, kjob)
+
+		// Job should be unignored so it can be retried
+		if w.isIgnored(jobUUID) {
+			t.Error("job is still ignored after recheck GetJobState failure; should have been unignored for retry")
+		}
+	})
+
+	t.Run("aborts cleanup when agent acquires job between state check and failJob", func(t *testing.T) {
+	
+		ctx := context.Background()
+		server := api.NewFakeAgentServer()
+		defer server.Close()
+
+		// Initial state check returns "reserved", but by the time we recheck
+		// after failJob fails, the agent has acquired the job ("running").
+		// We simulate this by having the server change state after FinishJob is called.
+		server.JobStates = map[string]string{testJobUUID: "reserved"}
+		server.FinishJobStatusCode = 404
+		server.FinishJobError = "not found"
+		server.OnFinishJob = func(jobUUID string) {
+			server.JobStates[testJobUUID] = "running"
+		}
+		w, k8sClient := newTestJobWatcher(t, server)
+
+		kjob := newTestK8sJob(testJobUUID)
+		if _, err := k8sClient.BatchV1().Jobs("default").Create(ctx, kjob, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("Create job: %v", err)
+		}
+
+		w.cleanupStalledJob(ctx, kjob)
+
+		// FinishJob was called (and failed)
+		if got := len(server.FinishJobCalls); got != 1 {
+			t.Errorf("len(FinishJobCalls) = %d, want 1", got)
+		}
+
+		// Recheck saw "running" — should NOT have set ActiveDeadlineSeconds
+		updated, err := k8sClient.BatchV1().Jobs("default").Get(ctx, kjob.Name, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("Get job: %v", err)
+		}
+		if updated.Spec.ActiveDeadlineSeconds != nil {
+			t.Errorf("ActiveDeadlineSeconds = %d, want nil (agent acquired job during cleanup)", *updated.Spec.ActiveDeadlineSeconds)
+		}
+	})
+
+	t.Run("proceeds with cleanup when BK job state is empty (job deleted/expired)", func(t *testing.T) {
+		ctx := context.Background()
+		server := api.NewFakeAgentServer()
+		defer server.Close()
+
+		// JobStates is empty — the test UUID is absent, so GetJobState returns ""
+		server.JobStates = map[string]string{}
+		w, k8sClient := newTestJobWatcher(t, server)
+
+		kjob := newTestK8sJob(testJobUUID)
+		if _, err := k8sClient.BatchV1().Jobs("default").Create(ctx, kjob, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("Create job: %v", err)
+		}
+
+		w.cleanupStalledJob(ctx, kjob)
+
+		// Should have called FinishJob (even though it will likely fail on BK side)
+		if got := len(server.FinishJobCalls); got != 1 {
+			t.Errorf("len(FinishJobCalls) = %d, want 1", got)
+		}
+
+		// Should have set ActiveDeadlineSeconds = 1
+		updated, err := k8sClient.BatchV1().Jobs("default").Get(ctx, kjob.Name, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("Get job: %v", err)
+		}
+		if updated.Spec.ActiveDeadlineSeconds == nil {
+			t.Fatal("ActiveDeadlineSeconds = nil, want 1")
+		}
+		if got := *updated.Spec.ActiveDeadlineSeconds; got != 1 {
+			t.Errorf("ActiveDeadlineSeconds = %d, want 1", got)
+		}
+	})
+
+	t.Run("aborts cleanup when recheck after failJob error also fails", func(t *testing.T) {
+		ctx := context.Background()
+		server := api.NewFakeAgentServer()
+		defer server.Close()
+
+		server.JobStates = map[string]string{testJobUUID: "reserved"}
+		server.FinishJobStatusCode = 404
+		server.FinishJobError = "not found"
+		// After FinishJob is called, make GetJobStates also fail
+		server.OnFinishJob = func(jobUUID string) {
+			server.GetJobStatesError = "internal error"
+			server.GetJobStatesStatusCode = 500
+		}
+		w, k8sClient := newTestJobWatcher(t, server)
+
+		kjob := newTestK8sJob(testJobUUID)
+		if _, err := k8sClient.BatchV1().Jobs("default").Create(ctx, kjob, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("Create job: %v", err)
+		}
+
+		w.cleanupStalledJob(ctx, kjob)
+
+		// FinishJob was called (and failed)
+		if got := len(server.FinishJobCalls); got != 1 {
+			t.Errorf("len(FinishJobCalls) = %d, want 1", got)
+		}
+
+		// Recheck also failed — should NOT have set ActiveDeadlineSeconds
+		updated, err := k8sClient.BatchV1().Jobs("default").Get(ctx, kjob.Name, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("Get job: %v", err)
+		}
+		if updated.Spec.ActiveDeadlineSeconds != nil {
+			t.Errorf("ActiveDeadlineSeconds = %d, want nil (recheck failed, should abort)", *updated.Spec.ActiveDeadlineSeconds)
+		}
+	})
+
+	t.Run("proceeds with cleanup when recheck returns empty state after failJob error", func(t *testing.T) {
+		ctx := context.Background()
+		server := api.NewFakeAgentServer()
+		defer server.Close()
+
+		server.JobStates = map[string]string{testJobUUID: "reserved"}
+		server.FinishJobStatusCode = 404
+		server.FinishJobError = "not found"
+		// After FinishJob is called, the BK job disappears from the API
+		server.OnFinishJob = func(jobUUID string) {
+			delete(server.JobStates, testJobUUID)
+		}
+		w, k8sClient := newTestJobWatcher(t, server)
+
+		kjob := newTestK8sJob(testJobUUID)
+		if _, err := k8sClient.BatchV1().Jobs("default").Create(ctx, kjob, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("Create job: %v", err)
+		}
+
+		w.cleanupStalledJob(ctx, kjob)
+
+		// FinishJob was called (and failed)
+		if got := len(server.FinishJobCalls); got != 1 {
+			t.Errorf("len(FinishJobCalls) = %d, want 1", got)
+		}
+
+		// Recheck returned empty — should still proceed with ActiveDeadlineSeconds
+		updated, err := k8sClient.BatchV1().Jobs("default").Get(ctx, kjob.Name, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("Get job: %v", err)
+		}
+		if updated.Spec.ActiveDeadlineSeconds == nil {
+			t.Fatal("ActiveDeadlineSeconds = nil, want 1")
+		}
+		if got := *updated.Spec.ActiveDeadlineSeconds; got != 1 {
+			t.Errorf("ActiveDeadlineSeconds = %d, want 1", got)
+		}
+	})
+}

--- a/internal/controller/scheduler/job_watcher_test.go
+++ b/internal/controller/scheduler/job_watcher_test.go
@@ -44,7 +44,8 @@ func newTestJobWatcher(t *testing.T, fakeServer *api.FakeAgentServer) (*jobWatch
 }
 
 func newTestK8sJob(jobUUID string) *batchv1.Job {
-	now := metav1.Now()
+	// Started long enough ago to be past EmptyJobGracePeriod.
+	started := metav1.NewTime(time.Now().Add(-time.Minute))
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "buildkite-job-" + jobUUID[:8],
@@ -54,414 +55,142 @@ func newTestK8sJob(jobUUID string) *batchv1.Job {
 			},
 		},
 		Status: batchv1.JobStatus{
-			StartTime: &now,
+			StartTime: &started,
 		},
 	}
 }
 
-func TestCleanupStalledJob(t *testing.T) {
-
-
-	t.Run("skips cleanup when BK job is running", func(t *testing.T) {
-	
-		ctx := context.Background()
-		server := api.NewFakeAgentServer()
-		defer server.Close()
-
-		server.JobStates = map[string]string{testJobUUID: "running"}
-		w, k8sClient := newTestJobWatcher(t, server)
-
-		kjob := newTestK8sJob(testJobUUID)
-		// Create the job in the fake K8s client so we can check it after
-		if _, err := k8sClient.BatchV1().Jobs("default").Create(ctx, kjob, metav1.CreateOptions{}); err != nil {
-			t.Fatalf("Create job: %v", err)
-		}
-
-		w.cleanupStalledJob(ctx, kjob)
-
-		// Should NOT have called FinishJob
-		if got := len(server.FinishJobCalls); got != 0 {
-			t.Errorf("FinishJobCalls = %d, want 0", got)
-		}
-
-		// Should NOT have set ActiveDeadlineSeconds
-		updated, err := k8sClient.BatchV1().Jobs("default").Get(ctx, kjob.Name, metav1.GetOptions{})
-		if err != nil {
-			t.Fatalf("Get job: %v", err)
-		}
-		if updated.Spec.ActiveDeadlineSeconds != nil {
-			t.Errorf("ActiveDeadlineSeconds = %d, want nil", *updated.Spec.ActiveDeadlineSeconds)
-		}
-	})
-
-	t.Run("skips cleanup when BK job is accepted", func(t *testing.T) {
-	
-		ctx := context.Background()
-		server := api.NewFakeAgentServer()
-		defer server.Close()
-
-		server.JobStates = map[string]string{testJobUUID: "accepted"}
-		w, k8sClient := newTestJobWatcher(t, server)
-
-		kjob := newTestK8sJob(testJobUUID)
-		if _, err := k8sClient.BatchV1().Jobs("default").Create(ctx, kjob, metav1.CreateOptions{}); err != nil {
-			t.Fatalf("Create job: %v", err)
-		}
-
-		w.cleanupStalledJob(ctx, kjob)
-
-		if got := len(server.FinishJobCalls); got != 0 {
-			t.Errorf("FinishJobCalls = %d, want 0", got)
-		}
-
-		updated, err := k8sClient.BatchV1().Jobs("default").Get(ctx, kjob.Name, metav1.GetOptions{})
-		if err != nil {
-			t.Fatalf("Get job: %v", err)
-		}
-		if updated.Spec.ActiveDeadlineSeconds != nil {
-			t.Errorf("ActiveDeadlineSeconds = %d, want nil", *updated.Spec.ActiveDeadlineSeconds)
-		}
-	})
-
-	t.Run("proceeds with cleanup when BK job is reserved", func(t *testing.T) {
-	
-		ctx := context.Background()
-		server := api.NewFakeAgentServer()
-		defer server.Close()
-
-		server.JobStates = map[string]string{testJobUUID: "reserved"}
-		w, k8sClient := newTestJobWatcher(t, server)
-
-		kjob := newTestK8sJob(testJobUUID)
-		if _, err := k8sClient.BatchV1().Jobs("default").Create(ctx, kjob, metav1.CreateOptions{}); err != nil {
-			t.Fatalf("Create job: %v", err)
-		}
-
-		w.cleanupStalledJob(ctx, kjob)
-
-		// Should have called FinishJob
-		if got := len(server.FinishJobCalls); got != 1 {
-			t.Errorf("len(FinishJobCalls) = %d, want 1", got)
-		} else if server.FinishJobCalls[0] != testJobUUID {
-			t.Errorf("FinishJobCalls[0] = %q, want %q", server.FinishJobCalls[0], testJobUUID)
-		}
-
-		// Should have set ActiveDeadlineSeconds = 1
-		updated, err := k8sClient.BatchV1().Jobs("default").Get(ctx, kjob.Name, metav1.GetOptions{})
-		if err != nil {
-			t.Fatalf("Get job: %v", err)
-		}
-		if updated.Spec.ActiveDeadlineSeconds == nil {
-			t.Fatal("ActiveDeadlineSeconds = nil, want 1")
-		}
-		if got := *updated.Spec.ActiveDeadlineSeconds; got != 1 {
-			t.Errorf("ActiveDeadlineSeconds = %d, want 1", got)
-		}
-	})
-
-	t.Run("proceeds with cleanup when BK job is scheduled", func(t *testing.T) {
-	
-		ctx := context.Background()
-		server := api.NewFakeAgentServer()
-		defer server.Close()
-
-		server.JobStates = map[string]string{testJobUUID: "scheduled"}
-		w, k8sClient := newTestJobWatcher(t, server)
-
-		kjob := newTestK8sJob(testJobUUID)
-		if _, err := k8sClient.BatchV1().Jobs("default").Create(ctx, kjob, metav1.CreateOptions{}); err != nil {
-			t.Fatalf("Create job: %v", err)
-		}
-
-		w.cleanupStalledJob(ctx, kjob)
-
-		if got := len(server.FinishJobCalls); got != 1 {
-			t.Errorf("len(FinishJobCalls) = %d, want 1", got)
-		}
-
-		updated, err := k8sClient.BatchV1().Jobs("default").Get(ctx, kjob.Name, metav1.GetOptions{})
-		if err != nil {
-			t.Fatalf("Get job: %v", err)
-		}
-		if updated.Spec.ActiveDeadlineSeconds == nil {
-			t.Fatal("ActiveDeadlineSeconds = nil, want 1")
-		}
-		if got := *updated.Spec.ActiveDeadlineSeconds; got != 1 {
-			t.Errorf("ActiveDeadlineSeconds = %d, want 1", got)
-		}
-	})
-
-	t.Run("skips cleanup when GetJobState fails", func(t *testing.T) {
-	
-		ctx := context.Background()
-		server := api.NewFakeAgentServer()
-		defer server.Close()
-
-		server.GetJobStatesStatusCode = 500
-		server.GetJobStatesError = "internal error"
-		w, k8sClient := newTestJobWatcher(t, server)
-
-		kjob := newTestK8sJob(testJobUUID)
-		if _, err := k8sClient.BatchV1().Jobs("default").Create(ctx, kjob, metav1.CreateOptions{}); err != nil {
-			t.Fatalf("Create job: %v", err)
-		}
-
-		w.cleanupStalledJob(ctx, kjob)
-
-		if got := len(server.FinishJobCalls); got != 0 {
-			t.Errorf("FinishJobCalls = %d, want 0", got)
-		}
-
-		updated, err := k8sClient.BatchV1().Jobs("default").Get(ctx, kjob.Name, metav1.GetOptions{})
-		if err != nil {
-			t.Fatalf("Get job: %v", err)
-		}
-		if updated.Spec.ActiveDeadlineSeconds != nil {
-			t.Errorf("ActiveDeadlineSeconds = %d, want nil", *updated.Spec.ActiveDeadlineSeconds)
-		}
-	})
-
-	t.Run("still patches ActiveDeadlineSeconds when failJob fails but recheck confirms reserved", func(t *testing.T) {
-	
-		ctx := context.Background()
-		server := api.NewFakeAgentServer()
-		defer server.Close()
-
-		// State is reserved (so both initial and recheck pass), but FinishJob returns 404
-		server.JobStates = map[string]string{testJobUUID: "reserved"}
-		server.FinishJobStatusCode = 404
-		server.FinishJobError = "not found"
-		w, k8sClient := newTestJobWatcher(t, server)
-
-		kjob := newTestK8sJob(testJobUUID)
-		if _, err := k8sClient.BatchV1().Jobs("default").Create(ctx, kjob, metav1.CreateOptions{}); err != nil {
-			t.Fatalf("Create job: %v", err)
-		}
-
-		w.cleanupStalledJob(ctx, kjob)
-
-		// FinishJob WAS called (but it failed)
-		if got := len(server.FinishJobCalls); got != 1 {
-			t.Errorf("len(FinishJobCalls) = %d, want 1", got)
-		}
-
-		// Recheck confirmed still reserved, so ActiveDeadlineSeconds should be set.
-		updated, err := k8sClient.BatchV1().Jobs("default").Get(ctx, kjob.Name, metav1.GetOptions{})
-		if err != nil {
-			t.Fatalf("Get job: %v", err)
-		}
-		if updated.Spec.ActiveDeadlineSeconds == nil {
-			t.Fatal("ActiveDeadlineSeconds = nil, want 1")
-		}
-		if got := *updated.Spec.ActiveDeadlineSeconds; got != 1 {
-			t.Errorf("ActiveDeadlineSeconds = %d, want 1", got)
-		}
-	})
-
-	t.Run("unignores job when GetJobState fails so retry is possible", func(t *testing.T) {
-
-		ctx := context.Background()
-		server := api.NewFakeAgentServer()
-		defer server.Close()
-
-		server.GetJobStatesStatusCode = 500
-		server.GetJobStatesError = "internal error"
-		w, k8sClient := newTestJobWatcher(t, server)
-
-		kjob := newTestK8sJob(testJobUUID)
-		if _, err := k8sClient.BatchV1().Jobs("default").Create(ctx, kjob, metav1.CreateOptions{}); err != nil {
-			t.Fatalf("Create job: %v", err)
-		}
-
-		jobUUID := uuid.MustParse(testJobUUID)
-		w.ignoreJob(jobUUID) // simulate what stalledJobChecker does before calling cleanupStalledJob
-
-		w.cleanupStalledJob(ctx, kjob)
-
-		// Job should be unignored so it can be retried
-		if w.isIgnored(jobUUID) {
-			t.Error("job is still ignored after GetJobState failure; should have been unignored for retry")
-		}
-	})
-
-	t.Run("unignores job when recheck GetJobState fails so retry is possible", func(t *testing.T) {
-
-		ctx := context.Background()
-		server := api.NewFakeAgentServer()
-		defer server.Close()
-
-		// Initial state check succeeds (reserved), failJob fails, recheck fails
-		server.JobStates = map[string]string{testJobUUID: "reserved"}
-		server.FinishJobStatusCode = 404
-		server.FinishJobError = "not found"
-		server.OnFinishJob = func(jobUUID string) {
-			server.GetJobStatesError = "internal error"
-			server.GetJobStatesStatusCode = 500
-		}
-		w, k8sClient := newTestJobWatcher(t, server)
-
-		kjob := newTestK8sJob(testJobUUID)
-		if _, err := k8sClient.BatchV1().Jobs("default").Create(ctx, kjob, metav1.CreateOptions{}); err != nil {
-			t.Fatalf("Create job: %v", err)
-		}
-
-		jobUUID := uuid.MustParse(testJobUUID)
-		w.ignoreJob(jobUUID)
-
-		w.cleanupStalledJob(ctx, kjob)
-
-		// Job should be unignored so it can be retried
-		if w.isIgnored(jobUUID) {
-			t.Error("job is still ignored after recheck GetJobState failure; should have been unignored for retry")
-		}
-	})
-
-	t.Run("aborts cleanup when agent acquires job between state check and failJob", func(t *testing.T) {
-	
-		ctx := context.Background()
-		server := api.NewFakeAgentServer()
-		defer server.Close()
-
-		// Initial state check returns "reserved", but by the time we recheck
-		// after failJob fails, the agent has acquired the job ("running").
-		// We simulate this by having the server change state after FinishJob is called.
-		server.JobStates = map[string]string{testJobUUID: "reserved"}
-		server.FinishJobStatusCode = 404
-		server.FinishJobError = "not found"
-		server.OnFinishJob = func(jobUUID string) {
-			server.JobStates[testJobUUID] = "running"
-		}
-		w, k8sClient := newTestJobWatcher(t, server)
-
-		kjob := newTestK8sJob(testJobUUID)
-		if _, err := k8sClient.BatchV1().Jobs("default").Create(ctx, kjob, metav1.CreateOptions{}); err != nil {
-			t.Fatalf("Create job: %v", err)
-		}
-
-		w.cleanupStalledJob(ctx, kjob)
-
-		// FinishJob was called (and failed)
-		if got := len(server.FinishJobCalls); got != 1 {
-			t.Errorf("len(FinishJobCalls) = %d, want 1", got)
-		}
-
-		// Recheck saw "running" — should NOT have set ActiveDeadlineSeconds
-		updated, err := k8sClient.BatchV1().Jobs("default").Get(ctx, kjob.Name, metav1.GetOptions{})
-		if err != nil {
-			t.Fatalf("Get job: %v", err)
-		}
-		if updated.Spec.ActiveDeadlineSeconds != nil {
-			t.Errorf("ActiveDeadlineSeconds = %d, want nil (agent acquired job during cleanup)", *updated.Spec.ActiveDeadlineSeconds)
-		}
-	})
-
-	t.Run("proceeds with cleanup when BK job state is empty (job deleted/expired)", func(t *testing.T) {
-		ctx := context.Background()
-		server := api.NewFakeAgentServer()
-		defer server.Close()
-
-		// JobStates is empty — the test UUID is absent, so GetJobState returns ""
-		server.JobStates = map[string]string{}
-		w, k8sClient := newTestJobWatcher(t, server)
-
-		kjob := newTestK8sJob(testJobUUID)
-		if _, err := k8sClient.BatchV1().Jobs("default").Create(ctx, kjob, metav1.CreateOptions{}); err != nil {
-			t.Fatalf("Create job: %v", err)
-		}
-
-		w.cleanupStalledJob(ctx, kjob)
-
-		// Should have called FinishJob (even though it will likely fail on BK side)
-		if got := len(server.FinishJobCalls); got != 1 {
-			t.Errorf("len(FinishJobCalls) = %d, want 1", got)
-		}
-
-		// Should have set ActiveDeadlineSeconds = 1
-		updated, err := k8sClient.BatchV1().Jobs("default").Get(ctx, kjob.Name, metav1.GetOptions{})
-		if err != nil {
-			t.Fatalf("Get job: %v", err)
-		}
-		if updated.Spec.ActiveDeadlineSeconds == nil {
-			t.Fatal("ActiveDeadlineSeconds = nil, want 1")
-		}
-		if got := *updated.Spec.ActiveDeadlineSeconds; got != 1 {
-			t.Errorf("ActiveDeadlineSeconds = %d, want 1", got)
-		}
-	})
-
-	t.Run("aborts cleanup when recheck after failJob error also fails", func(t *testing.T) {
-		ctx := context.Background()
-		server := api.NewFakeAgentServer()
-		defer server.Close()
-
-		server.JobStates = map[string]string{testJobUUID: "reserved"}
-		server.FinishJobStatusCode = 404
-		server.FinishJobError = "not found"
-		// After FinishJob is called, make GetJobStates also fail
-		server.OnFinishJob = func(jobUUID string) {
-			server.GetJobStatesError = "internal error"
-			server.GetJobStatesStatusCode = 500
-		}
-		w, k8sClient := newTestJobWatcher(t, server)
-
-		kjob := newTestK8sJob(testJobUUID)
-		if _, err := k8sClient.BatchV1().Jobs("default").Create(ctx, kjob, metav1.CreateOptions{}); err != nil {
-			t.Fatalf("Create job: %v", err)
-		}
-
-		w.cleanupStalledJob(ctx, kjob)
-
-		// FinishJob was called (and failed)
-		if got := len(server.FinishJobCalls); got != 1 {
-			t.Errorf("len(FinishJobCalls) = %d, want 1", got)
-		}
-
-		// Recheck also failed — should NOT have set ActiveDeadlineSeconds
-		updated, err := k8sClient.BatchV1().Jobs("default").Get(ctx, kjob.Name, metav1.GetOptions{})
-		if err != nil {
-			t.Fatalf("Get job: %v", err)
-		}
-		if updated.Spec.ActiveDeadlineSeconds != nil {
-			t.Errorf("ActiveDeadlineSeconds = %d, want nil (recheck failed, should abort)", *updated.Spec.ActiveDeadlineSeconds)
-		}
-	})
-
-	t.Run("proceeds with cleanup when recheck returns empty state after failJob error", func(t *testing.T) {
-		ctx := context.Background()
-		server := api.NewFakeAgentServer()
-		defer server.Close()
-
-		server.JobStates = map[string]string{testJobUUID: "reserved"}
-		server.FinishJobStatusCode = 404
-		server.FinishJobError = "not found"
-		// After FinishJob is called, the BK job disappears from the API
-		server.OnFinishJob = func(jobUUID string) {
-			delete(server.JobStates, testJobUUID)
-		}
-		w, k8sClient := newTestJobWatcher(t, server)
-
-		kjob := newTestK8sJob(testJobUUID)
-		if _, err := k8sClient.BatchV1().Jobs("default").Create(ctx, kjob, metav1.CreateOptions{}); err != nil {
-			t.Fatalf("Create job: %v", err)
-		}
-
-		w.cleanupStalledJob(ctx, kjob)
-
-		// FinishJob was called (and failed)
-		if got := len(server.FinishJobCalls); got != 1 {
-			t.Errorf("len(FinishJobCalls) = %d, want 1", got)
-		}
-
-		// Recheck returned empty — should still proceed with ActiveDeadlineSeconds
-		updated, err := k8sClient.BatchV1().Jobs("default").Get(ctx, kjob.Name, metav1.GetOptions{})
-		if err != nil {
-			t.Fatalf("Get job: %v", err)
-		}
-		if updated.Spec.ActiveDeadlineSeconds == nil {
-			t.Fatal("ActiveDeadlineSeconds = nil, want 1")
-		}
-		if got := *updated.Spec.ActiveDeadlineSeconds; got != 1 {
-			t.Errorf("ActiveDeadlineSeconds = %d, want 1", got)
-		}
-	})
+func TestCleanupStalledJobs(t *testing.T) {
+	tests := []struct {
+		name string
+		// bkState is the job state reported by the fake BK API. Empty means
+		// the job is unknown to BK (deleted/expired).
+		bkState          string
+		getJobStateFails bool
+		finishJobFails   bool
+
+		wantFinishJobCalls int
+		wantCleanedUp      bool
+		wantStalling       bool
+		wantIgnored        bool
+	}{
+		{
+			name:          "skips cleanup when an agent is working on the job",
+			bkState:       "running",
+			wantCleanedUp: false,
+			wantStalling:  false,
+			wantIgnored:   false,
+		},
+		{
+			name:          "skips cleanup when an agent has accepted the job",
+			bkState:       "accepted",
+			wantCleanedUp: false,
+			wantStalling:  false,
+			wantIgnored:   false,
+		},
+		{
+			name:               "cleans up when BK job is reserved",
+			bkState:            "reserved",
+			wantFinishJobCalls: 1,
+			wantCleanedUp:      true,
+			wantStalling:       false,
+			wantIgnored:        true,
+		},
+		{
+			name:               "cleans up when BK job is scheduled",
+			bkState:            "scheduled",
+			wantFinishJobCalls: 1,
+			wantCleanedUp:      true,
+			wantStalling:       false,
+			wantIgnored:        true,
+		},
+		{
+			name:               "cleans up when BK job has ended",
+			bkState:            "finished",
+			wantFinishJobCalls: 1,
+			wantCleanedUp:      true,
+			wantStalling:       false,
+			wantIgnored:        true,
+		},
+		{
+			name:               "cleans up when BK job is unknown (deleted/expired)",
+			bkState:            "",
+			wantFinishJobCalls: 1,
+			wantCleanedUp:      true,
+			wantStalling:       false,
+			wantIgnored:        true,
+		},
+		{
+			name:             "keeps job in stalling set when GetJobState fails, for retry next cycle",
+			getJobStateFails: true,
+			wantCleanedUp:    false,
+			wantStalling:     true,
+			wantIgnored:      false,
+		},
+		{
+			name:               "cleans up even when failJob fails",
+			bkState:            "reserved",
+			finishJobFails:     true,
+			wantFinishJobCalls: 1,
+			wantCleanedUp:      true,
+			wantStalling:       false,
+			wantIgnored:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			server := api.NewFakeAgentServer()
+			defer server.Close()
+
+			if tt.bkState != "" {
+				server.JobStates = map[string]string{testJobUUID: tt.bkState}
+			}
+			if tt.getJobStateFails {
+				server.GetJobStatesStatusCode = 500
+				server.GetJobStatesError = "internal error"
+			}
+			if tt.finishJobFails {
+				server.FinishJobStatusCode = 404
+				server.FinishJobError = "not found"
+			}
+
+			w, k8sClient := newTestJobWatcher(t, server)
+
+			kjob := newTestK8sJob(testJobUUID)
+			if _, err := k8sClient.BatchV1().Jobs("default").Create(ctx, kjob, metav1.CreateOptions{}); err != nil {
+				t.Fatalf("Create job: %v", err)
+			}
+
+			jobUUID := uuid.MustParse(testJobUUID)
+			w.addToStalling(jobUUID, kjob)
+
+			w.cleanupStalledJobs(ctx)
+
+			if got := len(server.FinishJobCalls); got != tt.wantFinishJobCalls {
+				t.Errorf("len(FinishJobCalls) = %d, want %d", got, tt.wantFinishJobCalls)
+			}
+
+			updated, err := k8sClient.BatchV1().Jobs("default").Get(ctx, kjob.Name, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("Get job: %v", err)
+			}
+			cleanedUp := updated.Spec.ActiveDeadlineSeconds != nil && *updated.Spec.ActiveDeadlineSeconds == 1
+			if cleanedUp != tt.wantCleanedUp {
+				t.Errorf("job cleaned up (ActiveDeadlineSeconds set) = %t, want %t", cleanedUp, tt.wantCleanedUp)
+			}
+
+			w.stallingJobsMu.Lock()
+			_, stalling := w.stallingJobs[jobUUID]
+			w.stallingJobsMu.Unlock()
+			if stalling != tt.wantStalling {
+				t.Errorf("job in stallingJobs = %t, want %t", stalling, tt.wantStalling)
+			}
+
+			if got := w.isIgnored(jobUUID); got != tt.wantIgnored {
+				t.Errorf("isIgnored = %t, want %t", got, tt.wantIgnored)
+			}
+		})
+	}
 }

--- a/internal/controller/scheduler/metrics.go
+++ b/internal/controller/scheduler/metrics.go
@@ -109,6 +109,12 @@ var (
 		Name:      "jobs_stalled_without_pod_total",
 		Help:      "Count of jobs that ran for too long without a pod",
 	})
+	jobWatcherStalledCleanupSkippedCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: "job_watcher",
+		Name:      "stalled_cleanup_skipped_total",
+		Help:      "Count of stalled job cleanups skipped because the Buildkite job was no longer in a pre-agent state",
+	})
 
 	jobWatcherBuildkiteJobFailsCounter = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: promNamespace,

--- a/internal/controller/scheduler/metrics.go
+++ b/internal/controller/scheduler/metrics.go
@@ -113,7 +113,7 @@ var (
 		Namespace: promNamespace,
 		Subsystem: "job_watcher",
 		Name:      "stalled_cleanup_skipped_total",
-		Help:      "Count of stalled job cleanups skipped because the Buildkite job was no longer in a pre-agent state",
+		Help:      "Count of stalled job cleanups skipped because an agent was working on the Buildkite job",
 	})
 
 	jobWatcherBuildkiteJobFailsCounter = promauto.NewCounter(prometheus.CounterOpts{


### PR DESCRIPTION
## Change

Under heavy load, the k8s informer cache can lag. The stalled-job checker then sees a k8s Job with no pod, concludes the job stalled, and kills it — even though a pod exists and an agent is running the job normally. This caused healthy jobs to be unexpectedly terminated.

The fix: before cleaning up a "stalled" job, ask Buildkite for the actual job state.

- If an agent is actively working on the job (accepted, assigned, running, canceling, timing_out), a pod must exist — the stall signal was a false positive, so leave the job alone.
- In any other state (not started, terminal, or unknown to BK), the k8s Job is a zombie holding a slot and is reaped as before.
- If the state check fails, the job stays in the stalling set and is retried on the next cycle, so a transient API error can't kill a running job or permanently drop a genuinely stalled one.

Supersedes #918: Owen's commits squashed into one, plus a follow-up commit addressing review feedback.

## Context

Reference: [A-1565](https://linear.app/buildkite/issue/A-1565/notion-agent-unexpectedly-terminated)