### PR TITLE
A-1576: Cross-check the live k8s API before reaping a stalled job

### DIFF
--- a/.buildkite/cache.yml
+++ b/.buildkite/cache.yml
@@ -2,21 +2,21 @@ caches:
   - name: go_build
     cache_key:
       - agent: os
-      - {agent: arch, fallbackLimit: true}
+      - {agent: arch, fallback_limit: true}
       - checksum: go.mod
     target_paths:
       - /root/.cache/go-build
   - name: go_mod
     cache_key:
       - agent: os
-      - {agent: arch, fallbackLimit: true}
+      - {agent: arch, fallback_limit: true}
       - checksum: go.mod
     target_paths:
       - /root/.cache/go-mod
   - name: golangci_lint
     cache_key:
       - agent: os
-      - {agent: arch, fallbackLimit: true}
+      - {agent: arch, fallback_limit: true}
       - checksum: .golangci.yaml
     target_paths:
       - /root/.cache/golangci-lint

--- a/internal/controller/scheduler/job_watcher.go
+++ b/internal/controller/scheduler/job_watcher.go
@@ -228,13 +228,7 @@ func (w *jobWatcher) checkStalledWithoutPod(log *slog.Logger, jobUUID uuid.UUID,
 
 	// If the job is not finished and there is no pod, it should start one
 	// before too long. Otherwise the job is stalled.
-	pods := kjob.Status.Active + kjob.Status.Failed + kjob.Status.Succeeded
-	// Ready and Terminating are subsets of Active (I think)
-	if utp := kjob.Status.UncountedTerminatedPods; utp != nil {
-		pods += int32(len(utp.Succeeded))
-		pods += int32(len(utp.Failed))
-	}
-	if pods > 0 {
+	if hasPod(kjob) {
 		// All's well with the world.
 		w.removeFromStalling(jobUUID)
 		return
@@ -246,6 +240,24 @@ func (w *jobWatcher) checkStalledWithoutPod(log *slog.Logger, jobUUID uuid.UUID,
 	}
 
 	w.addToStalling(jobUUID, kjob)
+}
+
+// hasPod reports whether the job controller has ever observed a pod for the
+// k8s Job, in any lifecycle stage: pending/running (Active), terminating
+// (deletionTimestamp set but not yet terminal), or terminated — both
+// accounted (Succeeded, Failed) and not yet accounted
+// (UncountedTerminatedPods). False means the Job never produced a pod.
+// Ready is a subset of Active, so it is not summed.
+func hasPod(kjob *batchv1.Job) bool {
+	pods := kjob.Status.Active + kjob.Status.Failed + kjob.Status.Succeeded
+	if t := kjob.Status.Terminating; t != nil {
+		pods += *t
+	}
+	if utp := kjob.Status.UncountedTerminatedPods; utp != nil {
+		pods += int32(len(utp.Succeeded))
+		pods += int32(len(utp.Failed))
+	}
+	return pods > 0
 }
 
 func (w *jobWatcher) fetchEvents(ctx context.Context, log *slog.Logger, kjob *batchv1.Job) string {
@@ -341,6 +353,19 @@ func (w *jobWatcher) removeFromStalling(jobUUID uuid.UUID) {
 	delete(w.stallingJobs, jobUUID)
 }
 
+// removeCandidateFromStalling removes the stalling entry for jobUUID only if
+// it still refers to the same k8s Job as the checked candidate. An informer
+// event may have replaced the entry with a recreated Job (same deterministic
+// name, different UID) while the candidate was being checked against the
+// APIs; that replacement must stay and age through its own grace period.
+func (w *jobWatcher) removeCandidateFromStalling(jobUUID uuid.UUID, candidate *batchv1.Job) {
+	w.stallingJobsMu.Lock()
+	defer w.stallingJobsMu.Unlock()
+	if current, ok := w.stallingJobs[jobUUID]; ok && current.UID == candidate.UID {
+		delete(w.stallingJobs, jobUUID)
+	}
+}
+
 func (w *jobWatcher) stalledJobChecker(ctx context.Context) {
 	ticker := time.Tick(time.Second)
 	for {
@@ -374,22 +399,16 @@ func (w *jobWatcher) cleanupStalledJobs(ctx context.Context) {
 	for jobUUID, kjob := range candidates {
 		log := loggerForObject(w.logger, kjob)
 
-		// The informer cache may be stale — before doing anything destructive,
-		// ask Buildkite whether an agent is actually working on the job.
-		active, state, err := w.isJobActive(ctx, jobUUID)
+		reap, err := w.confirmStalled(ctx, log, jobUUID, kjob)
 		switch {
 		case err != nil:
 			// Leave it in stallingJobs so the next cycle retries.
-			log.Warn("Failed to fetch BK job state; skipping stalled job cleanup to avoid killing a potentially running job", "error", err)
 			continue
 
-		case active:
-			// A pod must exist: the "stalled without pod" signal was a false
-			// positive from a stale informer cache. Once the cache catches
-			// up, the job leaves stallingJobs for good.
-			log.Info("Skipping stalled job cleanup: an agent is working on the Buildkite job (informer cache was likely stale)", "bk_job_state", string(state))
-			jobWatcherStalledCleanupSkippedCounter.Inc()
-			w.removeFromStalling(jobUUID)
+		case !reap:
+			// A false positive from a stale informer cache. Once the cache
+			// catches up, the job leaves stallingJobs for good.
+			w.removeCandidateFromStalling(jobUUID, kjob)
 
 		default:
 			// The k8s Job is a zombie holding a slot: no pod after the grace
@@ -413,6 +432,59 @@ func (w *jobWatcher) cleanupStalledJobs(ctx context.Context) {
 	for _, kjob := range stalled {
 		w.cleanupStalledJob(ctx, kjob)
 	}
+}
+
+// confirmStalled reports whether a stall candidate is really stalled and
+// should be reaped. The informer cache may be stale, so before doing anything
+// destructive, double-check against two live sources:
+//   - Buildkite: an agent actively working on the job implies a pod exists.
+//   - The k8s API server: a pod may exist whose agent hasn't connected yet
+//     (e.g. still pulling a large image), or the Job may already be gone,
+//     leaving nothing to reap.
+//
+// An error means neither source could confirm the stall.
+func (w *jobWatcher) confirmStalled(ctx context.Context, log *slog.Logger, jobUUID uuid.UUID, kjob *batchv1.Job) (bool, error) {
+	active, state, err := w.isJobActive(ctx, jobUUID)
+	if err != nil {
+		log.Warn("Failed to fetch BK job state; skipping stalled job cleanup to avoid killing a potentially running job", "error", err)
+		return false, err
+	}
+	if active {
+		log.Info("Skipping stalled job cleanup: an agent is working on the Buildkite job (informer cache was likely stale)", "bk_job_state", string(state))
+		jobWatcherStalledCleanupSkippedCounter.WithLabelValues("agent_active").Inc()
+		return false, nil
+	}
+
+	job, err := w.k8s.BatchV1().Jobs(kjob.Namespace).Get(ctx, kjob.Name, metav1.GetOptions{})
+	if kerrors.IsNotFound(err) {
+		// There is no zombie k8s Job holding a slot, so there is nothing to
+		// reap. OnDelete tidies the bookkeeping, the deduper drops the UUID,
+		// and a still-scheduled BK job gets recreated from a later jobs
+		// query. Failing the BK job here would foreclose that retry.
+		log.Info("Skipping stalled job cleanup: the k8s Job no longer exists", "bk_job_state", string(state))
+		jobWatcherStalledCleanupSkippedCounter.WithLabelValues("job_gone").Inc()
+		return false, nil
+	}
+	if err != nil {
+		log.Warn("Failed to fetch job from the API server; skipping stalled job cleanup to avoid killing a potentially starting pod", "error", err)
+		return false, err
+	}
+	if job.UID != kjob.UID {
+		// Job names are deterministic per Buildkite job UUID: the candidate
+		// was deleted and a replacement Job was already created under the
+		// same name. Reaping the replacement with the old candidate's
+		// expired grace period would foreclose that retry.
+		log.Info("Skipping stalled job cleanup: the k8s Job was replaced by a newer Job with the same name", "bk_job_state", string(state))
+		jobWatcherStalledCleanupSkippedCounter.WithLabelValues("job_replaced").Inc()
+		return false, nil
+	}
+	if hasPod(job) {
+		log.Info("Skipping stalled job cleanup: the job has pods (informer cache was stale)", "bk_job_state", string(state))
+		jobWatcherStalledCleanupSkippedCounter.WithLabelValues("pod_exists").Inc()
+		return false, nil
+	}
+
+	return true, nil
 }
 
 // isJobActive reports whether an agent is actively working on the Buildkite

--- a/internal/controller/scheduler/job_watcher_test.go
+++ b/internal/controller/scheduler/job_watcher_test.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"os"
 	"testing"
@@ -13,7 +14,10 @@ import (
 
 	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+	"k8s.io/utils/ptr"
 )
 
 const testJobUUID = "019f719c-0000-0000-0000-000000000000"
@@ -50,6 +54,7 @@ func newTestK8sJob(jobUUID string) *batchv1.Job {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "buildkite-job-" + jobUUID[:8],
 			Namespace: "default",
+			UID:       "original-uid",
 			Labels: map[string]string{
 				config.UUIDLabel: jobUUID,
 			},
@@ -68,6 +73,21 @@ func TestCleanupStalledJobs(t *testing.T) {
 		bkState          string
 		getJobStateFails bool
 		finishJobFails   bool
+		// livePods makes the k8s Job in the fake clientset have an active
+		// pod, while the snapshot in stallingJobs remains podless (a stale
+		// informer cache).
+		livePods bool
+		// liveTerminating is like livePods, but the pod is terminating:
+		// excluded from Active and not yet in Failed/Succeeded/UTP.
+		liveTerminating bool
+		// jobMissing leaves the k8s Job out of the fake clientset entirely.
+		jobMissing bool
+		// jobReplaced gives the k8s Job in the fake clientset a different
+		// UID, as if the candidate was deleted and recreated under the same
+		// deterministic name.
+		jobReplaced bool
+		// getK8sJobFails makes live Gets of the k8s Job fail.
+		getK8sJobFails bool
 
 		wantFinishJobCalls int
 		wantCleanedUp      bool
@@ -128,6 +148,51 @@ func TestCleanupStalledJobs(t *testing.T) {
 			wantIgnored:      false,
 		},
 		{
+			name:          "skips cleanup when the live API shows pods (stale informer cache)",
+			bkState:       "scheduled",
+			livePods:      true,
+			wantCleanedUp: false,
+			wantStalling:  false,
+			wantIgnored:   false,
+		},
+		{
+			// A terminating pod is a pod: the job controller replaces it,
+			// so the job is not stalled.
+			name:            "skips cleanup when the live API shows only a terminating pod",
+			bkState:         "scheduled",
+			liveTerminating: true,
+			wantCleanedUp:   false,
+			wantStalling:    false,
+			wantIgnored:     false,
+		},
+		{
+			name:           "keeps job in stalling set when the live k8s Get fails, for retry next cycle",
+			bkState:        "scheduled",
+			getK8sJobFails: true,
+			wantStalling:   true,
+			wantIgnored:    false,
+		},
+		{
+			// Nothing to reap, and the BK job may be legitimately recreated
+			// once the deduper drops the UUID.
+			name:         "skips cleanup when the k8s Job no longer exists",
+			bkState:      "scheduled",
+			jobMissing:   true,
+			wantStalling: false,
+			wantIgnored:  false,
+		},
+		{
+			// The candidate was deleted and legitimately recreated under the
+			// same deterministic name; the fresh replacement must not be
+			// reaped with the old candidate's expired grace period.
+			name:          "skips cleanup when the k8s Job was replaced (delete/recreate race)",
+			bkState:       "scheduled",
+			jobReplaced:   true,
+			wantCleanedUp: false,
+			wantStalling:  false,
+			wantIgnored:   false,
+		},
+		{
 			name:               "cleans up even when failJob fails",
 			bkState:            "reserved",
 			finishJobFails:     true,
@@ -158,9 +223,28 @@ func TestCleanupStalledJobs(t *testing.T) {
 
 			w, k8sClient := newTestJobWatcher(t, server)
 
+			// The snapshot in stallingJobs is always podless; the copy in
+			// the fake clientset represents the live API state.
 			kjob := newTestK8sJob(testJobUUID)
-			if _, err := k8sClient.BatchV1().Jobs("default").Create(ctx, kjob, metav1.CreateOptions{}); err != nil {
-				t.Fatalf("Create job: %v", err)
+			if !tt.jobMissing {
+				live := kjob.DeepCopy()
+				if tt.livePods {
+					live.Status.Active = 1
+				}
+				if tt.liveTerminating {
+					live.Status.Terminating = ptr.To[int32](1)
+				}
+				if tt.jobReplaced {
+					live.UID = "replacement-uid"
+				}
+				if _, err := k8sClient.BatchV1().Jobs("default").Create(ctx, live, metav1.CreateOptions{}); err != nil {
+					t.Fatalf("Create job: %v", err)
+				}
+			}
+			if tt.getK8sJobFails {
+				k8sClient.PrependReactor("get", "jobs", func(k8stesting.Action) (bool, runtime.Object, error) {
+					return true, nil, errors.New("api server unavailable")
+				})
 			}
 
 			jobUUID := uuid.MustParse(testJobUUID)
@@ -172,13 +256,15 @@ func TestCleanupStalledJobs(t *testing.T) {
 				t.Errorf("len(FinishJobCalls) = %d, want %d", got, tt.wantFinishJobCalls)
 			}
 
-			updated, err := k8sClient.BatchV1().Jobs("default").Get(ctx, kjob.Name, metav1.GetOptions{})
-			if err != nil {
-				t.Fatalf("Get job: %v", err)
-			}
-			cleanedUp := updated.Spec.ActiveDeadlineSeconds != nil && *updated.Spec.ActiveDeadlineSeconds == 1
-			if cleanedUp != tt.wantCleanedUp {
-				t.Errorf("job cleaned up (ActiveDeadlineSeconds set) = %t, want %t", cleanedUp, tt.wantCleanedUp)
+			if !tt.jobMissing && !tt.getK8sJobFails {
+				updated, err := k8sClient.BatchV1().Jobs("default").Get(ctx, kjob.Name, metav1.GetOptions{})
+				if err != nil {
+					t.Fatalf("Get job: %v", err)
+				}
+				cleanedUp := updated.Spec.ActiveDeadlineSeconds != nil && *updated.Spec.ActiveDeadlineSeconds == 1
+				if cleanedUp != tt.wantCleanedUp {
+					t.Errorf("job cleaned up (ActiveDeadlineSeconds set) = %t, want %t", cleanedUp, tt.wantCleanedUp)
+				}
 			}
 
 			w.stallingJobsMu.Lock()
@@ -192,5 +278,50 @@ func TestCleanupStalledJobs(t *testing.T) {
 				t.Errorf("isIgnored = %t, want %t", got, tt.wantIgnored)
 			}
 		})
+	}
+}
+
+// While confirmStalled checks a candidate against the APIs, an informer event
+// may replace the stallingJobs entry with a recreated Job (same name, new
+// UID). The skip must not remove the replacement's entry, or a genuinely
+// stalled replacement would never be checked again.
+func TestCleanupStalledJobs_ReplacementAddedDuringCheck(t *testing.T) {
+	ctx := context.Background()
+	server := api.NewFakeAgentServer()
+	defer server.Close()
+	server.JobStates = map[string]string{testJobUUID: "scheduled"}
+
+	w, k8sClient := newTestJobWatcher(t, server)
+
+	candidate := newTestK8sJob(testJobUUID)
+	replacement := newTestK8sJob(testJobUUID)
+	replacement.UID = "replacement-uid"
+	if _, err := k8sClient.BatchV1().Jobs("default").Create(ctx, replacement, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Create job: %v", err)
+	}
+
+	jobUUID := uuid.MustParse(testJobUUID)
+	w.addToStalling(jobUUID, candidate)
+
+	// Simulate the replacement's OnAdd arriving while confirmStalled waits
+	// on the live Get, then fall through to the default tracker.
+	k8sClient.PrependReactor("get", "jobs", func(k8stesting.Action) (bool, runtime.Object, error) {
+		w.addToStalling(jobUUID, replacement)
+		return false, nil, nil
+	})
+
+	w.cleanupStalledJobs(ctx)
+
+	w.stallingJobsMu.Lock()
+	current := w.stallingJobs[jobUUID]
+	w.stallingJobsMu.Unlock()
+	if current == nil || current.UID != replacement.UID {
+		t.Errorf("stallingJobs[jobUUID] = %v, want the replacement to survive the skip", current)
+	}
+	if got := len(server.FinishJobCalls); got != 0 {
+		t.Errorf("len(FinishJobCalls) = %d, want 0", got)
+	}
+	if w.isIgnored(jobUUID) {
+		t.Error("isIgnored = true, want false")
 	}
 }

--- a/internal/controller/scheduler/metrics.go
+++ b/internal/controller/scheduler/metrics.go
@@ -109,12 +109,12 @@ var (
 		Name:      "jobs_stalled_without_pod_total",
 		Help:      "Count of jobs that ran for too long without a pod",
 	})
-	jobWatcherStalledCleanupSkippedCounter = promauto.NewCounter(prometheus.CounterOpts{
+	jobWatcherStalledCleanupSkippedCounter = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: promNamespace,
 		Subsystem: "job_watcher",
 		Name:      "stalled_cleanup_skipped_total",
-		Help:      "Count of stalled job cleanups skipped because an agent was working on the Buildkite job",
-	})
+		Help:      "Count of stalled job cleanups skipped because the job turned out not to be stalled",
+	}, []string{"reason"})
 
 	jobWatcherBuildkiteJobFailsCounter = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: promNamespace,


### PR DESCRIPTION
Fixes [A-1576](https://linear.app/buildkite/issue/A-1576/agent-stack-k8s-stalled-job-checker-can-reap-a-healthy-pod-mid-image). Follow-up to #926.

## The seam

At reap time the two sources of truth can disagree:

- Kubernetes says active: a Pending, image-pulling pod exists (`Job.Status.Active = 1`)
- Buildkite says not active: the agent has not connected yet, state is still `scheduled`

The #926 guard only asks Buildkite, sees `scheduled`, and reaps the k8s Job. The pod is deleted mid image pull and the build fails with "The Kubernetes job spent 30s without starting a pod".

This only fires when the informer misses the `Active = 1` update for the whole window between pod creation and the grace deadline (~20s+ of lag with the default 30s grace). In normal operation the pod-creation status update removes the job from the stalling set well before the deadline. But that lag is the same heavy-load condition behind A-1565, so it is plausible in the clusters that hit it.

## The fix

After Buildkite reports the job as not active, `confirmStalled` cross-checks the API server directly (a non-cached `Get` of the Job) before doing anything destructive:

- pods exist: skip the reap and remove from the stalling set, same as the BK-active skip
- the Job no longer exists: skip too. There is no zombie holding a slot, and failing the BK job would foreclose the legitimate recreation that happens once the deduper drops the UUID (previously `failJob` ran anyway in this case)
- the Job's UID differs from the candidate's: skip. Job names are deterministic per BK job UUID, so the candidate was deleted and already recreated under the same name; the fresh replacement must not be reaped with the old candidate's expired grace period
- `Get` fails: leave the job in the stalling set so the next cycle retries, mirroring the `GetJobState` error path

A skip removes the stalling entry with a compare-and-delete on the candidate's UID: an informer event may have replaced the entry with a recreated Job mid-check, and that replacement must stay and age through its own grace period rather than being silently dropped from stall detection.

Skips are counted in `stalled_cleanup_skipped_total`, now labelled by `reason` (`agent_active`, `job_gone`, `job_replaced`, `pod_exists`). Dashboards summing the previously unlabelled series need a `sum()` across reasons.

## API cost

The new `Get` is per reap candidate, not per job. Candidates past the grace period already make a Buildkite API call per tick, and a job that is actually reaped already costs an events `List`, a `FinishJob`, and a `Get`+`Update` for the ADS patch. Steady state (empty stalling set) makes zero new calls.

## Tests

Four new rows in the `cleanupStalledJobs` table test: live API shows pods (stale snapshot in the stalling set) → skip; live `Get` fails → stays in stalling for retry; job missing from the live API → skip, nothing to reap; job replaced (UID mismatch, delete/recreate race) → skip. Plus a dedicated test that a replacement entry added to the stalling set mid-check survives the skip's compare-and-delete.
