### PR TITLE
Check podless k8s Jobs for Buildkite cancellation

### DIFF
--- a/charts/agent-stack-k8s/templates/rbac.yaml.tpl
+++ b/charts/agent-stack-k8s/templates/rbac.yaml.tpl
@@ -13,6 +13,7 @@ rules:
       - watch
       - create
       - update
+      - delete
   - apiGroups:
       - ""
     resources:

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -245,14 +245,32 @@ func Run(ctx context.Context, logger *slog.Logger, k8sClient kubernetes.Interfac
 		}
 	}
 
+	// The Buildkite job cancel checker is shared by both watchers. jobWatcher
+	// registers k8s Jobs that have no pod, podWatcher registers pending pods,
+	// and both use the same poll loop against the Buildkite API. Sharing it
+	// keeps one registration per Buildkite job, so a job cannot be checked
+	// twice or deleted by two paths at once.
+	jobCancelCheckerInterval := cfg.JobCancelCheckerPollInterval
+	if jobCancelCheckerInterval <= 0 {
+		jobCancelCheckerInterval = config.DefaultJobCancelCheckerPollInterval
+	}
+	bkJobChecker := scheduler.NewBatchBuildkiteJobChecker(
+		logger.With("component", "buildkiteJobChecker"),
+		agentClient,
+		k8sClient,
+		jobCancelCheckerInterval,
+	)
+
 	// JobWatcher watches for jobs in bad conditions to clean up:
 	// * Jobs that fail without ever creating a pod
 	// * Jobs that stall forever without ever creating a pod
+	// * Jobs with no pod whose Buildkite job has been cancelled
 	jobWatcher := scheduler.NewJobWatcher(
 		logger.With("component", "jobWatcher"),
 		k8sClient,
 		agentClient,
 		cfg,
+		bkJobChecker,
 	)
 	if err := jobWatcher.RegisterInformer(ctx, informerFactory); err != nil {
 		logger.Error("failed to register jobWatcher informer", "error", err)
@@ -268,12 +286,13 @@ func Run(ctx context.Context, logger *slog.Logger, k8sClient kubernetes.Interfac
 		k8sClient,
 		agentClient,
 		cfg,
+		bkJobChecker,
 	)
 	if err := podWatcher.RegisterInformer(ctx, informerFactory); err != nil {
 		logger.Error("failed to register podWatcher informer", "error", err)
 		return
 	}
-	podWatcher.StartBuildkiteJobChecker(ctx)
+	bkJobChecker.StartChecking(ctx)
 
 	select {
 	case <-ctx.Done():

--- a/internal/controller/scheduler/batch_buildkite_job_checker.go
+++ b/internal/controller/scheduler/batch_buildkite_job_checker.go
@@ -14,6 +14,29 @@ import (
 	"log/slog"
 )
 
+// cancelTargetKind says what the checker should delete once it learns a
+// Buildkite job was cancelled.
+type cancelTargetKind int
+
+const (
+	// cancelTargetPod deletes the pod. Scheduler sets BackoffLimit=0 on the
+	// k8s Job, so removing its pod also terminates the Job.
+	cancelTargetPod cancelTargetKind = iota
+
+	// cancelTargetJob deletes the k8s Job itself. Needed when no pod exists to
+	// delete, which is the steady state for a Job held suspended by an
+	// admission controller such as Kueue: registration used to be driven purely
+	// by pod events, so those Jobs were never checked at all and only ran once
+	// something else admitted them.
+	cancelTargetJob
+)
+
+// cancelTarget is the object the checker deletes for one Buildkite job.
+type cancelTarget struct {
+	kind cancelTargetKind
+	meta metav1.ObjectMeta
+}
+
 // BatchBuildkiteJobChecker monitors Buildkite jobs for cancellation state changes.
 // Unlike the old legacy BuildkiteJobChecker, this checker check all pending jobs together,
 // relying on the new Stack API.
@@ -25,9 +48,9 @@ type BatchBuildkiteJobChecker struct {
 	// The job cancel checkers query the job state every so often.
 	jobCancelCheckerInterval time.Duration
 
-	// Store jobs that we will check against.
+	// Store jobs that we will check against, and what to delete for each.
 	checkingJobsMu sync.Mutex
-	checkingJobs   map[uuid.UUID]metav1.ObjectMeta
+	checkingJobs   map[uuid.UUID]cancelTarget
 }
 
 // NewBatchBuildkiteJobChecker creates a new Batch Buildkite job checker.
@@ -37,13 +60,15 @@ func NewBatchBuildkiteJobChecker(
 	k8s kubernetes.Interface,
 	interval time.Duration,
 ) *BatchBuildkiteJobChecker {
-	return &BatchBuildkiteJobChecker{
+	c := &BatchBuildkiteJobChecker{
 		logger:                   logger,
 		agentClient:              agentClient,
 		k8s:                      k8s,
 		jobCancelCheckerInterval: interval,
-		checkingJobs:             make(map[uuid.UUID]metav1.ObjectMeta),
+		checkingJobs:             make(map[uuid.UUID]cancelTarget),
 	}
+	jobCancelCheckerGaugeFunc = c.GetActiveCheckCount
+	return c
 }
 
 // StartChecking starts a gorouting loop to periodically check job states for all jobs that it manages.
@@ -75,14 +100,14 @@ func (c *BatchBuildkiteJobChecker) checkJobStates(ctx context.Context) {
 		return
 	}
 
-	// Create slices for job UUIDs and corresponding pod metadata
+	// Create slices for job UUIDs and corresponding deletion targets
 	jobUUIDs := make([]string, 0, len(c.checkingJobs))
-	jobToPodMeta := make(map[string]metav1.ObjectMeta, len(c.checkingJobs))
+	jobToTarget := make(map[string]cancelTarget, len(c.checkingJobs))
 
-	for jobUUID, podMeta := range c.checkingJobs {
+	for jobUUID, target := range c.checkingJobs {
 		jobUUIDStr := jobUUID.String()
 		jobUUIDs = append(jobUUIDs, jobUUIDStr)
-		jobToPodMeta[jobUUIDStr] = podMeta
+		jobToTarget[jobUUIDStr] = target
 	}
 	c.checkingJobsMu.Unlock() // Release the lock as soon as possible.
 
@@ -115,19 +140,35 @@ func (c *BatchBuildkiteJobChecker) checkJobStates(ctx context.Context) {
 	// Process results from all batches
 	for jobStates := range jobStatesCh {
 		for jobUUIDStr, jobState := range jobStates {
-			podMeta := jobToPodMeta[jobUUIDStr]
+			target := jobToTarget[jobUUIDStr]
 			// Concurrently handle cancelled jobs.
 			// This is at the mercy of k8s API rate limit and buildkite stack API rate limit.
 			// If either rate limit were breached, it will result in delay in resource release.
-			go c.handleJobState(ctx, jobUUIDStr, jobState, podMeta)
+			go c.handleJobState(ctx, jobUUIDStr, jobState, target)
 		}
 	}
 }
 
-func (c *BatchBuildkiteJobChecker) AddJob(jobUUID uuid.UUID, podMeta metav1.ObjectMeta) {
+// AddPod registers a Buildkite job whose pod exists and is pending. A pod is
+// the preferred deletion target, so this always replaces any Job registration.
+func (c *BatchBuildkiteJobChecker) AddPod(jobUUID uuid.UUID, podMeta metav1.ObjectMeta) {
 	c.checkingJobsMu.Lock()
 	defer c.checkingJobsMu.Unlock()
-	c.checkingJobs[jobUUID] = podMeta
+	c.checkingJobs[jobUUID] = cancelTarget{kind: cancelTargetPod, meta: podMeta}
+}
+
+// AddK8sJob registers a Buildkite job whose k8s Job exists but has no pod yet.
+//
+// This never downgrades an existing pod registration: pod events and Job events
+// arrive independently, so a stale Job event must not replace a pod target that
+// a later pod event installed.
+func (c *BatchBuildkiteJobChecker) AddK8sJob(jobUUID uuid.UUID, jobMeta metav1.ObjectMeta) {
+	c.checkingJobsMu.Lock()
+	defer c.checkingJobsMu.Unlock()
+	if existing, ok := c.checkingJobs[jobUUID]; ok && existing.kind == cancelTargetPod {
+		return
+	}
+	c.checkingJobs[jobUUID] = cancelTarget{kind: cancelTargetJob, meta: jobMeta}
 }
 
 func (c *BatchBuildkiteJobChecker) StopCheckingJob(jobUUID uuid.UUID) {
@@ -136,14 +177,22 @@ func (c *BatchBuildkiteJobChecker) StopCheckingJob(jobUUID uuid.UUID) {
 	delete(c.checkingJobs, jobUUID)
 }
 
-func (c *BatchBuildkiteJobChecker) handleJobState(ctx context.Context, jobUUIDStr string, jobState api.JobState, podMeta metav1.ObjectMeta) {
+func (c *BatchBuildkiteJobChecker) handleJobState(ctx context.Context, jobUUIDStr string, jobState api.JobState, target cancelTarget) {
 	log := c.logger.With("job_uuid", jobUUIDStr, "job_state", string(jobState))
 
 	switch jobState {
 	case api.JobStateCanceled, api.JobStateCanceling:
-		log.Info("Deleting pending pod for cancelled job")
-		if err := forcefullyDeletePod(ctx, log, c.k8s, &podMeta, "job_cancelled"); err != nil {
-			log.Error("Failed to delete pod for cancelled job", "error", err)
+		var err error
+		switch target.kind {
+		case cancelTargetPod:
+			log.Info("Deleting pending pod for cancelled job")
+			err = forcefullyDeletePod(ctx, log, c.k8s, &target.meta, "job_cancelled")
+		case cancelTargetJob:
+			log.Info("Deleting podless k8s job for cancelled job")
+			err = forcefullyDeleteJob(ctx, log, c.k8s, &target.meta, "job_cancelled")
+		}
+		if err != nil {
+			log.Error("Failed to delete resource for cancelled job", "error", err)
 			return
 		}
 		// Remove the job from checking list after successful deletion
@@ -161,6 +210,14 @@ func (c *BatchBuildkiteJobChecker) handleJobState(ctx context.Context, jobUUIDSt
 		jobUUID, _ := uuid.Parse(jobUUIDStr)
 		c.StopCheckingJob(jobUUID)
 	}
+}
+
+// targetFor returns the registered deletion target for a Buildkite job.
+func (c *BatchBuildkiteJobChecker) targetFor(jobUUID uuid.UUID) (cancelTarget, bool) {
+	c.checkingJobsMu.Lock()
+	defer c.checkingJobsMu.Unlock()
+	target, ok := c.checkingJobs[jobUUID]
+	return target, ok
 }
 
 // GetActiveCheckCount returns the number of jobs currently being checked.

--- a/internal/controller/scheduler/job_watcher.go
+++ b/internal/controller/scheduler/job_watcher.go
@@ -42,6 +42,11 @@ type jobWatcher struct {
 
 	agentClient *api.AgentClient
 
+	// Shared with podWatcher. A k8s Job held suspended by an admission
+	// controller never produces a pod, so pod events alone never register it
+	// for cancellation checks.
+	bkJobChecker *BatchBuildkiteJobChecker
+
 	// Tracks stalling jobs (jobs that have yet to create pods).
 	stallingJobsMu sync.Mutex
 	stallingJobs   map[uuid.UUID]*batchv1.Job
@@ -59,12 +64,13 @@ type jobWatcher struct {
 }
 
 // NewJobWatcher creates a JobWatcher.
-func NewJobWatcher(logger *slog.Logger, k8sClient kubernetes.Interface, agentClient *api.AgentClient, cfg *config.Config) *jobWatcher {
+func NewJobWatcher(logger *slog.Logger, k8sClient kubernetes.Interface, agentClient *api.AgentClient, cfg *config.Config, bkJobChecker *BatchBuildkiteJobChecker) *jobWatcher {
 	w := &jobWatcher{
 		logger:       logger,
 		k8s:          k8sClient,
 		agentClient:  agentClient,
 		cfg:          cfg,
+		bkJobChecker: bkJobChecker,
 		stallingJobs: make(map[uuid.UUID]*batchv1.Job),
 		ignoredJobs:  make(map[uuid.UUID]struct{}),
 	}
@@ -132,6 +138,7 @@ func (w *jobWatcher) OnDelete(prev any) {
 	}
 
 	w.removeFromStalling(jobUUID)
+	w.stopCheckingBuildkiteJob(jobUUID)
 
 	// The job is gone, so we can stop ignoring it (if it comes back).
 	w.unignoreJob(jobUUID)
@@ -154,10 +161,34 @@ func (w *jobWatcher) runChecks(ctx context.Context, kjob *batchv1.Job) {
 
 	if model.JobFinished(kjob) {
 		w.removeFromStalling(jobUUID)
+		w.stopCheckingBuildkiteJob(jobUUID)
 		w.checkFinished(ctx, log, jobUUID, kjob)
-	} else {
-		w.checkStalledWithoutPod(log, jobUUID, kjob)
+		return
 	}
+
+	// Register for cancellation checks while there is no pod. podWatcher only
+	// sees jobs once a pod exists, so without this a Job suspended by an
+	// admission controller is never checked: cancelling the build does nothing,
+	// and the job still runs whenever it is eventually admitted.
+	if !hasPod(kjob) {
+		w.addToBuildkiteJobChecker(jobUUID, kjob)
+	}
+
+	w.checkStalledWithoutPod(log, jobUUID, kjob)
+}
+
+func (w *jobWatcher) addToBuildkiteJobChecker(jobUUID uuid.UUID, kjob *batchv1.Job) {
+	if w.bkJobChecker == nil {
+		return
+	}
+	w.bkJobChecker.AddK8sJob(jobUUID, kjob.ObjectMeta)
+}
+
+func (w *jobWatcher) stopCheckingBuildkiteJob(jobUUID uuid.UUID) {
+	if w.bkJobChecker == nil {
+		return
+	}
+	w.bkJobChecker.StopCheckingJob(jobUUID)
 }
 
 // checkFinished inspects a finished K8s Job and, when needed, fails the

--- a/internal/controller/scheduler/job_watcher_test.go
+++ b/internal/controller/scheduler/job_watcher_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/uuid"
 
 	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
@@ -23,6 +24,12 @@ import (
 const testJobUUID = "019f719c-0000-0000-0000-000000000000"
 
 func newTestJobWatcher(t *testing.T, fakeServer *api.FakeAgentServer) (*jobWatcher, *fake.Clientset) {
+	t.Helper()
+	w, k8sClient, _ := newTestJobWatcherWithChecker(t, fakeServer)
+	return w, k8sClient
+}
+
+func newTestJobWatcherWithChecker(t *testing.T, fakeServer *api.FakeAgentServer) (*jobWatcher, *fake.Clientset, *BatchBuildkiteJobChecker) {
 	t.Helper()
 	ctx := context.Background()
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
@@ -39,12 +46,14 @@ func newTestJobWatcher(t *testing.T, fakeServer *api.FakeAgentServer) (*jobWatch
 
 	k8sClient := fake.NewSimpleClientset()
 
+	checker := NewBatchBuildkiteJobChecker(logger, agentClient, k8sClient, time.Second)
+
 	w := NewJobWatcher(logger, k8sClient, agentClient, &config.Config{
 		Namespace:           "default",
 		EmptyJobGracePeriod: 30 * time.Second,
-	})
+	}, checker)
 
-	return w, k8sClient
+	return w, k8sClient, checker
 }
 
 func newTestK8sJob(jobUUID string) *batchv1.Job {
@@ -323,5 +332,95 @@ func TestCleanupStalledJobs_ReplacementAddedDuringCheck(t *testing.T) {
 	}
 	if w.isIgnored(jobUUID) {
 		t.Error("isIgnored = true, want false")
+	}
+}
+
+// A k8s Job that has no pod must still be registered for Buildkite cancellation
+// checks. Before this, registration happened only on pod events, so a Job held
+// suspended by an admission controller such as Kueue was never checked at all:
+// cancelling the build did nothing, and the job ran in full whenever it was
+// later admitted.
+func TestPodlessJobIsRegisteredForCancelChecks(t *testing.T) {
+	t.Parallel()
+
+	fakeServer := api.NewFakeAgentServer()
+	defer fakeServer.Close()
+
+	w, _, checker := newTestJobWatcherWithChecker(t, fakeServer)
+
+	kjob := newTestK8sJob(testJobUUID)
+	kjob.Spec.Suspend = ptr.To(true)
+
+	w.runChecks(context.Background(), kjob)
+
+	if got := checker.GetActiveCheckCount(); got != 1 {
+		t.Fatalf("checker.GetActiveCheckCount() = %d, want 1", got)
+	}
+
+	jobUUID := uuid.MustParse(testJobUUID)
+	target, ok := checker.targetFor(jobUUID)
+	if !ok {
+		t.Fatalf("checker has no target for %s", testJobUUID)
+	}
+	if target.kind != cancelTargetJob {
+		t.Errorf("target.kind = %v, want cancelTargetJob", target.kind)
+	}
+	if target.meta.Name != kjob.Name {
+		t.Errorf("target.meta.Name = %q, want %q", target.meta.Name, kjob.Name)
+	}
+}
+
+// Once a pod exists it is the better thing to delete, and a later Job event
+// must not downgrade the registration back to the Job.
+func TestPodTargetIsNotDowngradedByJobEvent(t *testing.T) {
+	t.Parallel()
+
+	fakeServer := api.NewFakeAgentServer()
+	defer fakeServer.Close()
+
+	w, _, checker := newTestJobWatcherWithChecker(t, fakeServer)
+
+	jobUUID := uuid.MustParse(testJobUUID)
+	checker.AddPod(jobUUID, metav1.ObjectMeta{Name: "the-pod", Namespace: "default"})
+
+	kjob := newTestK8sJob(testJobUUID)
+	w.runChecks(context.Background(), kjob)
+
+	target, ok := checker.targetFor(jobUUID)
+	if !ok {
+		t.Fatalf("checker has no target for %s", testJobUUID)
+	}
+	if target.kind != cancelTargetPod {
+		t.Errorf("target.kind = %v, want cancelTargetPod", target.kind)
+	}
+	if target.meta.Name != "the-pod" {
+		t.Errorf("target.meta.Name = %q, want %q", target.meta.Name, "the-pod")
+	}
+}
+
+// A finished Job must be deregistered, so the checker does not keep polling
+// Buildkite for jobs that are already over.
+func TestFinishedJobIsDeregistered(t *testing.T) {
+	t.Parallel()
+
+	fakeServer := api.NewFakeAgentServer()
+	defer fakeServer.Close()
+
+	w, _, checker := newTestJobWatcherWithChecker(t, fakeServer)
+
+	jobUUID := uuid.MustParse(testJobUUID)
+	checker.AddK8sJob(jobUUID, metav1.ObjectMeta{Name: "the-job", Namespace: "default"})
+
+	kjob := newTestK8sJob(testJobUUID)
+	kjob.Status.Succeeded = 1
+	kjob.Status.Conditions = []batchv1.JobCondition{{
+		Type:   batchv1.JobComplete,
+		Status: corev1.ConditionTrue,
+	}}
+
+	w.runChecks(context.Background(), kjob)
+
+	if got := checker.GetActiveCheckCount(); got != 0 {
+		t.Errorf("checker.GetActiveCheckCount() = %d, want 0", got)
 	}
 }

--- a/internal/controller/scheduler/metrics.go
+++ b/internal/controller/scheduler/metrics.go
@@ -244,4 +244,19 @@ var (
 		Name:      "pods_forceful_deletion_errors_total",
 		Help:      "Count of failures to delete pod forcefully by podWatcher",
 	}, []string{"delete_reason", "error_reason"})
+
+	// Deleting a k8s Job directly, rather than its pod, happens when the
+	// Buildkite job was cancelled while the Job had no pod to delete.
+	forcefullyDeletedJobCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: "job_watcher",
+		Name:      "jobs_forcefully_deleted_total",
+		Help:      "Count of forceful k8s job deletions for cancelled Buildkite jobs",
+	}, []string{"delete_reason"})
+	forcefulJobDeletionErrorsCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: "job_watcher",
+		Name:      "jobs_forceful_deletion_errors_total",
+		Help:      "Count of failures to forcefully delete a k8s job",
+	}, []string{"delete_reason", "error_reason"})
 )

--- a/internal/controller/scheduler/pod_watcher.go
+++ b/internal/controller/scheduler/pod_watcher.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/tools/cache"
+	"k8s.io/utils/ptr"
 )
 
 type podWatcher struct {
@@ -90,15 +91,11 @@ type podWatcher struct {
 //   - If a pod is pending, every so often Buildkite will be checked to see if
 //     the corresponding job has been cancelled so that the pod can be evicted
 //     early.
-func NewPodWatcher(logger *slog.Logger, k8s kubernetes.Interface, agentClient *api.AgentClient, cfg *config.Config) *podWatcher {
+func NewPodWatcher(logger *slog.Logger, k8s kubernetes.Interface, agentClient *api.AgentClient, cfg *config.Config, bkJobChecker *BatchBuildkiteJobChecker) *podWatcher {
 	imagePullBackOffGracePeriod := cfg.ImagePullBackOffGracePeriod
 	podPendingTimeout := cfg.PodPendingTimeout
 	if imagePullBackOffGracePeriod <= 0 {
 		imagePullBackOffGracePeriod = config.DefaultImagePullBackOffGracePeriod
-	}
-	jobCancelCheckerInterval := cfg.JobCancelCheckerPollInterval
-	if jobCancelCheckerInterval <= 0 {
-		jobCancelCheckerInterval = config.DefaultJobCancelCheckerPollInterval
 	}
 	if podPendingTimeout <= 0 {
 		podPendingTimeout = config.DefaultPodPendingTimeout
@@ -116,14 +113,11 @@ func NewPodWatcher(logger *slog.Logger, k8s kubernetes.Interface, agentClient *a
 		imageFailureNotified:        make(map[uuid.UUID]struct{}),
 		watchingForPendingTimeout:   make(map[uuid.UUID]*corev1.Pod),
 	}
-	pw.batchBkJobChecker = NewBatchBuildkiteJobChecker(logger, agentClient, k8s, jobCancelCheckerInterval)
+	pw.batchBkJobChecker = bkJobChecker
 	podWatcherIgnoredJobsGaugeFunc = func() int {
 		pw.ignoredJobsMu.RLock()
 		defer pw.ignoredJobsMu.RUnlock()
 		return len(pw.ignoredJobs)
-	}
-	jobCancelCheckerGaugeFunc = func() int {
-		return pw.batchBkJobChecker.GetActiveCheckCount()
 	}
 	watchingForImageFailureGaugeFunc = func() int {
 		pw.watchingForImageFailureMu.Lock()
@@ -168,11 +162,6 @@ func (w *podWatcher) OnDelete(previousState any) {
 
 	// The pod is gone, so we can stop ignoring it (if it comes back).
 	w.unignoreJob(jobUUID)
-}
-
-// Start batch buildkite job checker, no-op when stack api is off.
-func (w *podWatcher) StartBuildkiteJobChecker(ctx context.Context) {
-	w.batchBkJobChecker.StartChecking(ctx)
 }
 
 func (w *podWatcher) OnAdd(currentState any, _ bool) {
@@ -242,7 +231,7 @@ func (w *podWatcher) runChecks(ctx context.Context, pod *corev1.Pod) {
 	case corev1.PodPending:
 		w.watchForImageFailure(jobUUID, pod)
 		w.watchForPendingTimeout(jobUUID, pod)
-		w.batchBkJobChecker.AddJob(jobUUID, pod.ObjectMeta)
+		w.batchBkJobChecker.AddPod(jobUUID, pod.ObjectMeta)
 
 	case corev1.PodRunning:
 		w.watchForImageFailure(jobUUID, pod)
@@ -512,6 +501,34 @@ func forcefullyDeletePod(
 		return err
 	}
 	forcefullyDeletedPodCounter.WithLabelValues(reason).Inc()
+
+	return nil
+}
+
+// forcefullyDeleteJob deletes a k8s Job and, with Background propagation, any
+// pods it owns. Used when a Buildkite job is cancelled before its k8s Job ever
+// produced a pod, so there is nothing for forcefullyDeletePod to act on.
+func forcefullyDeleteJob(
+	ctx context.Context,
+	log *slog.Logger,
+	k8s kubernetes.Interface,
+	jobMetadata *metav1.ObjectMeta,
+	reason string,
+) error {
+	deleteOptions := metav1.DeleteOptions{
+		GracePeriodSeconds: new(int64), // zero value
+		// Without this the pods are orphaned rather than removed, which is the
+		// opposite of the intent: the point is to stop the job consuming
+		// cluster resources.
+		PropagationPolicy: ptr.To(metav1.DeletePropagationBackground),
+	}
+
+	if err := k8s.BatchV1().Jobs(jobMetadata.Namespace).Delete(ctx, jobMetadata.Name, deleteOptions); err != nil {
+		log.Error("Couldn't forcefully delete job", "error", err)
+		forcefulJobDeletionErrorsCounter.WithLabelValues(reason, string(kerrors.ReasonForError(err))).Inc()
+		return err
+	}
+	forcefullyDeletedJobCounter.WithLabelValues(reason).Inc()
 
 	return nil
 }


### PR DESCRIPTION
## Change

Register k8s Jobs that have no pod with the Buildkite job cancel checker, so cancelling a build cleans them up.

`BatchBuildkiteJobChecker` already polls, but the only thing that registers a job with it is `podWatcher.runChecks`, on a `PodPending` pod. A Job that has not produced a pod is therefore never checked at all.

- `jobWatcher` registers a Job with the checker while it has no pod, and deregisters on finish or delete.
- Both watchers share one checker instance, constructed in `controller.go`, so each Buildkite job has a single registration and cannot be acted on by two paths at once.
- The checker now records *what* to delete. A pod where one exists — still preferred, since `scheduler.go` sets `BackoffLimit=0`, so deleting the pod also terminates the Job — and the k8s Job otherwise, with `Background` propagation.
- `AddK8sJob` never downgrades an existing pod registration. Pod and Job events arrive independently, so a stale Job event must not replace a pod target installed by a later pod event.
- Two counters under a `job_watcher` subsystem for Job deletions and their errors.

## Context

Registration keyed on a pod is sound when a Job and its pod are created together: "there is a pod now" and "there will ever be a pod" are the same statement.

An admission controller breaks that equivalence. Under [Kueue](https://kueue.sigs.k8s.io/) a Job is created suspended and stays that way until quota frees up, which on a scarce accelerator pool can be hours. Under MultiKueue the manager-side Job additionally carries `spec.managedBy`, so it never produces a local pod at all — the pod runs on a worker cluster.

Cancelling such a build currently does nothing. No pod event ever fires, the checker never learns the job exists, and the job runs in full whenever it is eventually admitted. The agent then starts, polls, discovers the cancellation, and exits immediately — after a node scale-up. On our TPU pool that is roughly 3.5 minutes of accelerator provisioning per cancelled job, and worse, the cancelled job takes a quota slot ahead of work that is still wanted.

Worth noting this is not specific to MultiKueue, or even to Kueue. Any delay between Job creation and pod creation opens the same window; there is a narrow race even with no admission controller, if a build is cancelled in between. Kueue just widens it from milliseconds to hours.

This is the same class of problem as #392, which the pod-based cancel checker fixed for jobs whose pod exists. This closes the remaining case where there is no pod to fire an event.

Opened as a draft: happy to adjust the approach if you would rather the registration live somewhere other than `jobWatcher`, or if sharing one checker between the watchers cuts against a direction you have in mind.

## Testing

- `go build ./...`, `go vet ./...` clean.
- All unit packages pass. `internal/integration` was not run; it needs a live cluster and the `-ldflags` branch name.
- Three tests added to `job_watcher_test.go`: a podless Job is registered with a Job target; a Job event does not downgrade a pod target; a finished Job is deregistered.

Not yet exercised against a live cluster with Kueue — that is the main thing I would want a reviewer to be skeptical about, and I am happy to run it in our environment before this leaves draft.

## Affiliation (optional, external contributors)

Google, running the vLLM `tpu-inference` TPU CI on Agent Stack + Kueue/MultiKueue.

## Disclosures / Credits

Implemented with AI assistance (Claude Code); the diagnosis, design decisions, and review are mine. Prior art: #392, #382, #133.

🤖 Generated with [Claude Code](https://claude.com/claude-code)