### PR TITLE
Modernise: use t.Context(), new(value)

### DIFF
--- a/api/fake_agent_server_test.go
+++ b/api/fake_agent_server_test.go
@@ -1,7 +1,6 @@
 package api_test
 
 import (
-	"context"
 	"log/slog"
 	"testing"
 
@@ -11,7 +10,7 @@ import (
 )
 
 func TestFakeAgentServer_DefaultBehavior(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create fake server
 	server := api.NewFakeAgentServer()
@@ -47,7 +46,7 @@ func TestFakeAgentServer_DefaultBehavior(t *testing.T) {
 }
 
 func TestFakeAgentServer_RecordsCalls(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	server := api.NewFakeAgentServer()
 	defer server.Close()
@@ -82,7 +81,7 @@ func TestFakeAgentServer_RecordsCalls(t *testing.T) {
 }
 
 func TestFakeAgentServer_CustomError(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	server := api.NewFakeAgentServer()
 	defer server.Close()
@@ -111,7 +110,7 @@ func TestFakeAgentServer_CustomError(t *testing.T) {
 }
 
 func TestFakeAgentServer_CustomResult(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	server := api.NewFakeAgentServer()
 	defer server.Close()

--- a/api/stack_notification_batcher_test.go
+++ b/api/stack_notification_batcher_test.go
@@ -27,7 +27,7 @@ func TestNotificationBatcher_SendsBatchesPeriodically(t *testing.T) {
 
 	nb := newNotificationBatcher("test-stack", client, slog.Default())
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	if err := nb.start(ctx); err != nil {
@@ -75,7 +75,7 @@ func TestNotificationBatcher_ChunksBatchesBySize(t *testing.T) {
 
 	nb := newNotificationBatcher("test-stack", client, slog.Default())
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	if err := nb.start(ctx); err != nil {

--- a/internal/controller/config/agent_config_test.go
+++ b/internal/controller/config/agent_config_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/utils/ptr"
 )
 
 func envValue(ctr *corev1.Container, name string) (string, bool) {
@@ -18,9 +17,9 @@ func envValue(ctr *corev1.Container, name string) (string, bool) {
 
 func TestApplyToAgentStart_Tracing(t *testing.T) {
 	agentConfig := &AgentConfig{
-		TracingBackend:              ptr.To("opentelemetry"),
-		TracingServiceName:          ptr.To("my-service"),
-		TracingPropagateTraceparent: ptr.To(true),
+		TracingBackend:              new("opentelemetry"),
+		TracingServiceName:          new("my-service"),
+		TracingPropagateTraceparent: new(true),
 	}
 
 	ctr := &corev1.Container{}

--- a/internal/controller/deduper/deduper_test.go
+++ b/internal/controller/deduper/deduper_test.go
@@ -1,7 +1,6 @@
 package deduper_test
 
 import (
-	"context"
 	"log/slog"
 	"testing"
 
@@ -14,8 +13,7 @@ import (
 func TestDeduper_SkipsDuplicateJobs(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	fakeSched := model.NewFakeScheduler(0, nil)
 	dd := deduper.New(slog.Default(), fakeSched)

--- a/internal/controller/reserver/reserver_test.go
+++ b/internal/controller/reserver/reserver_test.go
@@ -24,7 +24,7 @@ func (f *fakeHandler) Pause(pause bool) {}
 func TestReserver_ChunksJobsInto1000(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create fake server
 	server := api.NewFakeAgentServer()
@@ -76,7 +76,7 @@ func TestReserver_ChunksJobsInto1000(t *testing.T) {
 func TestReserver_PassesReservationExpirySeconds(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	server := api.NewFakeAgentServer()
 	defer server.Close()

--- a/internal/controller/scheduler/job_watcher.go
+++ b/internal/controller/scheduler/job_watcher.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
-	"k8s.io/utils/ptr"
 )
 
 // jobWatcher watches k8s jobs for failure to start a pod. The corresponding
@@ -559,7 +558,7 @@ func (w *jobWatcher) cleanupStalledJob(ctx context.Context, kjob *batchv1.Job) {
 		// activeDeadlineSeconds applies from the start of the job. But the
 		// job is only cleaned up though TTLSecondsAfterFinished, which is way
 		// in the future.
-		job.Spec.ActiveDeadlineSeconds = ptr.To[int64](1)
+		job.Spec.ActiveDeadlineSeconds = new(int64(1))
 		_, err = w.k8s.BatchV1().Jobs(kjob.Namespace).Update(ctx, job, metav1.UpdateOptions{})
 		return err
 	}); err != nil {

--- a/internal/controller/scheduler/job_watcher_test.go
+++ b/internal/controller/scheduler/job_watcher_test.go
@@ -1,7 +1,6 @@
 package scheduler
 
 import (
-	"context"
 	"errors"
 	"log/slog"
 	"os"
@@ -18,7 +17,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
-	"k8s.io/utils/ptr"
 )
 
 const testJobUUID = "019f719c-0000-0000-0000-000000000000"
@@ -31,7 +29,7 @@ func newTestJobWatcher(t *testing.T, fakeServer *api.FakeAgentServer) (*jobWatch
 
 func newTestJobWatcherWithChecker(t *testing.T, fakeServer *api.FakeAgentServer) (*jobWatcher, *fake.Clientset, *BatchBuildkiteJobChecker) {
 	t.Helper()
-	ctx := context.Background()
+	ctx := t.Context()
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 
 	agentClient, err := api.NewAgentClient(ctx, api.AgentClientOpts{
@@ -214,7 +212,7 @@ func TestCleanupStalledJobs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			server := api.NewFakeAgentServer()
 			defer server.Close()
 
@@ -241,7 +239,7 @@ func TestCleanupStalledJobs(t *testing.T) {
 					live.Status.Active = 1
 				}
 				if tt.liveTerminating {
-					live.Status.Terminating = ptr.To[int32](1)
+					live.Status.Terminating = new(int32(1))
 				}
 				if tt.jobReplaced {
 					live.UID = "replacement-uid"
@@ -295,7 +293,7 @@ func TestCleanupStalledJobs(t *testing.T) {
 // UID). The skip must not remove the replacement's entry, or a genuinely
 // stalled replacement would never be checked again.
 func TestCleanupStalledJobs_ReplacementAddedDuringCheck(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	server := api.NewFakeAgentServer()
 	defer server.Close()
 	server.JobStates = map[string]string{testJobUUID: "scheduled"}
@@ -349,9 +347,9 @@ func TestPodlessJobIsRegisteredForCancelChecks(t *testing.T) {
 	w, _, checker := newTestJobWatcherWithChecker(t, fakeServer)
 
 	kjob := newTestK8sJob(testJobUUID)
-	kjob.Spec.Suspend = ptr.To(true)
+	kjob.Spec.Suspend = new(true)
 
-	w.runChecks(context.Background(), kjob)
+	w.runChecks(t.Context(), kjob)
 
 	if got := checker.GetActiveCheckCount(); got != 1 {
 		t.Fatalf("checker.GetActiveCheckCount() = %d, want 1", got)
@@ -384,7 +382,7 @@ func TestPodTargetIsNotDowngradedByJobEvent(t *testing.T) {
 	checker.AddPod(jobUUID, metav1.ObjectMeta{Name: "the-pod", Namespace: "default"})
 
 	kjob := newTestK8sJob(testJobUUID)
-	w.runChecks(context.Background(), kjob)
+	w.runChecks(t.Context(), kjob)
 
 	target, ok := checker.targetFor(jobUUID)
 	if !ok {
@@ -418,7 +416,7 @@ func TestFinishedJobIsDeregistered(t *testing.T) {
 		Status: corev1.ConditionTrue,
 	}}
 
-	w.runChecks(context.Background(), kjob)
+	w.runChecks(t.Context(), kjob)
 
 	if got := checker.GetActiveCheckCount(); got != 0 {
 		t.Errorf("checker.GetActiveCheckCount() = %d, want 0", got)

--- a/internal/controller/scheduler/pod_watcher_test.go
+++ b/internal/controller/scheduler/pod_watcher_test.go
@@ -8,7 +8,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 )
 
 func TestPodHasExceededPendingTimeout(t *testing.T) {
@@ -144,7 +143,7 @@ func TestIsSidecarInitContainer(t *testing.T) {
 				{Name: "checkout"},
 				{
 					Name:          "sidecar-0",
-					RestartPolicy: ptr.To(corev1.ContainerRestartPolicyAlways),
+					RestartPolicy: new(corev1.ContainerRestartPolicyAlways),
 				},
 				{Name: "imagecheck-0"},
 			},

--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -33,7 +33,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/yaml"
 )
 
@@ -350,7 +349,7 @@ func (w *worker) Build(podSpec *corev1.PodSpec, skipCheckout bool, inputs buildI
 
 	kjob.Spec.Template.Labels = kjob.Labels
 	kjob.Spec.Template.Annotations = kjob.Annotations
-	kjob.Spec.BackoffLimit = ptr.To[int32](0)
+	kjob.Spec.BackoffLimit = new(int32(0))
 
 	if podSpec.TerminationGracePeriodSeconds == nil {
 		podSpec.TerminationGracePeriodSeconds = new(int64(w.cfg.DefaultTerminationGracePeriodSeconds))
@@ -515,7 +514,7 @@ func (w *worker) Build(podSpec *corev1.PodSpec, skipCheckout bool, inputs buildI
 			maps.Copy(kjob.Spec.Template.Annotations, sidecarAnnotation)
 
 			// Per https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/
-			c.RestartPolicy = ptr.To(corev1.ContainerRestartPolicyAlways)
+			c.RestartPolicy = new(corev1.ContainerRestartPolicyAlways)
 			podSpec.InitContainers = append(podSpec.InitContainers, c)
 
 			sidecarCounterCount += 1
@@ -960,8 +959,8 @@ func (w *worker) createWorkspaceSetupContainer(podSpec *corev1.PodSpec, workspac
 	case podUser != 0 && podGroup != 0:
 		// The init container needs to be run as root to create the user and give it ownership to the workspace directory
 		securityContext = &corev1.SecurityContext{
-			RunAsUser:    ptr.To[int64](0),
-			RunAsGroup:   ptr.To[int64](0),
+			RunAsUser:    new(int64(0)),
+			RunAsGroup:   new(int64(0)),
 			RunAsNonRoot: new(false),
 		}
 
@@ -970,8 +969,8 @@ func (w *worker) createWorkspaceSetupContainer(podSpec *corev1.PodSpec, workspac
 	case podUser != 0 && podGroup == 0:
 		//The init container needs to be run as root to create the user and give it ownership to the workspace directory
 		securityContext = &corev1.SecurityContext{
-			RunAsUser:    ptr.To[int64](0),
-			RunAsGroup:   ptr.To[int64](0),
+			RunAsUser:    new(int64(0)),
+			RunAsGroup:   new(int64(0)),
 			RunAsNonRoot: new(false),
 		}
 
@@ -1133,8 +1132,8 @@ func (w *worker) createCheckoutContainer(
 	case podUser != 0:
 		// The checkout container needs to be run as root to create the user. After that, it switches to the user.
 		checkoutContainer.SecurityContext = &corev1.SecurityContext{
-			RunAsUser:    ptr.To[int64](0),
-			RunAsGroup:   ptr.To[int64](0),
+			RunAsUser:    new(int64(0)),
+			RunAsGroup:   new(int64(0)),
 			RunAsNonRoot: new(false),
 		}
 

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -19,7 +19,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/utils/ptr"
 )
 
 func TestWalkingSkeleton(t *testing.T) {
@@ -29,7 +28,7 @@ func TestWalkingSkeleton(t *testing.T) {
 		Repo:    repoHTTP,
 		GraphQL: api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
 	}.Init()
-	ctx := context.Background()
+	ctx := t.Context()
 	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)
 	tc.StartController(ctx, cfg)
 	build := tc.TriggerBuild(ctx, pipelineID)
@@ -43,7 +42,7 @@ func TestUbuntuAgentImage(t *testing.T) {
 		Repo:    repoHTTP,
 		GraphQL: api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
 	}.Init()
-	ctx := context.Background()
+	ctx := t.Context()
 	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)
 
 	testCfg := cfg
@@ -61,7 +60,7 @@ func TestResourceClass(t *testing.T) {
 		Repo:    repoHTTP,
 		GraphQL: api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
 	}.Init()
-	ctx := context.Background()
+	ctx := t.Context()
 	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)
 
 	// Configure resource classes for the test
@@ -98,7 +97,7 @@ func TestDefaultResourceClass(t *testing.T) {
 		Repo:    repoHTTP,
 		GraphQL: api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
 	}.Init()
-	ctx := context.Background()
+	ctx := t.Context()
 	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)
 
 	testCfg := cfg
@@ -132,7 +131,7 @@ func TestPodResourceClass(t *testing.T) {
 		Repo:    repoHTTP,
 		GraphQL: api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
 	}.Init()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	sv, err := tc.Kubernetes.Discovery().ServerVersion()
 	if err != nil {
@@ -178,7 +177,7 @@ func TestPodTemplate(t *testing.T) {
 		Repo:    repoHTTP,
 		GraphQL: api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
 	}.Init()
-	ctx := context.Background()
+	ctx := t.Context()
 	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)
 	tc.StartController(ctx, cfg)
 	build := tc.TriggerBuild(ctx, pipelineID)
@@ -198,7 +197,7 @@ func TestDefaultQueue(t *testing.T) {
 		GraphQL:     api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
 		CustomQueue: "default",
 	}.Init()
-	ctx := context.Background()
+	ctx := t.Context()
 	// Note: this shouldn't interfere with the stack running the tests, because
 	// the stack uses the "kubernetes" queue.
 	// We provide a custom tag to ensure this run of the test controller picks
@@ -227,7 +226,7 @@ func TestExplicitDefaultQueue(t *testing.T) {
 		GraphQL:     api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
 		CustomQueue: "default",
 	}.Init()
-	ctx := context.Background()
+	ctx := t.Context()
 	pipeline := tc.createPipelineWithCleanup(ctx, "default", map[string]string{
 		// You may wonder what this pseudoQueue is.
 		// Since in this particular test case, the queue is static, without extra tag, we will be effectively limiting
@@ -251,7 +250,7 @@ func TestPodSpecPatchInStep(t *testing.T) {
 		Repo:    repoHTTP,
 		GraphQL: api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
 	}.Init()
-	ctx := context.Background()
+	ctx := t.Context()
 	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)
 	tc.StartController(ctx, cfg)
 	build := tc.TriggerBuild(ctx, pipelineID)
@@ -268,7 +267,7 @@ func TestPodSpecPatchAllowsPatchingCommandContainerCommands(t *testing.T) {
 		GraphQL: api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
 	}.Init()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)
 
 	tc.StartController(ctx, cfg)
@@ -286,7 +285,7 @@ func TestPodSpecPatchRejectsPatchingAgentContainerCommand(t *testing.T) {
 		GraphQL: api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
 	}.Init()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)
 
 	tc.StartController(ctx, cfg)
@@ -306,7 +305,7 @@ func TestPodSpecPatchInController(t *testing.T) {
 		Repo:    repoHTTP,
 		GraphQL: api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
 	}.Init()
-	ctx := context.Background()
+	ctx := t.Context()
 	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)
 	cfg := cfg
 	cfg.PodSpecPatch = &corev1.PodSpec{
@@ -337,7 +336,7 @@ func TestPodSpecPatchWithoutContainers(t *testing.T) {
 		Repo:    repoHTTP,
 		GraphQL: api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
 	}.Init()
-	ctx := context.Background()
+	ctx := t.Context()
 	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)
 	cfg := cfg
 	cfg.PodSpecPatch = &corev1.PodSpec{
@@ -365,7 +364,7 @@ func TestControllerPicksUpJobsWithSubsetOfAgentTags(t *testing.T) {
 		GraphQL: api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
 	}.Init()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)
 
 	cfg := cfg
@@ -384,7 +383,7 @@ func TestControllerSetsAdditionalRedactedVars(t *testing.T) {
 		GraphQL: api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
 	}.Init()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)
 
 	cfg := cfg
@@ -412,7 +411,7 @@ func TestChown(t *testing.T) {
 		Repo:    repoHTTP,
 		GraphQL: api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
 	}.Init()
-	ctx := context.Background()
+	ctx := t.Context()
 	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)
 	tc.StartController(ctx, cfg)
 	build := tc.TriggerBuild(ctx, pipelineID)
@@ -428,7 +427,7 @@ func TestSSHRepoClone(t *testing.T) {
 		GraphQL: api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
 	}.Init()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := tc.Kubernetes.CoreV1().
 		Secrets(cfg.Namespace).
 		Get(ctx, "integration-test-ssh-key", metav1.GetOptions{})
@@ -450,7 +449,7 @@ func TestPluginCloneFailsTests(t *testing.T) {
 		GraphQL: api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
 	}.Init()
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)
 	tc.StartController(ctx, cfg)
@@ -466,7 +465,7 @@ func TestMaxInFlightLimited(t *testing.T) {
 		GraphQL: api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
 	}.Init()
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)
 	cfg := cfg
@@ -514,7 +513,7 @@ func TestMaxInFlightUnlimited(t *testing.T) {
 		GraphQL: api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
 	}.Init()
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)
 	cfg := cfg
@@ -576,7 +575,7 @@ func TestSidecars(t *testing.T) {
 		Repo:    repoHTTP,
 		GraphQL: api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
 	}.Init()
-	ctx := context.Background()
+	ctx := t.Context()
 	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)
 	tc.StartController(ctx, cfg)
 	build := tc.TriggerBuild(ctx, pipelineID)
@@ -591,7 +590,7 @@ func TestExtraVolumeMounts(t *testing.T) {
 		Repo:    repoHTTP,
 		GraphQL: api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
 	}.Init()
-	ctx := context.Background()
+	ctx := t.Context()
 	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)
 	tc.StartController(ctx, cfg)
 	build := tc.TriggerBuild(ctx, pipelineID)
@@ -605,7 +604,7 @@ func TestExtraVolumeMountsCommandContainers(t *testing.T) {
 		Repo:    repoHTTP,
 		GraphQL: api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
 	}.Init()
-	ctx := context.Background()
+	ctx := t.Context()
 	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)
 	tc.StartController(ctx, cfg)
 	build := tc.TriggerBuild(ctx, pipelineID)
@@ -619,7 +618,7 @@ func TestExtraVolumeMountsSidecars(t *testing.T) {
 		Repo:    repoHTTP,
 		GraphQL: api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
 	}.Init()
-	ctx := context.Background()
+	ctx := t.Context()
 	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)
 	tc.StartController(ctx, cfg)
 	build := tc.TriggerBuild(ctx, pipelineID)
@@ -633,7 +632,7 @@ func TestInvalidPodSpec(t *testing.T) {
 		Repo:    repoHTTP,
 		GraphQL: api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
 	}.Init()
-	ctx := context.Background()
+	ctx := t.Context()
 	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)
 	tc.StartController(ctx, cfg)
 	build := tc.TriggerBuild(ctx, pipelineID)
@@ -652,7 +651,7 @@ func TestInvalidPodJSON(t *testing.T) {
 		Repo:    repoHTTP,
 		GraphQL: api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
 	}.Init()
-	ctx := context.Background()
+	ctx := t.Context()
 	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)
 	tc.StartController(ctx, cfg)
 	build := tc.TriggerBuild(ctx, pipelineID)
@@ -671,7 +670,7 @@ func TestMissingServiceAccount(t *testing.T) {
 		Repo:    repoHTTP,
 		GraphQL: api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
 	}.Init()
-	ctx := context.Background()
+	ctx := t.Context()
 	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)
 	tc.StartController(ctx, cfg)
 	build := tc.TriggerBuild(ctx, pipelineID)
@@ -690,7 +689,7 @@ func TestEnvVariables(t *testing.T) {
 		Repo:    repoHTTP,
 		GraphQL: api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
 	}.Init()
-	ctx := context.Background()
+	ctx := t.Context()
 	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)
 	tc.StartController(ctx, cfg)
 	build := tc.TriggerBuild(ctx, pipelineID)
@@ -705,7 +704,7 @@ func TestImagePullBackOffFailed(t *testing.T) {
 		Repo:    repoHTTP,
 		GraphQL: api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
 	}.Init()
-	ctx := context.Background()
+	ctx := t.Context()
 	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)
 	tc.StartController(ctx, cfg)
 	build := tc.TriggerBuild(ctx, pipelineID)
@@ -744,7 +743,7 @@ func TestImagePullBackOffRunningSurfacesNotification(t *testing.T) {
 		Repo:    repoHTTP,
 		GraphQL: api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
 	}.Init()
-	ctx := context.Background()
+	ctx := t.Context()
 	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)
 
 	containerStartTimeout := 60 * time.Second
@@ -780,7 +779,7 @@ func TestCreateContainerConfigErrorFailed(t *testing.T) {
 		Repo:    repoHTTP,
 		GraphQL: api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
 	}.Init()
-	ctx := context.Background()
+	ctx := t.Context()
 	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)
 	tc.StartController(ctx, cfg)
 	build := tc.TriggerBuild(ctx, pipelineID)
@@ -802,7 +801,7 @@ func TestPodPendingTimeoutFailed(t *testing.T) {
 		Repo:    repoHTTP,
 		GraphQL: api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
 	}.Init()
-	ctx := context.Background()
+	ctx := t.Context()
 	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)
 
 	testCfg := cfg
@@ -828,7 +827,7 @@ func TestPullPolicyNeverMissingImage(t *testing.T) {
 		Repo:    repoHTTP,
 		GraphQL: api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
 	}.Init()
-	ctx := context.Background()
+	ctx := t.Context()
 	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)
 	tc.StartController(ctx, cfg)
 	build := tc.TriggerBuild(ctx, pipelineID)
@@ -853,7 +852,7 @@ func TestBrokenInitContainer(t *testing.T) {
 		Repo:    repoHTTP,
 		GraphQL: api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
 	}.Init()
-	ctx := context.Background()
+	ctx := t.Context()
 	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)
 	tc.StartController(ctx, cfg)
 	build := tc.TriggerBuild(ctx, pipelineID)
@@ -875,7 +874,7 @@ func TestInvalidImageRefFormat(t *testing.T) {
 		Repo:    repoHTTP,
 		GraphQL: api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
 	}.Init()
-	ctx := context.Background()
+	ctx := t.Context()
 	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)
 	tc.StartController(ctx, cfg)
 	build := tc.TriggerBuild(ctx, pipelineID)
@@ -894,7 +893,7 @@ func TestArtifactsUploadFailedJobs(t *testing.T) {
 		Repo:    repoHTTP,
 		GraphQL: api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
 	}.Init()
-	ctx := context.Background()
+	ctx := t.Context()
 	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)
 	tc.StartController(ctx, cfg)
 	build := tc.TriggerBuild(ctx, pipelineID)
@@ -909,7 +908,7 @@ func TestInterposerBuildkite(t *testing.T) {
 		Repo:    repoHTTP,
 		GraphQL: api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
 	}.Init()
-	ctx := context.Background()
+	ctx := t.Context()
 	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)
 	tc.StartController(ctx, cfg)
 	build := tc.TriggerBuild(ctx, pipelineID)
@@ -934,7 +933,7 @@ func TestInterposerVector(t *testing.T) {
 		Repo:    repoHTTP,
 		GraphQL: api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
 	}.Init()
-	ctx := context.Background()
+	ctx := t.Context()
 	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)
 	tc.StartController(ctx, cfg)
 	build := tc.TriggerBuild(ctx, pipelineID)
@@ -955,7 +954,7 @@ func TestCancelCheckerDeletePod(t *testing.T) {
 		Repo:    repoHTTP,
 		GraphQL: api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
 	}.Init()
-	ctx := context.Background()
+	ctx := t.Context()
 	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)
 	tc.StartController(ctx, cfg)
 	build := tc.TriggerBuild(ctx, pipelineID)
@@ -1026,7 +1025,7 @@ func TestPodKilledBeforeAgentReleasesBKJob(t *testing.T) {
 		Repo:    repoHTTP,
 		GraphQL: api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
 	}.Init()
-	ctx := context.Background()
+	ctx := t.Context()
 	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)
 	tc.StartController(ctx, cfg)
 	build := tc.TriggerBuild(ctx, pipelineID)
@@ -1090,7 +1089,7 @@ func TestJobActiveDeadlineSeconds(t *testing.T) {
 		Repo:    repoHTTP,
 		GraphQL: api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
 	}.Init()
-	ctx := context.Background()
+	ctx := t.Context()
 	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)
 	tc.StartController(ctx, cfg)
 	build := tc.TriggerBuild(ctx, pipelineID)
@@ -1104,7 +1103,7 @@ func TestHooksAndPlugins(t *testing.T) {
 		Repo:    repoHTTP,
 		GraphQL: api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
 	}.Init()
-	ctx := context.Background()
+	ctx := t.Context()
 	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)
 	cfg := cfg
 	cfg.AgentConfig = &config.AgentConfig{
@@ -1115,7 +1114,7 @@ func TestHooksAndPlugins(t *testing.T) {
 					LocalObjectReference: corev1.LocalObjectReference{
 						Name: "integration-tests-fixture-hooks",
 					},
-					DefaultMode: ptr.To[int32](0o755),
+					DefaultMode: new(int32(0o755)),
 				},
 			},
 		},
@@ -1152,7 +1151,7 @@ func TestAdditionalHooks(t *testing.T) {
 		Repo:    repoHTTP,
 		GraphQL: api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
 	}.Init()
-	ctx := context.Background()
+	ctx := t.Context()
 	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)
 	cfg := cfg
 	cfg.AgentConfig = &config.AgentConfig{
@@ -1166,7 +1165,7 @@ func TestAdditionalHooks(t *testing.T) {
 							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "integration-tests-fixture-additional-hooks",
 							},
-							DefaultMode: ptr.To[int32](0o755),
+							DefaultMode: new(int32(0o755)),
 						},
 					},
 				},
@@ -1198,7 +1197,7 @@ func TestSkipCheckoutContainer(t *testing.T) {
 		Repo:    repoHTTP,
 		GraphQL: api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
 	}.Init()
-	ctx := context.Background()
+	ctx := t.Context()
 	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)
 	tc.StartController(ctx, cfg)
 	build := tc.TriggerBuild(ctx, pipelineID)
@@ -1213,7 +1212,7 @@ func TestImageAttribute(t *testing.T) {
 		Repo:    repoHTTP,
 		GraphQL: api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
 	}.Init()
-	ctx := context.Background()
+	ctx := t.Context()
 	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)
 	tc.StartController(ctx, cfg)
 	build := tc.TriggerBuild(ctx, pipelineID)
@@ -1241,7 +1240,7 @@ func TestCompletionsWatcherCleansUpSidecars(t *testing.T) {
 		Repo:    repoHTTP,
 		GraphQL: api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
 	}.Init()
-	ctx := context.Background()
+	ctx := t.Context()
 	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)
 
 	// Use a short termination grace period so the test runs faster.
@@ -1302,7 +1301,7 @@ func TestContainerStartTimeout(t *testing.T) {
 		Repo:    repoHTTP,
 		GraphQL: api.NewGraphQLClient(cfg.BuildkiteToken, cfg.GraphQLEndpoint),
 	}.Init()
-	ctx := context.Background()
+	ctx := t.Context()
 	pipelineID := tc.PrepareQueueAndPipelineWithCleanup(ctx)
 
 	timeout := 30 * time.Second

--- a/internal/integration/testcase_test.go
+++ b/internal/integration/testcase_test.go
@@ -153,11 +153,11 @@ func (t testcase) createClusterQueueWithCleanup() *buildkite.ClusterQueue {
 		if t.preserveEphemeralObjects() {
 			return
 		}
-
+		ctx := context.WithoutCancel(t.Context()) // By the time we get here, t.Context() is already cancelled, so detach.
 		if err := roko.NewRetrier(
 			roko.WithMaxAttempts(5),
 			roko.WithStrategy(roko.Constant(5*time.Second)),
-		).DoWithContext(context.Background(), func(r *roko.Retrier) error {
+		).DoWithContext(ctx, func(r *roko.Retrier) error {
 			// There is a small chance that we are deleting queue too soon before queue realize agent has disconnected.
 			_, err := t.Buildkite.ClusterQueues.Delete(t.Org, t.ClusterUUID, *queue.ID)
 			return err
@@ -197,11 +197,11 @@ func (t testcase) createPipelineWithCleanup(ctx context.Context, queueName strin
 		ClusterID:     t.ClusterUUID,
 	})
 	if err != nil {
-		t.Fatalf("t.Buildkite.Pipelines.Create(%q, &buildkite.CreatePipeline{\n\tName:\t\tt.PipelineName,\n\tRepository:\tt.Repo,\n\tProviderSettings: &buildkite.GitHubSettings{\n\t\tTriggerMode: ptr.To(\"none\"),\n\t},\n\tConfiguration:\tsteps.String(),\n\tClusterID:\tt.ClusterUUID,\n}) error = %v, want nil", t.Org, err)
+		t.Fatalf("t.Buildkite.Pipelines.Create(%q, &buildkite.CreatePipeline{\n\tName:\t\tt.PipelineName,\n\tRepository:\tt.Repo,\n\tProviderSettings: &buildkite.GitHubSettings{\n\t\tTriggerMode: new(\"none\"),\n\t},\n\tConfiguration:\tsteps.String(),\n\tClusterID:\tt.ClusterUUID,\n}) error = %v, want nil", t.Org, err)
 	}
 	EnsureCleanup(t.T, func() {
 		if !t.preserveEphemeralObjects() {
-			t.deletePipeline(ctx)
+			t.deletePipeline(context.WithoutCancel(ctx)) // By this point, t.Context() is already cancelled, so detach.
 		}
 	})
 
@@ -260,6 +260,7 @@ func (t testcase) TriggerBuild(ctx context.Context, pipelineGraphQLID string) ap
 		t.Fatalf("api.BuildCreate(ctx, t.GraphQL, api.BuildCreateInput{\n\tAuthor: api.BuildAuthorInput{\n\t\tEmail:\tauthorEmail,\n\t\tName:\tauthorName,\n\t},\n\tPipelineID:\tpipelineGraphQLID,\n\tCommit:\t\t\"HEAD\",\n\tBranch:\t\tbranch,\n\tMessage:\tt.Name(),\n}) error = %v, want nil", err)
 	}
 	EnsureCleanup(t.T, func() {
+		ctx := context.WithoutCancel(ctx) // By this point, t.Context() is already cancelled, so detach.
 		if _, err := api.BuildCancel(ctx, t.GraphQL, api.BuildCancelInput{
 			Id: createBuild.BuildCreate.Build.Id,
 		}); err != nil {
@@ -535,7 +536,7 @@ func ignorableError(err error) bool {
 
 func (t testcase) getAgentTokenIdentity() *agentApi.AgentTokenIdentity {
 	t.Helper()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	token, err := fetchAgentToken(ctx, t.Logger, t.Kubernetes, cfg.Namespace, cfg.AgentTokenSecret)
 	if err != nil {
@@ -554,9 +555,9 @@ func (t testcase) getAgentTokenIdentity() *agentApi.AgentTokenIdentity {
 		t.Fatalf("agentApi.NewAgentTokenClient(agentApi.AgentTokenClientOpts{\n\tToken:\t\ttoken,\n\tEndpoint:\tagentEndpoint,\n}) error = %v, want nil", err)
 	}
 
-	result, _, err := client.GetTokenIdentity(context.Background())
+	result, _, err := client.GetTokenIdentity(t.Context())
 	if err != nil {
-		t.Fatalf("client.GetTokenIdentity(context.Background()) error = %v, want nil", err)
+		t.Fatalf("client.GetTokenIdentity(t.Context()) error = %v, want nil", err)
 	}
 
 	return result


### PR DESCRIPTION
## Change

- Replace `context.Background()` in tests with `t.Context()`.
- Replace `ptr.To` with `new`.

## Context

Noticed while reviewing other code.

## Disclosures / Credits

I did not use an LLM. I did use search and replace.