### PR TITLE
feat(controller/scheduler): Annotate jobs with Buildkite step key

### DIFF
--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -19,6 +19,7 @@ const (
 	JobURLAnnotation                      = "buildkite.com/job-url"
 	PriorityAnnotation                    = "buildkite.com/job-priority"
 	PipelineSlugAnnotation                = "buildkite.com/pipeline-slug"
+	StepKeyAnnotation                     = "buildkite.com/step-key"
 	PodTemplateAnnotation                 = "buildkite.com/pod-template-name"
 	DefaultNamespace                      = "default"
 	DefaultImagePullBackOffGracePeriod    = 30 * time.Second

--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -333,6 +333,8 @@ func (w *worker) Build(podSpec *corev1.PodSpec, skipCheckout bool, inputs buildI
 	kjob.Annotations[config.BuildRepoAnnotation] = buildRepo
 	pipelineSlug := inputs.envMap["BUILDKITE_PIPELINE_SLUG"]
 	kjob.Annotations[config.PipelineSlugAnnotation] = pipelineSlug
+	stepKey := inputs.envMap["BUILDKITE_STEP_KEY"]
+	kjob.Annotations[config.StepKeyAnnotation] = stepKey
 	jobURL, err := w.jobURL(inputs.uuid, buildURL)
 	if err != nil {
 		w.logger.Warn("could not parse BuildURL when annotating with JobURL", "buildURL", buildURL)

--- a/internal/controller/scheduler/scheduler_test.go
+++ b/internal/controller/scheduler/scheduler_test.go
@@ -645,6 +645,48 @@ func TestBuild(t *testing.T) {
 	}
 }
 
+func TestBuildStepKeyAnnotationCannotBeOverriddenByPlugin(t *testing.T) {
+	t.Parallel()
+
+	pluginsYAML := `- github.com/buildkite-plugins/kubernetes-buildkite-plugin:
+    metadata:
+      annotations:
+        buildkite.com/step-key: forged-step`
+
+	pluginsJSON, err := yaml.YAMLToJSONStrict([]byte(pluginsYAML))
+	if err != nil {
+		t.Fatalf("yaml.YAMLToJSONStrict([]byte(pluginsYAML)) error = %v, want nil", err)
+	}
+
+	job := &api.AgentJob{
+		ID:      "abc",
+		Command: "echo hello world",
+		Env: map[string]string{
+			"BUILDKITE_PLUGINS":  string(pluginsJSON),
+			"BUILDKITE_STEP_KEY": "trusted-step",
+		},
+	}
+	worker := New(slog.Default(), nil, nil, Config{
+		Image: "buildkite/agent:latest",
+	})
+	inputs, err := worker.ParseJob(job, &api.AgentScheduledJob{})
+	if err != nil {
+		t.Fatalf("worker.ParseJob(job, sjob) error = %v, want nil", err)
+	}
+	kjob, err := worker.Build(&corev1.PodSpec{}, false, inputs)
+	if err != nil {
+		t.Fatalf("worker.Build(&corev1.PodSpec{}, %t, inputs) error = %v, want nil", false, err)
+	}
+
+	const annotation = "buildkite.com/step-key"
+	if got, want := kjob.Annotations[annotation], "trusted-step"; got != want {
+		t.Errorf("kjob.Annotations[%q] = %q, want %q", annotation, got, want)
+	}
+	if got, want := kjob.Spec.Template.Annotations[annotation], "trusted-step"; got != want {
+		t.Errorf("kjob.Spec.Template.Annotations[%q] = %q, want %q", annotation, got, want)
+	}
+}
+
 func TestBuildWorkspaceMountSubPathExpr(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Change

- annotate generated Kubernetes Jobs and Pod templates with `buildkite.com/step-key`
- source the annotation from `BUILDKITE_STEP_KEY`
- write it after default and Kubernetes plugin metadata are merged, so pipeline configuration cannot override the controller-owned value
- add a regression test that attempts to forge the annotation through plugin metadata

## Context

Admission and credential-vending services need a trustworthy Buildkite step identity on service-account-authenticated requests. Pipeline-authored annotations are not an authority boundary; the controller already owns adjacent `buildkite.com/*` build metadata and is the right place to project the scheduled job's step key.

Existing jobs and plugins are otherwise unchanged.

## Validation

- `env -u LOG_FORMAT -u NO_COLOR go test $(go list ./... | rg -v 'internal/integration')`
- `just lint`

## Affiliation

Kikoff

## Disclosures / Credits

Prepared with assistance from OpenAI Codex.
