### PR TITLE
fix: inject POD_NAME for workspace subPathExpr mounts

### DIFF
--- a/charts/agent-stack-k8s/values.schema.json
+++ b/charts/agent-stack-k8s/values.schema.json
@@ -386,7 +386,7 @@
         "workspace-mount-sub-path-expr": {
           "type": "string",
           "default": "",
-          "title": "When set, applied as `subPathExpr` to every /workspace VolumeMount the controller creates, so a shared workspace volume can be sliced into per-pod subdirectories. Typically `$(POD_NAME)`, with POD_NAME supplied via downward API.",
+          "title": "When set, applied as `subPathExpr` to every /workspace VolumeMount the controller creates, so a shared workspace volume can be sliced into per-pod subdirectories. Typically `$(POD_NAME)`; the controller supplies POD_NAME from metadata.name via the downward API unless the container already defines it.",
           "examples": ["", "$(POD_NAME)"]
         },
         "agent-config": {

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -60,6 +60,10 @@ workspace-volume:
           requests:
             storage: 1Gi
 
+# For workspace volumes shared between pods, mount each pod's workspace in its
+# own directory. The controller supplies POD_NAME via the downward API.
+# workspace-mount-sub-path-expr: "$(POD_NAME)"
+
 # Applies to all agents
 agent-config:
   # Setting a custom Agent REST API endpoint is usually only useful if you have

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -98,7 +98,9 @@ type Config struct {
 	WorkspaceVolume *corev1.Volume `json:"workspace-volume" validate:"omitempty"`
 
 	// WorkspaceMountSubPathExpr, when set, is applied as `subPathExpr` to
-	// every /workspace VolumeMount the controller creates.
+	// every /workspace VolumeMount the controller creates. When a final
+	// /workspace mount expands POD_NAME, the scheduler supplies it from the
+	// pod's metadata.name unless the container already defines it.
 	WorkspaceMountSubPathExpr string `json:"workspace-mount-sub-path-expr" validate:"omitempty"`
 
 	AgentConfig            *AgentConfig    `json:"agent-config"             validate:"omitempty"`

--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/buildkite/agent-stack-k8s/v2/api"
 	"github.com/buildkite/agent-stack-k8s/v2/internal/controller/agenttags"
@@ -789,6 +790,10 @@ func (w *worker) Build(podSpec *corev1.PodSpec, skipCheckout bool, inputs buildI
 	// Dedupe VolumeMounts for both InitContainers and Containers
 	podSpec.InitContainers = config.PrepareVolumeMounts(podSpec.InitContainers)
 	podSpec.Containers = config.PrepareVolumeMounts(podSpec.Containers)
+	// Inspect mounts only after patches and deduplication so the environment
+	// matches the mount that will reach Kubernetes.
+	addPodNameEnvForWorkspaceMounts(podSpec.InitContainers)
+	addPodNameEnvForWorkspaceMounts(podSpec.Containers)
 
 	kjob.Spec.Template.Spec = *podSpec
 
@@ -927,6 +932,76 @@ func PatchPodSpec(original *corev1.PodSpec, patch *corev1.PodSpec, cmdParams *co
 	}
 
 	return &patchedSpec, nil
+}
+
+func addPodNameEnvForWorkspaceMounts(containers []corev1.Container) {
+	for i := range containers {
+		container := &containers[i]
+		if slices.ContainsFunc(container.Env, func(env corev1.EnvVar) bool {
+			return env.Name == "POD_NAME"
+		}) {
+			continue
+		}
+
+		for _, mount := range container.VolumeMounts {
+			if mount.MountPath != "/workspace" || !subPathExprExpandsPodName(mount.SubPathExpr) {
+				continue
+			}
+			container.Env = append(container.Env, corev1.EnvVar{
+				Name: "POD_NAME",
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{
+						FieldPath: "metadata.name",
+					},
+				},
+			})
+			break
+		}
+	}
+}
+
+// subPathExprExpandsPodName reports whether Kubernetes will interpret part of
+// expr as a POD_NAME reference.
+func subPathExprExpandsPodName(expr string) bool {
+	for cursor := 0; cursor < len(expr); {
+		reference, next := readSubPathExprToken(expr, cursor)
+		if reference == "POD_NAME" {
+			return true
+		}
+		cursor = next
+	}
+	return false
+}
+
+// readSubPathExprToken returns the variable name at cursor, if any, and the
+// next byte to inspect. Kubernetes treats $$ as an escaped dollar; backslashes
+// have no special meaning during expansion. Parsing mirrors kubelet's
+// SubPathExpr expansion semantics:
+// https://github.com/kubernetes/kubernetes/blob/0f29094e5b73085e3802ecc1298ecae13866bfe6/pkg/kubelet/container/helpers.go#L245-L261
+// https://github.com/kubernetes/kubernetes/blob/0f29094e5b73085e3802ecc1298ecae13866bfe6/third_party/forked/golang/expansion/expand.go#L39-L103
+func readSubPathExprToken(expr string, cursor int) (string, int) {
+	if expr[cursor] != '$' {
+		return "", cursor + 1
+	}
+	if cursor+1 >= len(expr) {
+		return "", len(expr)
+	}
+
+	switch expr[cursor+1] {
+	case '$':
+		return "", cursor + 2
+	case '(':
+		referenceStart := cursor + 2
+		referenceLength := strings.IndexByte(expr[referenceStart:], ')')
+		if referenceLength < 0 {
+			return "", len(expr)
+		}
+		referenceEnd := referenceStart + referenceLength
+		return expr[referenceStart:referenceEnd], referenceEnd + 1
+	default:
+		_, size := utf8.DecodeRuneInString(expr[cursor+1:])
+		return "", cursor + 1 + size
+	}
 }
 
 // workspaceVolumeMount returns the standard /workspace VolumeMount with

--- a/internal/controller/scheduler/scheduler_test.go
+++ b/internal/controller/scheduler/scheduler_test.go
@@ -761,6 +761,104 @@ func TestBuildWorkspaceMountSubPathExpr(t *testing.T) {
 	}
 }
 
+func TestBuildWorkspaceMountSubPathExprAfterPodSpecPatches(t *testing.T) {
+	t.Parallel()
+
+	worker := New(slog.Default(), nil, nil, Config{
+		Image:                     "buildkite/agent:latest",
+		WorkspaceMountSubPathExpr: "$(POD_NAME)",
+		SkipImageCheckContainers:  true,
+		PodSpecPatch: &corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:         "controller-patched",
+				Image:        "alpine:latest",
+				VolumeMounts: workspaceVolumeMounts("$(POD_NAME)"),
+				Env: []corev1.EnvVar{{
+					Name:  "POD_NAME",
+					Value: "controller-value",
+				}},
+			}},
+		},
+	})
+
+	kjob, err := worker.Build(&corev1.PodSpec{}, false, buildInputs{
+		uuid:    "abc",
+		command: "echo hello world",
+		k8sPlugin: &KubernetesPlugin{
+			PodSpecPatch: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:         DefaultCommandContainerName,
+						VolumeMounts: workspaceVolumeMounts("static"),
+					},
+					{
+						Name: "controller-patched",
+						Env: []corev1.EnvVar{{
+							Name:  "POD_NAME",
+							Value: "plugin-value",
+						}},
+					},
+					{
+						Name:         "plugin-patched",
+						Image:        "busybox:latest",
+						VolumeMounts: workspaceVolumeMounts("$(POD_NAME)"),
+						EnvFrom: []corev1.EnvFromSource{{
+							ConfigMapRef: &corev1.ConfigMapEnvSource{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "pod-config"},
+							},
+						}},
+					},
+					{
+						Name:  "other-mount-path",
+						Image: "busybox:latest",
+						VolumeMounts: []corev1.VolumeMount{{
+							Name:        "workspace",
+							MountPath:   "/other",
+							SubPathExpr: "$(POD_NAME)",
+						}},
+					},
+				},
+				InitContainers: []corev1.Container{{
+					Name:         "plugin-patched-init",
+					Image:        "busybox:latest",
+					VolumeMounts: workspaceVolumeMounts("pods/$(POD_NAME)"),
+				}},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("worker.Build() error = %v, want nil", err)
+	}
+
+	controllerPatched := findContainer(t, kjob.Spec.Template.Spec.Containers, "controller-patched")
+	wantPodName := &corev1.EnvVar{Name: "POD_NAME", Value: "plugin-value"}
+	if diff := cmp.Diff(findEnv(t, controllerPatched.Env, "POD_NAME"), wantPodName); diff != "" {
+		t.Errorf("controller-patched POD_NAME diff (-got +want):\n%s", diff)
+	}
+	if got, want := countEnv(controllerPatched.Env, "POD_NAME"), 1; got != want {
+		t.Errorf("controller-patched POD_NAME env count = %d, want %d", got, want)
+	}
+
+	pluginPatched := findContainer(t, kjob.Spec.Template.Spec.Containers, "plugin-patched")
+	assertEnvFieldPath(t, pluginPatched, "POD_NAME", "metadata.name")
+	if got, want := len(pluginPatched.EnvFrom), 1; got != want {
+		t.Errorf("plugin-patched EnvFrom count = %d, want %d", got, want)
+	}
+
+	pluginPatchedInit := findContainer(t, kjob.Spec.Template.Spec.InitContainers, "plugin-patched-init")
+	assertEnvFieldPath(t, pluginPatchedInit, "POD_NAME", "metadata.name")
+
+	otherMountPath := findContainer(t, kjob.Spec.Template.Spec.Containers, "other-mount-path")
+	if got := findEnv(t, otherMountPath.Env, "POD_NAME"); got != nil {
+		t.Errorf("other-mount-path POD_NAME = %v, want nil", got)
+	}
+
+	defaultCommand := findContainer(t, kjob.Spec.Template.Spec.Containers, DefaultCommandContainerName)
+	if got := findEnv(t, defaultCommand.Env, "POD_NAME"); got != nil {
+		t.Errorf("default command POD_NAME = %v, want nil after plugin replaced SubPathExpr", got)
+	}
+}
+
 func TestSubPathExprExpandsPodName(t *testing.T) {
 	t.Parallel()
 
@@ -2124,6 +2222,14 @@ func countEnv(envs []corev1.EnvVar, name string) int {
 		}
 	}
 	return count
+}
+
+func workspaceVolumeMounts(subPathExpr string) []corev1.VolumeMount {
+	return []corev1.VolumeMount{{
+		Name:        "workspace",
+		MountPath:   "/workspace",
+		SubPathExpr: subPathExpr,
+	}}
 }
 
 func hasVolumeNamed(volumes []corev1.Volume, name string) bool {

--- a/internal/controller/scheduler/scheduler_test.go
+++ b/internal/controller/scheduler/scheduler_test.go
@@ -501,13 +501,13 @@ func TestTagEnv(t *testing.T) {
 func assertEnvFieldPath(t *testing.T, container corev1.Container, envVarName, fieldPath string) {
 	t.Helper()
 
+	if got, want := countEnv(container.Env, envVarName), 1; got != want {
+		t.Errorf("%s env count = %d, want %d", envVarName, got, want)
+		if got == 0 {
+			return
+		}
+	}
 	env := findEnv(t, container.Env, envVarName)
-	if got := env; got == nil {
-		t.Errorf("findEnv(t, container.Env, %q) = %v, want non-nil value", envVarName, got)
-	}
-	if env == nil {
-		return
-	}
 	if got, want := env.Value, ""; got != want {
 		t.Errorf("env.Value = %q, want %q", got, want)
 	}
@@ -519,7 +519,7 @@ func assertEnvFieldPath(t *testing.T, container corev1.Container, envVarName, fi
 		t.Errorf("env.ValueFrom.FieldRef = %v, want non-nil value", got)
 		return
 	}
-	if got, want := fieldPath, env.ValueFrom.FieldRef.FieldPath; got != want {
+	if got, want := env.ValueFrom.FieldRef.FieldPath, fieldPath; got != want {
 		t.Errorf("fieldPath = %q, want %q", got, want)
 	}
 }
@@ -710,37 +710,54 @@ func TestBuildWorkspaceMountSubPathExpr(t *testing.T) {
 	if err != nil {
 		t.Fatalf("worker.ParseJob(job, sjob) error = %v, want nil", err)
 	}
-	kjob, err := worker.Build(&corev1.PodSpec{}, false, inputs)
+	inputs.k8sPlugin = &KubernetesPlugin{
+		Sidecars: []corev1.Container{{
+			Name:  "custom-sidecar",
+			Image: "busybox:latest",
+		}},
+	}
+	kjob, err := worker.Build(&corev1.PodSpec{
+		Containers: []corev1.Container{{
+			Name:  "custom-command",
+			Image: "alpine:latest",
+		}},
+	}, false, inputs)
 	if err != nil {
-		t.Fatalf("worker.Build(&corev1.PodSpec{}, %t, inputs) error = %v, want nil", false, err)
+		t.Fatalf("worker.Build(podSpec, %t, inputs) error = %v, want nil", false, err)
 	}
 
 	const wantMountPath = "/workspace"
 	const wantSubPathExpr = "$(POD_NAME)"
 
-	checkWorkspaceMount := func(t *testing.T, label, containerName string, mounts []corev1.VolumeMount) {
+	checkWorkspaceMount := func(t *testing.T, label string, container corev1.Container) {
 		t.Helper()
 		var found bool
-		for _, m := range mounts {
+		for _, m := range container.VolumeMounts {
 			if m.MountPath != wantMountPath {
 				continue
 			}
 			found = true
 			if m.SubPathExpr != wantSubPathExpr {
 				t.Errorf("%s container %q: workspace mount SubPathExpr = %q, want %q",
-					label, containerName, m.SubPathExpr, wantSubPathExpr)
+					label, container.Name, m.SubPathExpr, wantSubPathExpr)
 			}
 		}
 		if !found {
-			t.Errorf("%s container %q: no /workspace mount found", label, containerName)
+			t.Errorf("%s container %q: no /workspace mount found", label, container.Name)
 		}
+		assertEnvFieldPath(t, container, "POD_NAME", "metadata.name")
 	}
 
 	for _, c := range kjob.Spec.Template.Spec.Containers {
-		checkWorkspaceMount(t, "container", c.Name, c.VolumeMounts)
+		checkWorkspaceMount(t, "container", c)
 	}
+	var foundImageCheck bool
 	for _, c := range kjob.Spec.Template.Spec.InitContainers {
-		checkWorkspaceMount(t, "initContainer", c.Name, c.VolumeMounts)
+		checkWorkspaceMount(t, "initContainer", c)
+		foundImageCheck = foundImageCheck || strings.HasPrefix(c.Name, ImageCheckContainerNamePrefix)
+	}
+	if !foundImageCheck {
+		t.Error("kjob.Spec.Template.Spec.InitContainers has no image-check container")
 	}
 }
 
@@ -2097,6 +2114,16 @@ func findEnv(t *testing.T, envs []corev1.EnvVar, name string) *corev1.EnvVar {
 	}
 
 	return nil
+}
+
+func countEnv(envs []corev1.EnvVar, name string) int {
+	var count int
+	for _, env := range envs {
+		if env.Name == name {
+			count++
+		}
+	}
+	return count
 }
 
 func hasVolumeNamed(volumes []corev1.Volume, name string) bool {

--- a/internal/controller/scheduler/scheduler_test.go
+++ b/internal/controller/scheduler/scheduler_test.go
@@ -744,6 +744,41 @@ func TestBuildWorkspaceMountSubPathExpr(t *testing.T) {
 	}
 }
 
+func TestSubPathExprExpandsPodName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		expr string
+		want bool
+	}{
+		{name: "whole expression", expr: "$(POD_NAME)", want: true},
+		{name: "embedded expression", expr: "pods/$(POD_NAME)/workspace", want: true},
+		{name: "after another reference", expr: "$(OTHER)/$(POD_NAME)", want: true},
+		{name: "odd dollar run", expr: "$$$(POD_NAME)", want: true},
+		{name: "backslash is not an escape", expr: `\$(POD_NAME)`, want: true},
+		{name: "after non-ASCII rune", expr: "$£$(POD_NAME)", want: true},
+		{name: "empty", expr: "", want: false},
+		{name: "static", expr: "workspace", want: false},
+		{name: "other reference", expr: "$(OTHER)", want: false},
+		{name: "escaped reference", expr: "$$(POD_NAME)", want: false},
+		{name: "shell reference", expr: "${POD_NAME}", want: false},
+		{name: "bare reference", expr: "$POD_NAME", want: false},
+		{name: "unterminated reference", expr: "$(POD_NAME", want: false},
+		{name: "nested reference", expr: "$($(POD_NAME))", want: false},
+		{name: "different name prefix", expr: "$(POD_NAME_SUFFIX)", want: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if got := subPathExprExpandsPodName(test.expr); got != test.want {
+				t.Errorf("subPathExprExpandsPodName(%q) = %t, want %t", test.expr, got, test.want)
+			}
+		})
+	}
+}
+
 // TestBuildWorkspaceMountSubPathExprDefault verifies the previous behavior
 // (no SubPathExpr) is preserved when the new field is unset.
 func TestBuildWorkspaceMountSubPathExprDefault(t *testing.T) {


### PR DESCRIPTION
## Change

<!-- What does this PR change? -->


Automatically add `POD_NAME` from `metadata.name` to containers whose final `/workspace` mount expands `$(POD_NAME)`. This runs after PodSpec patches and mount deduplication, preserves explicit values, and covers custom commands, sidecars, and init containers.

Kubernetes still expands the literal `subPathExpr`; the controller only supplies the missing downward API variable.

## Context

Fixes #939.

`workspace-mount-sub-path-expr` supports `$(POD_NAME)`, but kubelet can't prepare the mount unless every affected container defines that variable. Name-based PodSpec patches can't reliably cover custom or generated containers.

## Disclosures / Credits

<!-- Disclose any AI assistance, prior art, or contributors who deserve credit. -->
