### PR TITLE
Add job acquisition token support

### DIFF
--- a/.buildkite/rbac.yaml
+++ b/.buildkite/rbac.yaml
@@ -6,8 +6,15 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - podtemplates
       - secrets
+    verbs:
+      - get
+      - create
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - podtemplates
     verbs:
       - get
   - apiGroups:

--- a/api/agent_client.go
+++ b/api/agent_client.go
@@ -205,7 +205,8 @@ type AgentScheduledJob struct {
 type JobAcquisitionToken string
 
 type IssueJobAcquisitionTokensRequest struct {
-	JobUUIDs []string `json:"job_uuids"`
+	JobUUIDs             []string `json:"job_uuids"`
+	TokenLifetimeSeconds *int     `json:"token_lifetime_seconds,omitempty"`
 }
 
 type IssuedJobAcquisitionToken struct {
@@ -351,11 +352,18 @@ func (c *AgentClient) ReserveJobs(ctx context.Context, ids []string, reservation
 	return reservations, readRetryAfter(header), nil
 }
 
-func (c *AgentClient) IssueJobAcquisitionTokens(ctx context.Context, ids []string) (*IssueJobAcquisitionTokensResponse, time.Duration, error) {
+func (c *AgentClient) IssueJobAcquisitionTokens(ctx context.Context, ids []string, tokenLifetimeSeconds int) (*IssueJobAcquisitionTokensResponse, time.Duration, error) {
 	if len(ids) > 1000 {
 		return nil, 0, fmt.Errorf("job acquisition token request contains %d UUIDs, maximum is 1000", len(ids))
 	}
-	body, err := json.Marshal(IssueJobAcquisitionTokensRequest{JobUUIDs: ids})
+	if tokenLifetimeSeconds < 0 || tokenLifetimeSeconds > 3600 {
+		return nil, 0, fmt.Errorf("job acquisition token lifetime must be between 1 and 3600 seconds, or 0 to use the server default")
+	}
+	request := IssueJobAcquisitionTokensRequest{JobUUIDs: ids}
+	if tokenLifetimeSeconds > 0 {
+		request.TokenLifetimeSeconds = &tokenLifetimeSeconds
+	}
+	body, err := json.Marshal(request)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/api/agent_client.go
+++ b/api/agent_client.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -24,6 +25,8 @@ func isDefaultQueue(queue string) bool {
 // AgentClient is a client for Agent API methods for retrieving jobs.
 type AgentClient struct {
 	endpoint        *url.URL
+	httpClient      *http.Client
+	token           string
 	stacksAPIClient *stacksapi.Client
 
 	clusterID string
@@ -73,7 +76,12 @@ func NewAgentClient(ctx context.Context, opts AgentClientOpts) (*AgentClient, er
 	}
 
 	client := &AgentClient{
-		endpoint:  endpointURL,
+		endpoint: endpointURL,
+		token:    opts.Token,
+		httpClient: &http.Client{
+			Timeout:   opts.HTTPTimeout,
+			Transport: NewLogTransport(http.DefaultTransport, opts.Logger.With("component", "job-acquisition-tokens"), false),
+		},
 		clusterID: opts.ClusterID,
 		queue:     opts.Queue,
 		logger:    opts.Logger,
@@ -190,6 +198,25 @@ type AgentScheduledJob struct {
 
 	// added by GetScheduledJobs to track end-to-end latency
 	QueriedAt time.Time `json:"-"`
+
+	JobAcquisitionToken JobAcquisitionToken `json:"-"`
+}
+
+type JobAcquisitionToken string
+
+type IssueJobAcquisitionTokensRequest struct {
+	JobUUIDs []string `json:"job_uuids"`
+}
+
+type IssuedJobAcquisitionToken struct {
+	JobUUID             string              `json:"job_uuid"`
+	JobAcquisitionToken JobAcquisitionToken `json:"job_acquisition_token"`
+	ExpiresAt           time.Time           `json:"expires_at"`
+}
+
+type IssueJobAcquisitionTokensResponse struct {
+	JobAcquisitionTokens []IssuedJobAcquisitionToken `json:"job_acquisition_tokens"`
+	NotIssued            []string                    `json:"not_issued"`
 }
 
 // GetScheduledJobs gets a page of jobs that could be run.
@@ -322,6 +349,37 @@ func (c *AgentClient) ReserveJobs(ctx context.Context, ids []string, reservation
 	}
 
 	return reservations, readRetryAfter(header), nil
+}
+
+func (c *AgentClient) IssueJobAcquisitionTokens(ctx context.Context, ids []string) (*IssueJobAcquisitionTokensResponse, time.Duration, error) {
+	if len(ids) > 1000 {
+		return nil, 0, fmt.Errorf("job acquisition token request contains %d UUIDs, maximum is 1000", len(ids))
+	}
+	body, err := json.Marshal(IssueJobAcquisitionTokensRequest{JobUUIDs: ids})
+	if err != nil {
+		return nil, 0, err
+	}
+	u := c.endpoint.JoinPath("stacks", c.stack.Key, "job-acquisition-tokens")
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), bytes.NewReader(body))
+	if err != nil {
+		return nil, 0, fmt.Errorf("creating job acquisition token request: %w", err)
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("Token %s", c.token))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "agent-stack-k8s/"+version.Version())
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		if resp.StatusCode >= 400 {
+			return nil, readRetryAfter(resp.Header), decodeError(resp)
+		}
+		return nil, readRetryAfter(resp.Header), fmt.Errorf("issuing job acquisition tokens returned %s, want 201 Created", resp.Status)
+	}
+	return decodeResponse[IssueJobAcquisitionTokensResponse](resp)
 }
 
 func (c *AgentClient) DeregisterStack(ctx context.Context) error {

--- a/api/fake_agent_server.go
+++ b/api/fake_agent_server.go
@@ -48,6 +48,7 @@ type FakeAgentServer struct {
 
 	// JobStates maps job UUIDs to their state strings for GetJobStates.
 	JobStates map[string]string
+	AgentJobs map[string]*AgentJob
 
 	// GetJobStatesStatusCode configures the HTTP status code for GetJobStates.
 	// Default is 200.
@@ -240,14 +241,24 @@ func (f *FakeAgentServer) handleGetJobStates(w http.ResponseWriter, r *http.Requ
 }
 
 func (f *FakeAgentServer) handleFinishJob(w http.ResponseWriter, r *http.Request) {
+	path := r.URL.Path
+	const prefix = "/stacks/test-stack/jobs/"
+	if r.Method == http.MethodGet {
+		jobUUID := strings.TrimPrefix(path, prefix)
+		job, ok := f.AgentJobs[jobUUID]
+		if !ok {
+			writeJSONResponse(w, http.StatusNotFound, map[string]string{"message": "job not found"})
+			return
+		}
+		writeJSONResponse(w, http.StatusOK, job)
+		return
+	}
 	if r.Method != http.MethodPost {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 
 	// Path: /stacks/test-stack/jobs/{uuid}/finish
-	path := r.URL.Path
-	const prefix = "/stacks/test-stack/jobs/"
 	const suffix = "/finish"
 	if !strings.HasPrefix(path, prefix) || !strings.HasSuffix(path, suffix) {
 		http.Error(w, "not found", http.StatusNotFound)

--- a/api/fake_agent_server.go
+++ b/api/fake_agent_server.go
@@ -3,6 +3,7 @@ package api
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -36,10 +37,11 @@ type FakeAgentServer struct {
 	// ReserveError configures an error message to return.
 	ReserveError string
 
-	JobAcquisitionTokenCalls      [][]string
-	JobAcquisitionTokenResponse   *IssueJobAcquisitionTokensResponse
-	JobAcquisitionTokenStatusCode int
-	JobAcquisitionTokenError      string
+	JobAcquisitionTokenCalls         []IssueJobAcquisitionTokensRequest
+	JobAcquisitionTokenRequestBodies [][]byte
+	JobAcquisitionTokenResponse      *IssueJobAcquisitionTokensResponse
+	JobAcquisitionTokenStatusCode    int
+	JobAcquisitionTokenError         string
 
 	// NotificationCalls records all notification batches sent to the server.
 	NotificationCalls [][]stacksapi.StackNotification
@@ -92,13 +94,19 @@ func (f *FakeAgentServer) handleIssueJobAcquisitionTokens(w http.ResponseWriter,
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 	var req IssueJobAcquisitionTokensRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := json.Unmarshal(body, &req); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 	f.mu.Lock()
-	f.JobAcquisitionTokenCalls = append(f.JobAcquisitionTokenCalls, req.JobUUIDs)
+	f.JobAcquisitionTokenCalls = append(f.JobAcquisitionTokenCalls, req)
+	f.JobAcquisitionTokenRequestBodies = append(f.JobAcquisitionTokenRequestBodies, bytes.Clone(body))
 	f.mu.Unlock()
 	if f.JobAcquisitionTokenError != "" {
 		writeJSONResponse(w, f.JobAcquisitionTokenStatusCode, map[string]string{"message": f.JobAcquisitionTokenError})

--- a/api/fake_agent_server.go
+++ b/api/fake_agent_server.go
@@ -36,6 +36,11 @@ type FakeAgentServer struct {
 	// ReserveError configures an error message to return.
 	ReserveError string
 
+	JobAcquisitionTokenCalls      [][]string
+	JobAcquisitionTokenResponse   *IssueJobAcquisitionTokensResponse
+	JobAcquisitionTokenStatusCode int
+	JobAcquisitionTokenError      string
+
 	// NotificationCalls records all notification batches sent to the server.
 	NotificationCalls [][]stacksapi.StackNotification
 
@@ -64,20 +69,51 @@ type FakeAgentServer struct {
 // Use server.URL() to get the endpoint for creating a real AgentClient.
 func NewFakeAgentServer() *FakeAgentServer {
 	fake := &FakeAgentServer{
-		ReserveStatusCode:      http.StatusOK,
-		GetJobStatesStatusCode: http.StatusOK,
-		FinishJobStatusCode:    http.StatusOK,
+		ReserveStatusCode:             http.StatusOK,
+		JobAcquisitionTokenStatusCode: http.StatusCreated,
+		GetJobStatesStatusCode:        http.StatusOK,
+		FinishJobStatusCode:           http.StatusOK,
 	}
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/stacks/register", fake.handleRegisterStack)
 	mux.HandleFunc("/stacks/test-stack/scheduled-jobs/batch-reserve", fake.handleReserveJobs)
+	mux.HandleFunc("/stacks/test-stack/job-acquisition-tokens", fake.handleIssueJobAcquisitionTokens)
 	mux.HandleFunc("/stacks/test-stack/notifications", fake.handleNotifications)
 	mux.HandleFunc("/stacks/test-stack/jobs/get-states", fake.handleGetJobStates)
 	mux.HandleFunc("/stacks/test-stack/jobs/", fake.handleFinishJob)
 
 	fake.server = httptest.NewServer(mux)
 	return fake
+}
+
+func (f *FakeAgentServer) handleIssueJobAcquisitionTokens(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req IssueJobAcquisitionTokensRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	f.mu.Lock()
+	f.JobAcquisitionTokenCalls = append(f.JobAcquisitionTokenCalls, req.JobUUIDs)
+	f.mu.Unlock()
+	if f.JobAcquisitionTokenError != "" {
+		writeJSONResponse(w, f.JobAcquisitionTokenStatusCode, map[string]string{"message": f.JobAcquisitionTokenError})
+		return
+	}
+	resp := f.JobAcquisitionTokenResponse
+	if resp == nil {
+		resp = &IssueJobAcquisitionTokensResponse{}
+		for _, id := range req.JobUUIDs {
+			resp.JobAcquisitionTokens = append(resp.JobAcquisitionTokens, IssuedJobAcquisitionToken{
+				JobUUID: id, JobAcquisitionToken: JobAcquisitionToken("jat-" + id),
+			})
+		}
+	}
+	writeJSONResponse(w, f.JobAcquisitionTokenStatusCode, resp)
 }
 
 // URL returns the base URL of the fake server.

--- a/api/fake_agent_server_test.go
+++ b/api/fake_agent_server_test.go
@@ -1,13 +1,119 @@
 package api_test
 
 import (
+	"bytes"
+	"encoding/json"
 	"log/slog"
+	"net/http"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/buildkite/agent-stack-k8s/v2/api"
 	"github.com/buildkite/stacksapi"
 	"github.com/google/go-cmp/cmp"
 )
+
+func TestFakeAgentServer_IssuesJobAcquisitionTokens(t *testing.T) {
+	ctx := t.Context()
+	server := api.NewFakeAgentServer()
+	defer server.Close()
+
+	expiresAt := time.Now().Add(5 * time.Minute).UTC().Truncate(time.Second)
+	server.JobAcquisitionTokenResponse = &api.IssueJobAcquisitionTokensResponse{
+		JobAcquisitionTokens: []api.IssuedJobAcquisitionToken{{
+			JobUUID:             "job-1",
+			JobAcquisitionToken: "jat-1",
+			ExpiresAt:           expiresAt,
+		}},
+		NotIssued: []string{"job-2"},
+	}
+
+	client, err := api.NewAgentClient(ctx, api.AgentClientOpts{
+		Token:    "fake-token",
+		Endpoint: server.URL(),
+		StackID:  "test-stack",
+		Logger:   slog.Default(),
+	})
+	if err != nil {
+		t.Fatalf("NewAgentClient() error = %v", err)
+	}
+
+	got, _, err := client.IssueJobAcquisitionTokens(ctx, []string{"job-1", "job-2"})
+	if err != nil {
+		t.Fatalf("IssueJobAcquisitionTokens() error = %v", err)
+	}
+	if diff := cmp.Diff(got, server.JobAcquisitionTokenResponse); diff != "" {
+		t.Errorf("IssueJobAcquisitionTokens() diff (-got +want):\n%s", diff)
+	}
+	if diff := cmp.Diff(server.JobAcquisitionTokenCalls, [][]string{{"job-1", "job-2"}}); diff != "" {
+		t.Errorf("server.JobAcquisitionTokenCalls diff (-got +want):\n%s", diff)
+	}
+	if got := server.JobAcquisitionTokenStatusCode; got != http.StatusCreated {
+		t.Errorf("JobAcquisitionTokenStatusCode = %d, want %d", got, http.StatusCreated)
+	}
+}
+
+func TestIssueJobAcquisitionTokensDoesNotLogTokenPayload(t *testing.T) {
+	ctx := t.Context()
+	server := api.NewFakeAgentServer()
+	defer server.Close()
+	server.JobAcquisitionTokenResponse = &api.IssueJobAcquisitionTokensResponse{
+		JobAcquisitionTokens: []api.IssuedJobAcquisitionToken{{
+			JobUUID:             "job-1",
+			JobAcquisitionToken: "jat-secret",
+		}},
+	}
+
+	var logs bytes.Buffer
+	client, err := api.NewAgentClient(ctx, api.AgentClientOpts{
+		Token:           "cluster-secret",
+		Endpoint:        server.URL(),
+		StackID:         "test-stack",
+		Logger:          slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug})),
+		LogHTTPPayloads: true,
+	})
+	if err != nil {
+		t.Fatalf("NewAgentClient() error = %v", err)
+	}
+	if _, _, err := client.IssueJobAcquisitionTokens(ctx, []string{"job-1"}); err != nil {
+		t.Fatalf("IssueJobAcquisitionTokens() error = %v", err)
+	}
+	if strings.Contains(logs.String(), "jat-secret") {
+		t.Errorf("HTTP logs contain JAT: %s", logs.String())
+	}
+	if strings.Contains(logs.String(), "cluster-secret") {
+		t.Errorf("HTTP logs contain cluster token: %s", logs.String())
+	}
+}
+
+func TestIssueJobAcquisitionTokensRejectsMoreThan1000Jobs(t *testing.T) {
+	ctx := t.Context()
+	server := api.NewFakeAgentServer()
+	defer server.Close()
+	client, err := api.NewAgentClient(ctx, api.AgentClientOpts{
+		Token: "fake-token", Endpoint: server.URL(), StackID: "test-stack", Logger: slog.Default(),
+	})
+	if err != nil {
+		t.Fatalf("NewAgentClient() error = %v", err)
+	}
+	if _, _, err := client.IssueJobAcquisitionTokens(ctx, make([]string, 1001)); err == nil {
+		t.Fatal("IssueJobAcquisitionTokens() error = nil, want non-nil")
+	}
+	if got := len(server.JobAcquisitionTokenCalls); got != 0 {
+		t.Errorf("issuance calls = %d, want 0", got)
+	}
+}
+
+func TestAgentScheduledJobDoesNotSerializeJobAcquisitionToken(t *testing.T) {
+	b, err := json.Marshal(api.AgentScheduledJob{ID: "job-1", JobAcquisitionToken: "jat-secret"})
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	if strings.Contains(string(b), "jat-secret") {
+		t.Errorf("serialized AgentScheduledJob contains JAT: %s", b)
+	}
+}
 
 func TestFakeAgentServer_DefaultBehavior(t *testing.T) {
 	ctx := t.Context()

--- a/api/fake_agent_server_test.go
+++ b/api/fake_agent_server_test.go
@@ -39,18 +39,37 @@ func TestFakeAgentServer_IssuesJobAcquisitionTokens(t *testing.T) {
 		t.Fatalf("NewAgentClient() error = %v", err)
 	}
 
-	got, _, err := client.IssueJobAcquisitionTokens(ctx, []string{"job-1", "job-2"})
+	got, _, err := client.IssueJobAcquisitionTokens(ctx, []string{"job-1", "job-2"}, 1800)
 	if err != nil {
 		t.Fatalf("IssueJobAcquisitionTokens() error = %v", err)
 	}
 	if diff := cmp.Diff(got, server.JobAcquisitionTokenResponse); diff != "" {
 		t.Errorf("IssueJobAcquisitionTokens() diff (-got +want):\n%s", diff)
 	}
-	if diff := cmp.Diff(server.JobAcquisitionTokenCalls, [][]string{{"job-1", "job-2"}}); diff != "" {
+	wantCalls := []api.IssueJobAcquisitionTokensRequest{{JobUUIDs: []string{"job-1", "job-2"}, TokenLifetimeSeconds: new(1800)}}
+	if diff := cmp.Diff(server.JobAcquisitionTokenCalls, wantCalls); diff != "" {
 		t.Errorf("server.JobAcquisitionTokenCalls diff (-got +want):\n%s", diff)
 	}
 	if got := server.JobAcquisitionTokenStatusCode; got != http.StatusCreated {
 		t.Errorf("JobAcquisitionTokenStatusCode = %d, want %d", got, http.StatusCreated)
+	}
+}
+
+func TestIssueJobAcquisitionTokensOmitsDefaultTokenLifetime(t *testing.T) {
+	server := api.NewFakeAgentServer()
+	defer server.Close()
+	client, err := api.NewAgentClient(t.Context(), api.AgentClientOpts{
+		Token: "fake-token", Endpoint: server.URL(), StackID: "test-stack", Logger: slog.Default(),
+	})
+	if err != nil {
+		t.Fatalf("NewAgentClient() error = %v", err)
+	}
+
+	if _, _, err := client.IssueJobAcquisitionTokens(t.Context(), []string{"job-1"}, 0); err != nil {
+		t.Fatalf("IssueJobAcquisitionTokens() error = %v", err)
+	}
+	if bytes.Contains(server.JobAcquisitionTokenRequestBodies[0], []byte("token_lifetime_seconds")) {
+		t.Errorf("request body contains token_lifetime_seconds: %s", server.JobAcquisitionTokenRequestBodies[0])
 	}
 }
 
@@ -76,7 +95,7 @@ func TestIssueJobAcquisitionTokensDoesNotLogTokenPayload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewAgentClient() error = %v", err)
 	}
-	if _, _, err := client.IssueJobAcquisitionTokens(ctx, []string{"job-1"}); err != nil {
+	if _, _, err := client.IssueJobAcquisitionTokens(ctx, []string{"job-1"}, 0); err != nil {
 		t.Fatalf("IssueJobAcquisitionTokens() error = %v", err)
 	}
 	if strings.Contains(logs.String(), "jat-secret") {
@@ -97,8 +116,28 @@ func TestIssueJobAcquisitionTokensRejectsMoreThan1000Jobs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewAgentClient() error = %v", err)
 	}
-	if _, _, err := client.IssueJobAcquisitionTokens(ctx, make([]string, 1001)); err == nil {
+	if _, _, err := client.IssueJobAcquisitionTokens(ctx, make([]string, 1001), 0); err == nil {
 		t.Fatal("IssueJobAcquisitionTokens() error = nil, want non-nil")
+	}
+	if got := len(server.JobAcquisitionTokenCalls); got != 0 {
+		t.Errorf("issuance calls = %d, want 0", got)
+	}
+}
+
+func TestIssueJobAcquisitionTokensRejectsInvalidTokenLifetime(t *testing.T) {
+	server := api.NewFakeAgentServer()
+	defer server.Close()
+	client, err := api.NewAgentClient(t.Context(), api.AgentClientOpts{
+		Token: "fake-token", Endpoint: server.URL(), StackID: "test-stack", Logger: slog.Default(),
+	})
+	if err != nil {
+		t.Fatalf("NewAgentClient() error = %v", err)
+	}
+
+	for _, lifetime := range []int{-1, 3601} {
+		if _, _, err := client.IssueJobAcquisitionTokens(t.Context(), []string{"job-1"}, lifetime); err == nil {
+			t.Errorf("IssueJobAcquisitionTokens(tokenLifetimeSeconds: %d) error = nil, want non-nil", lifetime)
+		}
 	}
 	if got := len(server.JobAcquisitionTokenCalls); got != 0 {
 		t.Errorf("issuance calls = %d, want 0", got)

--- a/charts/agent-stack-k8s/templates/rbac.yaml.tpl
+++ b/charts/agent-stack-k8s/templates/rbac.yaml.tpl
@@ -26,8 +26,15 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - podtemplates
       - secrets
+    verbs:
+      - get
+      - create
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - podtemplates
     verbs:
       - get
   - apiGroups:

--- a/charts/agent-stack-k8s/values.schema.json
+++ b/charts/agent-stack-k8s/values.schema.json
@@ -360,6 +360,12 @@
           "title": "Runs an extra loop that checks for and terminates pods that are still running but with a terminated agent container",
           "examples": [false, true]
         },
+        "enable-job-acquisition-tokens": {
+          "type": "boolean",
+          "default": true,
+          "title": "Issue a job-scoped acquisition token immediately before scheduling each job",
+          "examples": [false, true]
+        },
         "prometheus-port": {
           "type": "integer",
           "default": 9216,

--- a/charts/agent-stack-k8s/values.yaml
+++ b/charts/agent-stack-k8s/values.yaml
@@ -9,6 +9,7 @@ config:
   prometheus-port: 9216
   reservation-expiry-seconds: 900
   enable-completion-watcher: true
+  enable-job-acquisition-tokens: false
   pod-pending-timeout: 15m
 
 resources:

--- a/charts/agent-stack-k8s/values.yaml
+++ b/charts/agent-stack-k8s/values.yaml
@@ -9,7 +9,7 @@ config:
   prometheus-port: 9216
   reservation-expiry-seconds: 900
   enable-completion-watcher: true
-  enable-job-acquisition-tokens: false
+  enable-job-acquisition-tokens: true
   pod-pending-timeout: 15m
 
 resources:

--- a/cmd/controller/controller_test.go
+++ b/cmd/controller/controller_test.go
@@ -678,9 +678,20 @@ tags:
 		}
 	})
 
-	t.Run("job acquisition tokens default disabled", func(t *testing.T) {
+	t.Run("job acquisition tokens default enabled", func(t *testing.T) {
 		cleanTestEnv(t)
 		cfg, err := buildConfig(t, []string{}, "")
+		if err != nil {
+			t.Fatalf("buildConfig() error = %v", err)
+		}
+		if !cfg.EnableJobAcquisitionTokens {
+			t.Error("cfg.EnableJobAcquisitionTokens = false, want true")
+		}
+	})
+
+	t.Run("job acquisition tokens disableable via CLI flag", func(t *testing.T) {
+		cleanTestEnv(t)
+		cfg, err := buildConfig(t, []string{"--enable-job-acquisition-tokens=false"}, "")
 		if err != nil {
 			t.Fatalf("buildConfig() error = %v", err)
 		}
@@ -689,26 +700,15 @@ tags:
 		}
 	})
 
-	t.Run("job acquisition tokens settable via CLI flag", func(t *testing.T) {
+	t.Run("job acquisition tokens disableable via env var", func(t *testing.T) {
 		cleanTestEnv(t)
-		cfg, err := buildConfig(t, []string{"--enable-job-acquisition-tokens"}, "")
-		if err != nil {
-			t.Fatalf("buildConfig() error = %v", err)
-		}
-		if !cfg.EnableJobAcquisitionTokens {
-			t.Error("cfg.EnableJobAcquisitionTokens = false, want true")
-		}
-	})
-
-	t.Run("job acquisition tokens settable via env var", func(t *testing.T) {
-		cleanTestEnv(t)
-		t.Setenv("ENABLE_JOB_ACQUISITION_TOKENS", "true")
+		t.Setenv("ENABLE_JOB_ACQUISITION_TOKENS", "false")
 		cfg, err := buildConfig(t, []string{}, "")
 		if err != nil {
 			t.Fatalf("buildConfig() error = %v", err)
 		}
-		if !cfg.EnableJobAcquisitionTokens {
-			t.Error("cfg.EnableJobAcquisitionTokens = false, want true")
+		if cfg.EnableJobAcquisitionTokens {
+			t.Error("cfg.EnableJobAcquisitionTokens = true, want false")
 		}
 	})
 }

--- a/cmd/controller/controller_test.go
+++ b/cmd/controller/controller_test.go
@@ -45,6 +45,7 @@ func TestReadAndParseConfig(t *testing.T) {
 		DefaultImageCheckPullPolicy:          "IfNotPresent",
 		EnableQueuePause:                     true,
 		EnableCompletionWatcher:              true,
+		EnableJobAcquisitionTokens:           true,
 		WorkQueueLimit:                       2_000_000,
 		ImageCheckContainerCPULimit:          "201m",
 		ImageCheckContainerMemoryLimit:       "129Mi",
@@ -676,6 +677,40 @@ tags:
 			t.Fatalf("buildConfig(t, []string{}, %q) error = %v, want non-nil error", configFile, err)
 		}
 	})
+
+	t.Run("job acquisition tokens default disabled", func(t *testing.T) {
+		cleanTestEnv(t)
+		cfg, err := buildConfig(t, []string{}, "")
+		if err != nil {
+			t.Fatalf("buildConfig() error = %v", err)
+		}
+		if cfg.EnableJobAcquisitionTokens {
+			t.Error("cfg.EnableJobAcquisitionTokens = true, want false")
+		}
+	})
+
+	t.Run("job acquisition tokens settable via CLI flag", func(t *testing.T) {
+		cleanTestEnv(t)
+		cfg, err := buildConfig(t, []string{"--enable-job-acquisition-tokens"}, "")
+		if err != nil {
+			t.Fatalf("buildConfig() error = %v", err)
+		}
+		if !cfg.EnableJobAcquisitionTokens {
+			t.Error("cfg.EnableJobAcquisitionTokens = false, want true")
+		}
+	})
+
+	t.Run("job acquisition tokens settable via env var", func(t *testing.T) {
+		cleanTestEnv(t)
+		t.Setenv("ENABLE_JOB_ACQUISITION_TOKENS", "true")
+		cfg, err := buildConfig(t, []string{}, "")
+		if err != nil {
+			t.Fatalf("buildConfig() error = %v", err)
+		}
+		if !cfg.EnableJobAcquisitionTokens {
+			t.Error("cfg.EnableJobAcquisitionTokens = false, want true")
+		}
+	})
 }
 
 // cleanTestEnv unsets environment variables that might be set in CI or .envrc
@@ -691,6 +726,7 @@ func cleanTestEnv(t *testing.T) {
 		"IMAGE_PULL_BACKOFF_GRACE_PERIOD",
 		"CONFIG",
 		"MAX_IN_FLIGHT",
+		"ENABLE_JOB_ACQUISITION_TOKENS",
 		"DEBUG",
 		"JOB_TTL",
 		"BUILDKITE_K8S_STACK_CONTROLLER_ID",

--- a/cmd/controller/flags.go
+++ b/cmd/controller/flags.go
@@ -56,7 +56,7 @@ type CLI struct {
 	QueryResetInterval         *time.Duration `kong:"help='Controls the interval between pagination cursor resets. Increasing this value will increase the number of jobs to be scheduled but also delay picking up any jobs that were missed from the start of the query (default: 10s)'"`
 	EnableQueuePause           *bool          `kong:"help='Allow controller to pause processing the jobs when queue is paused on Buildkite'"`
 	EnableCompletionWatcher    *bool          `kong:"help='Runs an extra loop that checks for and terminates pods that are still running but with a terminated agent container (default: true)'"`
-	EnableJobAcquisitionTokens *bool          `kong:"help='Issue a job-scoped acquisition token immediately before scheduling each job (default: false)'"`
+	EnableJobAcquisitionTokens *bool          `kong:"help='Issue a job-scoped acquisition token immediately before scheduling each job (default: true)'"`
 	WorkQueueLimit             *int           `kong:"help='Sets the maximum number of Jobs the controller will hold in the work queue (default: 1000000)'"`
 	ReservationExpirySeconds   *int           `kong:"help='Number of seconds until a job reservation expires. If the job is not started within this time, Buildkite will make it available for reservation again (default: 900, max: 3600)'"`
 
@@ -163,6 +163,7 @@ func newConfigWithDefaults() *config.Config {
 		QueryResetInterval:                   10 * time.Second,
 		WorkQueueLimit:                       1000000,
 		EnableCompletionWatcher:              true,
+		EnableJobAcquisitionTokens:           true,
 		ImageCheckContainerCPULimit:          "200m",
 		ImageCheckContainerMemoryLimit:       "128Mi",
 		LogFormat:                            "logfmt",

--- a/cmd/controller/flags.go
+++ b/cmd/controller/flags.go
@@ -40,24 +40,25 @@ type CLI struct {
 
 	// Controller settings
 	// name= and env= needed: Go field "ID" → Kong default "--i-d" and "$I_D", but we want "--id" and "$BUILDKITE_K8S_STACK_CONTROLLER_ID"
-	ID                       string         `kong:"name='id',env='BUILDKITE_K8S_STACK_CONTROLLER_ID',help='Unique identifier for this controller instance. Used as a k8s label to filter resources and as the Stack key when registering with the Buildkite API. Must be distinct per controller when running multiple instances in the same namespace, otherwise duplicate pods may be spawned'"`
-	JobCreationConcurrency   *int           `kong:"help='Number of concurrent goroutines to run for converting Buildkite jobs into Kubernetes jobs (default: 25)'"`
-	AgentTokenSecret         string         `kong:"help='Name of the Buildkite agent token secret (default: buildkite-agent-token)'"`
-	Image                    string         `kong:"help='The image to use for the Buildkite agent'"`
-	MaxInFlight              *int           `kong:"help='Max jobs in flight, 0 means no max (default: 25)'"`
-	Tags                     []string       `kong:"help='A comma-separated list of agent tags. The \"queue\" tag must be unique (e.g. \"queue=kubernetes,os=linux\")'"`
-	Queue                    string         `kong:"help='The Buildkite queue to poll for jobs (overrides the queue tag if set)'"`
-	PrometheusPort           *uint16        `kong:"help='Bind port to expose Prometheus /metrics; 0 disables it (default: 0)'"`
-	ProfilerAddress          string         `kong:"help='Bind address to expose the pprof profiler (e.g. localhost:6060)'"`
-	PollInterval             *time.Duration `kong:"help='Time to wait between polling for new jobs (minimum 1s); note that increasing this causes jobs to be slower to start (default: 1s)'"`
-	HTTPTimeout              *time.Duration `kong:"name='http-timeout',help='Timeout for HTTP requests to the Buildkite Agent API (default: 60s)'"`
-	PaginationPageSize       *int           `kong:"help='Sets the maximum number of Jobs per page when retrieving Buildkite Jobs to be Scheduled (default: 1000)'"`
-	PaginationDepthLimit     *int           `kong:"help='Sets the maximum number of pages when retrieving Buildkite Jobs to be Scheduled. Increasing this value will increase the number of requests made to the Buildkite API and number of Jobs to be scheduled on the Kubernetes Cluster (default: 2)'"`
-	QueryResetInterval       *time.Duration `kong:"help='Controls the interval between pagination cursor resets. Increasing this value will increase the number of jobs to be scheduled but also delay picking up any jobs that were missed from the start of the query (default: 10s)'"`
-	EnableQueuePause         *bool          `kong:"help='Allow controller to pause processing the jobs when queue is paused on Buildkite'"`
-	EnableCompletionWatcher  *bool          `kong:"help='Runs an extra loop that checks for and terminates pods that are still running but with a terminated agent container (default: true)'"`
-	WorkQueueLimit           *int           `kong:"help='Sets the maximum number of Jobs the controller will hold in the work queue (default: 1000000)'"`
-	ReservationExpirySeconds *int           `kong:"help='Number of seconds until a job reservation expires. If the job is not started within this time, Buildkite will make it available for reservation again (default: 900, max: 3600)'"`
+	ID                         string         `kong:"name='id',env='BUILDKITE_K8S_STACK_CONTROLLER_ID',help='Unique identifier for this controller instance. Used as a k8s label to filter resources and as the Stack key when registering with the Buildkite API. Must be distinct per controller when running multiple instances in the same namespace, otherwise duplicate pods may be spawned'"`
+	JobCreationConcurrency     *int           `kong:"help='Number of concurrent goroutines to run for converting Buildkite jobs into Kubernetes jobs (default: 25)'"`
+	AgentTokenSecret           string         `kong:"help='Name of the Buildkite agent token secret (default: buildkite-agent-token)'"`
+	Image                      string         `kong:"help='The image to use for the Buildkite agent'"`
+	MaxInFlight                *int           `kong:"help='Max jobs in flight, 0 means no max (default: 25)'"`
+	Tags                       []string       `kong:"help='A comma-separated list of agent tags. The \"queue\" tag must be unique (e.g. \"queue=kubernetes,os=linux\")'"`
+	Queue                      string         `kong:"help='The Buildkite queue to poll for jobs (overrides the queue tag if set)'"`
+	PrometheusPort             *uint16        `kong:"help='Bind port to expose Prometheus /metrics; 0 disables it (default: 0)'"`
+	ProfilerAddress            string         `kong:"help='Bind address to expose the pprof profiler (e.g. localhost:6060)'"`
+	PollInterval               *time.Duration `kong:"help='Time to wait between polling for new jobs (minimum 1s); note that increasing this causes jobs to be slower to start (default: 1s)'"`
+	HTTPTimeout                *time.Duration `kong:"name='http-timeout',help='Timeout for HTTP requests to the Buildkite Agent API (default: 60s)'"`
+	PaginationPageSize         *int           `kong:"help='Sets the maximum number of Jobs per page when retrieving Buildkite Jobs to be Scheduled (default: 1000)'"`
+	PaginationDepthLimit       *int           `kong:"help='Sets the maximum number of pages when retrieving Buildkite Jobs to be Scheduled. Increasing this value will increase the number of requests made to the Buildkite API and number of Jobs to be scheduled on the Kubernetes Cluster (default: 2)'"`
+	QueryResetInterval         *time.Duration `kong:"help='Controls the interval between pagination cursor resets. Increasing this value will increase the number of jobs to be scheduled but also delay picking up any jobs that were missed from the start of the query (default: 10s)'"`
+	EnableQueuePause           *bool          `kong:"help='Allow controller to pause processing the jobs when queue is paused on Buildkite'"`
+	EnableCompletionWatcher    *bool          `kong:"help='Runs an extra loop that checks for and terminates pods that are still running but with a terminated agent container (default: true)'"`
+	EnableJobAcquisitionTokens *bool          `kong:"help='Issue a job-scoped acquisition token immediately before scheduling each job (default: false)'"`
+	WorkQueueLimit             *int           `kong:"help='Sets the maximum number of Jobs the controller will hold in the work queue (default: 1000000)'"`
+	ReservationExpirySeconds   *int           `kong:"help='Number of seconds until a job reservation expires. If the job is not started within this time, Buildkite will make it available for reservation again (default: 900, max: 3600)'"`
 
 	// name= and env= needed: Go field "K8s..." → Kong default "--k-8-s-..." and "$K_8_S_...", but we want "--k8s-..." and "$K8S_..."
 	K8sClientRateLimiterQPS   *int `kong:"name='k8s-client-rate-limiter-qps',env='K8S_CLIENT_RATE_LIMITER_QPS',help='The QPS value of the K8s client rate limiter (default: 10)'"`

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -21,6 +21,7 @@ default-image-pull-policy: Never
 default-image-check-pull-policy: IfNotPresent
 enable-queue-pause: true
 enable-completion-watcher: true
+enable-job-acquisition-tokens: true
 pagination-page-size: 1000
 pagination-depth-limit: 5
 query-reset-interval: 10s

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -21,6 +21,7 @@ const (
 	PipelineSlugAnnotation                = "buildkite.com/pipeline-slug"
 	StepKeyAnnotation                     = "buildkite.com/step-key"
 	PodTemplateAnnotation                 = "buildkite.com/pod-template-name"
+	JobAcquisitionTokenSecretAnnotation   = "buildkite.com/job-acquisition-token-secret"
 	DefaultNamespace                      = "default"
 	DefaultImagePullBackOffGracePeriod    = 30 * time.Second
 	DefaultJobCancelCheckerPollInterval   = 5 * time.Second

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -53,22 +53,23 @@ type Config struct {
 	PodSpecPatch                         *corev1.PodSpec `json:"pod-spec-patch"                           validate:"omitempty"`
 
 	// Controller settings
-	JobCreationConcurrency  int           `json:"job-creation-concurrency"  validate:"omitempty"`
-	AgentTokenSecret        string        `json:"agent-token-secret"        validate:"required"`
-	Image                   string        `json:"image"                     validate:"required"`
-	MaxInFlight             int           `json:"max-in-flight"             validate:"min=0"`
-	Tags                    []string      `json:"tags"`
-	Queue                   string        `json:"queue"`
-	PrometheusPort          uint16        `json:"prometheus-port"           validate:"omitempty"`
-	ProfilerAddress         string        `json:"profiler-address"          validate:"omitempty,hostname_port"`
-	PollInterval            time.Duration `json:"poll-interval"`
-	HTTPTimeout             time.Duration `json:"http-timeout"              validate:"omitempty"`
-	PaginationPageSize      int           `json:"pagination-page-size"      validate:"min=1,max=1000"`
-	PaginationDepthLimit    int           `json:"pagination-depth-limit"    validate:"min=1,max=20"`
-	QueryResetInterval      time.Duration `json:"query-reset-interval"      validate:"omitempty"`
-	EnableQueuePause        bool          `json:"enable-queue-pause"        validate:"omitempty"`
-	WorkQueueLimit          int           `json:"work-queue-limit"          validate:"omitempty"`
-	EnableCompletionWatcher bool          `json:"enable-completion-watcher" validate:"omitempty"`
+	JobCreationConcurrency     int           `json:"job-creation-concurrency"  validate:"omitempty"`
+	AgentTokenSecret           string        `json:"agent-token-secret"        validate:"required"`
+	Image                      string        `json:"image"                     validate:"required"`
+	MaxInFlight                int           `json:"max-in-flight"             validate:"min=0"`
+	Tags                       []string      `json:"tags"`
+	Queue                      string        `json:"queue"`
+	PrometheusPort             uint16        `json:"prometheus-port"           validate:"omitempty"`
+	ProfilerAddress            string        `json:"profiler-address"          validate:"omitempty,hostname_port"`
+	PollInterval               time.Duration `json:"poll-interval"`
+	HTTPTimeout                time.Duration `json:"http-timeout"              validate:"omitempty"`
+	PaginationPageSize         int           `json:"pagination-page-size"      validate:"min=1,max=1000"`
+	PaginationDepthLimit       int           `json:"pagination-depth-limit"    validate:"min=1,max=20"`
+	QueryResetInterval         time.Duration `json:"query-reset-interval"      validate:"omitempty"`
+	EnableQueuePause           bool          `json:"enable-queue-pause"        validate:"omitempty"`
+	WorkQueueLimit             int           `json:"work-queue-limit"          validate:"omitempty"`
+	EnableCompletionWatcher    bool          `json:"enable-completion-watcher" validate:"omitempty"`
+	EnableJobAcquisitionTokens bool          `json:"enable-job-acquisition-tokens" validate:"omitempty"`
 	// ReservationExpirySeconds controls how long (in seconds) a job reservation
 	// is held before it expires. If the job is not started within this time,
 	// Buildkite will make it available for reservation again.

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -15,7 +15,9 @@ import (
 	"github.com/buildkite/agent-stack-k8s/v2/internal/controller/agenttags"
 	"github.com/buildkite/agent-stack-k8s/v2/internal/controller/config"
 	"github.com/buildkite/agent-stack-k8s/v2/internal/controller/deduper"
+	"github.com/buildkite/agent-stack-k8s/v2/internal/controller/jatissuer"
 	"github.com/buildkite/agent-stack-k8s/v2/internal/controller/limiter"
+	"github.com/buildkite/agent-stack-k8s/v2/internal/controller/model"
 	"github.com/buildkite/agent-stack-k8s/v2/internal/controller/monitor"
 	"github.com/buildkite/agent-stack-k8s/v2/internal/controller/reserver"
 	"github.com/buildkite/agent-stack-k8s/v2/internal/controller/scheduler"
@@ -148,7 +150,7 @@ func Run(ctx context.Context, logger *slog.Logger, k8sClient kubernetes.Interfac
 
 	// **************************************************************************
 	// ***                        JOB FLOW                                    ***
-	// ***       Monitor -> Reserver -> Limiter -> Deduper -> Scheduler       ***
+	// ***  Monitor -> Reserver -> Limiter -> JAT issuer -> Deduper -> Scheduler  ***
 	// **************************************************************************
 	//
 	// Monitor polls Buildkite for jobs. It passes them to Limiter.
@@ -175,6 +177,7 @@ func Run(ctx context.Context, logger *slog.Logger, k8sClient kubernetes.Interfac
 		ID:                                   cfg.ID,
 		Image:                                cfg.Image,
 		AgentTokenSecretName:                 cfg.AgentTokenSecret,
+		EnableJobAcquisitionTokens:           cfg.EnableJobAcquisitionTokens,
 		JobTTL:                               cfg.JobTTL,
 		JobPrefix:                            cfg.JobPrefix,
 		JobActiveDeadlineSeconds:             cfg.JobActiveDeadlineSeconds,
@@ -216,7 +219,11 @@ func Run(ctx context.Context, logger *slog.Logger, k8sClient kubernetes.Interfac
 	// Limiter prevents scheduling more than cfg.MaxInFlight jobs at once
 	// (if configured) and is responsible for the priority queue of jobs.
 	// Once it figures out a job can be scheduled, it passes to the deduper.
-	limiter := limiter.New(ctx, logger.With("component", "limiter"), deduper,
+	var postLimiter model.JobHandler = deduper
+	if cfg.EnableJobAcquisitionTokens {
+		postLimiter = jatissuer.New(logger.With("component", "jat-issuer"), agentClient, deduper)
+	}
+	limiter := limiter.New(ctx, logger.With("component", "limiter"), postLimiter,
 		cfg.MaxInFlight,
 		cfg.JobCreationConcurrency,
 		cfg.WorkQueueLimit,

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -221,7 +221,7 @@ func Run(ctx context.Context, logger *slog.Logger, k8sClient kubernetes.Interfac
 	// Once it figures out a job can be scheduled, it passes to the deduper.
 	var postLimiter model.JobHandler = deduper
 	if cfg.EnableJobAcquisitionTokens {
-		postLimiter = jatissuer.New(logger.With("component", "jat-issuer"), agentClient, deduper)
+		postLimiter = jatissuer.New(logger.With("component", "jat-issuer"), agentClient, deduper, cfg.ReservationExpirySeconds)
 	}
 	limiter := limiter.New(ctx, logger.With("component", "limiter"), postLimiter,
 		cfg.MaxInFlight,

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -447,6 +447,7 @@ func informerTransform(obj any) (any, error) {
 		return obj, nil
 
 	case *batchv1.Job:
+		jobAcquisitionTokenSecret := obj.Annotations[config.JobAcquisitionTokenSecretAnnotation]
 		// Job metadata we care about:
 		// - Name
 		// - Labels
@@ -454,6 +455,9 @@ func informerTransform(obj any) (any, error) {
 		obj.DeletionTimestamp = nil
 		obj.DeletionGracePeriodSeconds = nil
 		obj.Annotations = nil
+		if jobAcquisitionTokenSecret != "" {
+			obj.Annotations = map[string]string{config.JobAcquisitionTokenSecretAnnotation: jobAcquisitionTokenSecret}
+		}
 		obj.OwnerReferences = nil
 		obj.Finalizers = nil
 		obj.ManagedFields = nil

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -1,0 +1,28 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/buildkite/agent-stack-k8s/v2/internal/controller/config"
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestInformerTransformPreservesJobAcquisitionTokenSecretAnnotation(t *testing.T) {
+	kjob := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+		config.JobAcquisitionTokenSecretAnnotation: "job-token",
+		"unneeded": "annotation",
+	}}}
+
+	transformed, err := informerTransform(kjob)
+	if err != nil {
+		t.Fatalf("informerTransform() error = %v", err)
+	}
+	annotations := transformed.(*batchv1.Job).Annotations
+	if got := annotations[config.JobAcquisitionTokenSecretAnnotation]; got != "job-token" {
+		t.Errorf("job acquisition token secret annotation = %q, want %q", got, "job-token")
+	}
+	if _, ok := annotations["unneeded"]; ok {
+		t.Error("unneeded annotation was preserved")
+	}
+}

--- a/internal/controller/jatissuer/jatissuer.go
+++ b/internal/controller/jatissuer/jatissuer.go
@@ -12,17 +12,18 @@ import (
 )
 
 type client interface {
-	IssueJobAcquisitionTokens(context.Context, []string) (*api.IssueJobAcquisitionTokensResponse, time.Duration, error)
+	IssueJobAcquisitionTokens(context.Context, []string, int) (*api.IssueJobAcquisitionTokensResponse, time.Duration, error)
 }
 
 type Issuer struct {
-	logger  *slog.Logger
-	client  client
-	handler model.JobHandler
+	logger               *slog.Logger
+	client               client
+	handler              model.JobHandler
+	tokenLifetimeSeconds int
 }
 
-func New(logger *slog.Logger, client client, handler model.JobHandler) *Issuer {
-	return &Issuer{logger: logger, client: client, handler: handler}
+func New(logger *slog.Logger, client client, handler model.JobHandler, tokenLifetimeSeconds int) *Issuer {
+	return &Issuer{logger: logger, client: client, handler: handler, tokenLifetimeSeconds: tokenLifetimeSeconds}
 }
 
 func (i *Issuer) Handle(ctx context.Context, job *api.AgentScheduledJob) error {
@@ -33,7 +34,7 @@ func (i *Issuer) Handle(ctx context.Context, job *api.AgentScheduledJob) error {
 		roko.WithMaxAttempts(5),
 	)
 	response, err := roko.DoFunc(ctx, retrier, func(*roko.Retrier) (*api.IssueJobAcquisitionTokensResponse, error) {
-		response, retryAfter, err := i.client.IssueJobAcquisitionTokens(ctx, []string{job.ID})
+		response, retryAfter, err := i.client.IssueJobAcquisitionTokens(ctx, []string{job.ID}, i.tokenLifetimeSeconds)
 		if api.IsPermanentError(err) {
 			retrier.Break()
 		}

--- a/internal/controller/jatissuer/jatissuer.go
+++ b/internal/controller/jatissuer/jatissuer.go
@@ -1,0 +1,55 @@
+package jatissuer
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/buildkite/agent-stack-k8s/v2/api"
+	"github.com/buildkite/agent-stack-k8s/v2/internal/controller/model"
+	"github.com/buildkite/roko"
+)
+
+type client interface {
+	IssueJobAcquisitionTokens(context.Context, []string) (*api.IssueJobAcquisitionTokensResponse, time.Duration, error)
+}
+
+type Issuer struct {
+	logger  *slog.Logger
+	client  client
+	handler model.JobHandler
+}
+
+func New(logger *slog.Logger, client client, handler model.JobHandler) *Issuer {
+	return &Issuer{logger: logger, client: client, handler: handler}
+}
+
+func (i *Issuer) Handle(ctx context.Context, job *api.AgentScheduledJob) error {
+	i.logger.Debug("issuing job acquisition token", "job-uuid", job.ID)
+	retrier := roko.NewRetrier(
+		roko.WithStrategy(roko.ExponentialSubsecond(time.Second)),
+		roko.WithJitterRange(-time.Second, time.Second),
+		roko.WithMaxAttempts(5),
+	)
+	response, err := roko.DoFunc(ctx, retrier, func(*roko.Retrier) (*api.IssueJobAcquisitionTokensResponse, error) {
+		response, retryAfter, err := i.client.IssueJobAcquisitionTokens(ctx, []string{job.ID})
+		if api.IsPermanentError(err) {
+			retrier.Break()
+		}
+		retrier.SetNextInterval(max(retryAfter, retrier.NextInterval()))
+		return response, err
+	})
+	if err != nil {
+		return fmt.Errorf("issuing job acquisition token for job %s: %w", job.ID, err)
+	}
+	if response == nil || len(response.NotIssued) != 0 || len(response.JobAcquisitionTokens) != 1 {
+		return fmt.Errorf("job acquisition token was not issued for job %s", job.ID)
+	}
+	issued := response.JobAcquisitionTokens[0]
+	if issued.JobUUID != job.ID || issued.JobAcquisitionToken == "" {
+		return fmt.Errorf("invalid job acquisition token response for job %s", job.ID)
+	}
+	job.JobAcquisitionToken = issued.JobAcquisitionToken
+	return i.handler.Handle(ctx, job)
+}

--- a/internal/controller/jatissuer/jatissuer_test.go
+++ b/internal/controller/jatissuer/jatissuer_test.go
@@ -21,13 +21,18 @@ type fakeClient struct {
 	mu        sync.Mutex
 	responses []*api.IssueJobAcquisitionTokensResponse
 	errors    []error
-	calls     [][]string
+	calls     []fakeClientCall
 }
 
-func (f *fakeClient) IssueJobAcquisitionTokens(_ context.Context, ids []string) (*api.IssueJobAcquisitionTokensResponse, time.Duration, error) {
+type fakeClientCall struct {
+	ids                  []string
+	tokenLifetimeSeconds int
+}
+
+func (f *fakeClient) IssueJobAcquisitionTokens(_ context.Context, ids []string, tokenLifetimeSeconds int) (*api.IssueJobAcquisitionTokensResponse, time.Duration, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.calls = append(f.calls, ids)
+	f.calls = append(f.calls, fakeClientCall{ids: ids, tokenLifetimeSeconds: tokenLifetimeSeconds})
 	i := len(f.calls) - 1
 	var resp *api.IssueJobAcquisitionTokensResponse
 	if i < len(f.responses) {
@@ -75,7 +80,7 @@ func TestHandleCorrelatesIssuedTokenByJobUUID(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			next := &captureHandler{jobs: make(chan *api.AgentScheduledJob, 1)}
-			h := New(slog.Default(), &fakeClient{responses: []*api.IssueJobAcquisitionTokensResponse{test.resp}}, next)
+			h := New(slog.Default(), &fakeClient{responses: []*api.IssueJobAcquisitionTokensResponse{test.resp}}, next, 0)
 			if err := h.Handle(t.Context(), &api.AgentScheduledJob{ID: jobID}); err == nil {
 				t.Fatal("Handle() error = nil, want non-nil")
 			}
@@ -88,7 +93,7 @@ func TestHandleCorrelatesIssuedTokenByJobUUID(t *testing.T) {
 	}
 }
 
-func TestHandleRetriesAndForwardsTokenThroughDeduper(t *testing.T) {
+func TestHandleRetriesWithConfiguredLifetimeAndForwardsTokenThroughDeduper(t *testing.T) {
 	t.Parallel()
 
 	jobID := uuid.NewString()
@@ -99,7 +104,7 @@ func TestHandleRetriesAndForwardsTokenThroughDeduper(t *testing.T) {
 		errors: []error{errors.New("temporary failure"), nil},
 	}
 	next := &captureHandler{jobs: make(chan *api.AgentScheduledJob, 1)}
-	h := New(slog.Default(), client, deduper.New(slog.Default(), next))
+	h := New(slog.Default(), client, deduper.New(slog.Default(), next), 1800)
 
 	if err := h.Handle(t.Context(), &api.AgentScheduledJob{ID: jobID}); err != nil {
 		t.Fatalf("Handle() error = %v", err)
@@ -111,6 +116,14 @@ func TestHandleRetriesAndForwardsTokenThroughDeduper(t *testing.T) {
 	if got := len(client.calls); got != 2 {
 		t.Errorf("issuance calls = %d, want 2", got)
 	}
+	for i, call := range client.calls {
+		if len(call.ids) != 1 || call.ids[0] != jobID {
+			t.Errorf("issuance call %d job IDs = %v, want [%s]", i, call.ids, jobID)
+		}
+		if call.tokenLifetimeSeconds != 1800 {
+			t.Errorf("issuance call %d token lifetime = %d, want 1800", i, call.tokenLifetimeSeconds)
+		}
+	}
 }
 
 func TestIssuerRunsOnlyAfterLimiterReleasesCapacity(t *testing.T) {
@@ -121,7 +134,7 @@ func TestIssuerRunsOnlyAfterLimiterReleasesCapacity(t *testing.T) {
 		{JobAcquisitionTokens: []api.IssuedJobAcquisitionToken{{JobUUID: job2, JobAcquisitionToken: "jat-2"}}},
 	}}
 	next := &captureHandler{jobs: make(chan *api.AgentScheduledJob, 2)}
-	h := New(slog.Default(), client, next)
+	h := New(slog.Default(), client, next, 0)
 	ctx, cancel := context.WithCancel(t.Context())
 	lim := limiter.New(ctx, slog.Default(), h, 1, 1, 10)
 	defer lim.Wait()

--- a/internal/controller/jatissuer/jatissuer_test.go
+++ b/internal/controller/jatissuer/jatissuer_test.go
@@ -1,0 +1,148 @@
+package jatissuer
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/buildkite/agent-stack-k8s/v2/api"
+	"github.com/buildkite/agent-stack-k8s/v2/internal/controller/config"
+	"github.com/buildkite/agent-stack-k8s/v2/internal/controller/deduper"
+	"github.com/buildkite/agent-stack-k8s/v2/internal/controller/limiter"
+	"github.com/google/uuid"
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type fakeClient struct {
+	mu        sync.Mutex
+	responses []*api.IssueJobAcquisitionTokensResponse
+	errors    []error
+	calls     [][]string
+}
+
+func (f *fakeClient) IssueJobAcquisitionTokens(_ context.Context, ids []string) (*api.IssueJobAcquisitionTokensResponse, time.Duration, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, ids)
+	i := len(f.calls) - 1
+	var resp *api.IssueJobAcquisitionTokensResponse
+	if i < len(f.responses) {
+		resp = f.responses[i]
+	}
+	var err error
+	if i < len(f.errors) {
+		err = f.errors[i]
+	}
+	return resp, 0, err
+}
+
+type captureHandler struct {
+	jobs chan *api.AgentScheduledJob
+}
+
+func (h *captureHandler) Handle(_ context.Context, job *api.AgentScheduledJob) error {
+	h.jobs <- job
+	return nil
+}
+
+func jobStates(id string) (*batchv1.Job, *batchv1.Job) {
+	meta := metav1.ObjectMeta{Labels: map[string]string{config.UUIDLabel: id}}
+	return &batchv1.Job{ObjectMeta: meta}, &batchv1.Job{
+		ObjectMeta: meta,
+		Status:     batchv1.JobStatus{Conditions: []batchv1.JobCondition{{Type: batchv1.JobComplete}}},
+	}
+}
+
+func TestHandleCorrelatesIssuedTokenByJobUUID(t *testing.T) {
+	t.Parallel()
+
+	jobID := uuid.NewString()
+	tests := []struct {
+		name string
+		resp *api.IssueJobAcquisitionTokensResponse
+	}{
+		{name: "not issued", resp: &api.IssueJobAcquisitionTokensResponse{NotIssued: []string{jobID}}},
+		{name: "missing", resp: &api.IssueJobAcquisitionTokensResponse{}},
+		{name: "mismatched", resp: &api.IssueJobAcquisitionTokensResponse{JobAcquisitionTokens: []api.IssuedJobAcquisitionToken{{JobUUID: uuid.NewString(), JobAcquisitionToken: "wrong"}}}},
+		{name: "duplicate", resp: &api.IssueJobAcquisitionTokensResponse{JobAcquisitionTokens: []api.IssuedJobAcquisitionToken{{JobUUID: jobID, JobAcquisitionToken: "one"}, {JobUUID: jobID, JobAcquisitionToken: "two"}}}},
+		{name: "empty token", resp: &api.IssueJobAcquisitionTokensResponse{JobAcquisitionTokens: []api.IssuedJobAcquisitionToken{{JobUUID: jobID}}}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			next := &captureHandler{jobs: make(chan *api.AgentScheduledJob, 1)}
+			h := New(slog.Default(), &fakeClient{responses: []*api.IssueJobAcquisitionTokensResponse{test.resp}}, next)
+			if err := h.Handle(t.Context(), &api.AgentScheduledJob{ID: jobID}); err == nil {
+				t.Fatal("Handle() error = nil, want non-nil")
+			}
+			select {
+			case <-next.jobs:
+				t.Fatal("next handler called for malformed issuance response")
+			default:
+			}
+		})
+	}
+}
+
+func TestHandleRetriesAndForwardsTokenThroughDeduper(t *testing.T) {
+	t.Parallel()
+
+	jobID := uuid.NewString()
+	client := &fakeClient{
+		responses: []*api.IssueJobAcquisitionTokensResponse{nil, {
+			JobAcquisitionTokens: []api.IssuedJobAcquisitionToken{{JobUUID: jobID, JobAcquisitionToken: "jat-secret"}},
+		}},
+		errors: []error{errors.New("temporary failure"), nil},
+	}
+	next := &captureHandler{jobs: make(chan *api.AgentScheduledJob, 1)}
+	h := New(slog.Default(), client, deduper.New(slog.Default(), next))
+
+	if err := h.Handle(t.Context(), &api.AgentScheduledJob{ID: jobID}); err != nil {
+		t.Fatalf("Handle() error = %v", err)
+	}
+	got := <-next.jobs
+	if got.JobAcquisitionToken != "jat-secret" {
+		t.Errorf("JobAcquisitionToken = %q, want %q", got.JobAcquisitionToken, "jat-secret")
+	}
+	if got := len(client.calls); got != 2 {
+		t.Errorf("issuance calls = %d, want 2", got)
+	}
+}
+
+func TestIssuerRunsOnlyAfterLimiterReleasesCapacity(t *testing.T) {
+	job1 := uuid.NewString()
+	job2 := uuid.NewString()
+	client := &fakeClient{responses: []*api.IssueJobAcquisitionTokensResponse{
+		{JobAcquisitionTokens: []api.IssuedJobAcquisitionToken{{JobUUID: job1, JobAcquisitionToken: "jat-1"}}},
+		{JobAcquisitionTokens: []api.IssuedJobAcquisitionToken{{JobUUID: job2, JobAcquisitionToken: "jat-2"}}},
+	}}
+	next := &captureHandler{jobs: make(chan *api.AgentScheduledJob, 2)}
+	h := New(slog.Default(), client, next)
+	ctx, cancel := context.WithCancel(t.Context())
+	lim := limiter.New(ctx, slog.Default(), h, 1, 1, 10)
+	defer lim.Wait()
+	defer cancel()
+
+	if err := lim.HandleMany(ctx, []*api.AgentScheduledJob{{ID: job1}, {ID: job2}}); err != nil {
+		t.Fatalf("HandleMany() error = %v", err)
+	}
+	first := <-next.jobs
+	client.mu.Lock()
+	gotCalls := len(client.calls)
+	client.mu.Unlock()
+	if gotCalls != 1 {
+		t.Fatalf("issuance calls before capacity release = %d, want 1", gotCalls)
+	}
+
+	prev, curr := jobStates(first.ID)
+	lim.OnUpdate(prev, curr)
+	second := <-next.jobs
+	if second.ID != job2 {
+		t.Errorf("second job ID = %q, want %q", second.ID, job2)
+	}
+	cancel()
+}

--- a/internal/controller/scheduler/job_acquisition_token_secret_test.go
+++ b/internal/controller/scheduler/job_acquisition_token_secret_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/buildkite/agent-stack-k8s/v2/api"
 	"github.com/buildkite/agent-stack-k8s/v2/internal/controller/config"
 	"github.com/buildkite/agent-stack-k8s/v2/internal/controller/limiter"
+	"github.com/buildkite/agent-stack-k8s/v2/internal/controller/model"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -63,10 +64,10 @@ func TestCreateJobWithJobAcquisitionTokenSecret(t *testing.T) {
 	}
 }
 
-func TestCreateJobDoesNotCreateSecretWhenJobCreationFails(t *testing.T) {
+func TestCreateJobDoesNotCreateSecretWhenJobCreationHasDeterministicConflict(t *testing.T) {
 	k8sClient := fake.NewSimpleClientset()
 	k8sClient.PrependReactor("create", "jobs", func(k8stesting.Action) (bool, runtime.Object, error) {
-		return true, nil, errors.New("job create failed")
+		return true, nil, kerrors.NewConflict(batchv1.Resource("jobs"), "job-uuid", errors.New("conflict"))
 	})
 	worker := newJobAcquisitionTokenWorker(k8sClient)
 	kjob := buildJobWithJobAcquisitionToken(t, worker, "jat-secret")
@@ -80,6 +81,99 @@ func TestCreateJobDoesNotCreateSecretWhenJobCreationFails(t *testing.T) {
 	}
 	if len(secrets.Items) != 0 {
 		t.Errorf("len(secrets.Items) = %d, want 0", len(secrets.Items))
+	}
+	for _, action := range k8sClient.Actions() {
+		if action.GetVerb() == "get" || action.GetVerb() == "delete" {
+			t.Errorf("unexpected %s action after deterministic conflict: %v", action.GetVerb(), action)
+		}
+	}
+}
+
+type reportingHandler struct {
+	handler model.JobHandler
+	result  chan error
+}
+
+func (h *reportingHandler) Handle(ctx context.Context, job *api.AgentScheduledJob) error {
+	err := h.handler.Handle(ctx, job)
+	h.result <- err
+	return err
+}
+
+func TestHandleAlreadyExistingJobReportsDuplicateWithoutTouchingExistingResources(t *testing.T) {
+	k8sClient := fake.NewSimpleClientset()
+	worker := newJobAcquisitionTokenWorker(k8sClient)
+	existingJob := buildJobWithJobAcquisitionToken(t, worker, "original-jat")
+	existingJob.Namespace = "test-namespace"
+	existingJob.UID = "existing-job-uid"
+	if _, err := k8sClient.BatchV1().Jobs("test-namespace").Create(t.Context(), existingJob, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Create existing Job: %v", err)
+	}
+	immutable := true
+	existingSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            existingJob.Annotations[config.JobAcquisitionTokenSecretAnnotation],
+			Namespace:       existingJob.Namespace,
+			UID:             "existing-secret-uid",
+			Labels:          existingJob.Labels,
+			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(existingJob, batchv1.SchemeGroupVersion.WithKind("Job"))},
+		},
+		Immutable: &immutable,
+		Data:      map[string][]byte{agentTokenKey: []byte("original-jat")},
+	}
+	if _, err := k8sClient.CoreV1().Secrets("test-namespace").Create(t.Context(), existingSecret, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Create existing Secret: %v", err)
+	}
+
+	server := api.NewFakeAgentServer()
+	defer server.Close()
+	server.AgentJobs = map[string]*api.AgentJob{"job-uuid": {ID: "job-uuid", Command: "true"}}
+	agentClient, err := api.NewAgentClient(t.Context(), api.AgentClientOpts{
+		Token: "fake-token", Endpoint: server.URL(), StackID: "test-stack", Logger: slog.Default(),
+	})
+	if err != nil {
+		t.Fatalf("NewAgentClient() error = %v", err)
+	}
+	worker = New(slog.Default(), k8sClient, agentClient, worker.cfg)
+	reporter := &reportingHandler{handler: worker, result: make(chan error, 1)}
+	ctx, cancel := context.WithCancel(t.Context())
+	lim := limiter.New(ctx, slog.Default(), reporter, 1, 1, 10)
+	defer func() {
+		cancel()
+		lim.Wait()
+	}()
+	actionCount := len(k8sClient.Actions())
+	if err := lim.HandleMany(ctx, []*api.AgentScheduledJob{{ID: "job-uuid", JobAcquisitionToken: "new-jat", QueriedAt: time.Now()}}); err != nil {
+		t.Fatalf("HandleMany() error = %v", err)
+	}
+	select {
+	case err := <-reporter.result:
+		if !errors.Is(err, model.ErrDuplicateJob) {
+			t.Fatalf("Handle() error = %v, want ErrDuplicateJob", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for handler result")
+	}
+	handlerActions := append([]k8stesting.Action(nil), k8sClient.Actions()[actionCount:]...)
+
+	job, err := k8sClient.BatchV1().Jobs("test-namespace").Get(t.Context(), existingJob.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Get existing Job: %v", err)
+	}
+	secret, err := k8sClient.CoreV1().Secrets("test-namespace").Get(t.Context(), existingSecret.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Get existing Secret: %v", err)
+	}
+	if job.UID != existingJob.UID || secret.UID != existingSecret.UID || string(secret.Data[agentTokenKey]) != "original-jat" {
+		t.Fatalf("existing resources changed: Job UID %q, Secret UID %q, token %q", job.UID, secret.UID, secret.Data[agentTokenKey])
+	}
+	for _, action := range handlerActions {
+		if action.GetResource().Resource == "secrets" && (action.GetVerb() == "create" || action.GetVerb() == "delete") {
+			t.Errorf("unexpected Secret %s after AlreadyExists", action.GetVerb())
+		}
+		if action.GetResource().Resource == "jobs" && (action.GetVerb() == "get" || action.GetVerb() == "delete") {
+			t.Errorf("unexpected Job %s after AlreadyExists", action.GetVerb())
+		}
 	}
 }
 
@@ -108,6 +202,7 @@ func TestCreateJobDoesNotRetryPermanentJobCreationError(t *testing.T) {
 
 func TestHandleReconcilesJobCreatedBeforeResponseWasLost(t *testing.T) {
 	k8sClient := fake.NewSimpleClientset()
+	ctx, cancel := context.WithCancel(t.Context())
 	k8sClient.PrependReactor("create", "jobs", func(action k8stesting.Action) (bool, runtime.Object, error) {
 		job := action.(k8stesting.CreateAction).GetObject().(*batchv1.Job).DeepCopy()
 		job.Namespace = action.GetNamespace()
@@ -115,6 +210,7 @@ func TestHandleReconcilesJobCreatedBeforeResponseWasLost(t *testing.T) {
 		if err := k8sClient.Tracker().Create(batchv1.SchemeGroupVersion.WithResource("jobs"), job, job.Namespace); err != nil {
 			t.Fatalf("Track accepted job: %v", err)
 		}
+		cancel()
 		return true, nil, errors.New("job create response lost")
 	})
 	getCalls := 0
@@ -137,14 +233,8 @@ func TestHandleReconcilesJobCreatedBeforeResponseWasLost(t *testing.T) {
 	worker := New(slog.Default(), k8sClient, agentClient, Config{
 		Image: "buildkite/agent:latest", Namespace: "test-namespace", ID: "controller-id", EnableJobAcquisitionTokens: true,
 	})
-	ctx, cancel := context.WithCancel(t.Context())
-	lim := limiter.New(ctx, slog.Default(), worker, 1, 1, 10)
-	defer func() {
-		cancel()
-		lim.Wait()
-	}()
-	if err := lim.HandleMany(ctx, []*api.AgentScheduledJob{{ID: "job-uuid", JobAcquisitionToken: "jat-secret", QueriedAt: time.Now()}}); err != nil {
-		t.Fatalf("HandleMany() error = %v", err)
+	if err := worker.Handle(ctx, &api.AgentScheduledJob{ID: "job-uuid", JobAcquisitionToken: "jat-secret", QueriedAt: time.Now()}); err != nil {
+		t.Fatalf("Handle() error = %v", err)
 	}
 
 	var secret *corev1.Secret
@@ -168,6 +258,79 @@ func TestHandleReconcilesJobCreatedBeforeResponseWasLost(t *testing.T) {
 	}
 	if got := string(secret.Data[agentTokenKey]); got != "jat-secret" {
 		t.Errorf("reconciled secret token = %q, want jat-secret", got)
+	}
+}
+
+func TestCreateJobRecoversVerifiedJobForCleanupAfterLookupRetriesExhausted(t *testing.T) {
+	k8sClient := fake.NewSimpleClientset()
+	k8sClient.PrependReactor("create", "jobs", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		job := action.(k8stesting.CreateAction).GetObject().(*batchv1.Job).DeepCopy()
+		job.Namespace = action.GetNamespace()
+		job.UID = "accepted-job-uid"
+		if err := k8sClient.Tracker().Create(batchv1.SchemeGroupVersion.WithResource("jobs"), job, job.Namespace); err != nil {
+			t.Fatalf("Track accepted job: %v", err)
+		}
+		return true, nil, errors.New("job create response lost")
+	})
+	getCalls := 0
+	k8sClient.PrependReactor("get", "jobs", func(k8stesting.Action) (bool, runtime.Object, error) {
+		getCalls++
+		if getCalls <= resourceReconciliationBackoff.Steps {
+			return true, nil, kerrors.NewServerTimeout(batchv1.Resource("jobs"), "get", 0)
+		}
+		return false, nil, nil
+	})
+	worker := newJobAcquisitionTokenWorker(k8sClient)
+	kjob := buildJobWithJobAcquisitionToken(t, worker, "jat-secret")
+
+	if err := worker.createJob(t.Context(), kjob, "jat-secret"); err == nil {
+		t.Fatal("createJob() error = nil, want reconciliation error")
+	}
+	if getCalls <= resourceReconciliationBackoff.Steps {
+		t.Fatalf("Job get calls = %d, want bounded recovery after %d normal attempts", getCalls, resourceReconciliationBackoff.Steps)
+	}
+	if _, err := k8sClient.BatchV1().Jobs("test-namespace").Get(t.Context(), kjob.Name, metav1.GetOptions{}); !kerrors.IsNotFound(err) {
+		t.Fatalf("Get cleaned Job error = %v, want NotFound", err)
+	}
+	for _, action := range k8sClient.Actions() {
+		deleteAction, ok := action.(k8stesting.DeleteAction)
+		if !ok || action.GetResource().Resource != "jobs" {
+			continue
+		}
+		preconditions := deleteAction.GetDeleteOptions().Preconditions
+		if preconditions == nil || preconditions.UID == nil || *preconditions.UID != "accepted-job-uid" {
+			t.Errorf("Job delete UID precondition = %v, want accepted-job-uid", preconditions)
+		}
+	}
+}
+
+func TestCreateJobDoesNotDeleteUnverifiedJobWhenRecoveryExhausted(t *testing.T) {
+	k8sClient := fake.NewSimpleClientset()
+	k8sClient.PrependReactor("create", "jobs", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		job := action.(k8stesting.CreateAction).GetObject().(*batchv1.Job).DeepCopy()
+		job.Namespace = action.GetNamespace()
+		job.UID = "accepted-job-uid"
+		if err := k8sClient.Tracker().Create(batchv1.SchemeGroupVersion.WithResource("jobs"), job, job.Namespace); err != nil {
+			t.Fatalf("Track accepted job: %v", err)
+		}
+		return true, nil, errors.New("job create response lost")
+	})
+	k8sClient.PrependReactor("get", "jobs", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, kerrors.NewServerTimeout(batchv1.Resource("jobs"), "get", 0)
+	})
+	worker := newJobAcquisitionTokenWorker(k8sClient)
+	kjob := buildJobWithJobAcquisitionToken(t, worker, "jat-secret")
+
+	if err := worker.createJob(t.Context(), kjob, "jat-secret"); err == nil || !strings.Contains(err.Error(), "failed to recover job for cleanup") {
+		t.Fatalf("createJob() error = %v, want exhausted recovery error", err)
+	}
+	if _, err := k8sClient.Tracker().Get(batchv1.SchemeGroupVersion.WithResource("jobs"), "test-namespace", kjob.Name); err != nil {
+		t.Fatalf("accepted unverified Job was removed: %v", err)
+	}
+	for _, action := range k8sClient.Actions() {
+		if action.GetVerb() == "delete" {
+			t.Errorf("unexpected unverified %s delete", action.GetResource().Resource)
+		}
 	}
 }
 
@@ -278,9 +441,12 @@ func TestCreateJobDoesNotReconcileJobWithDifferentIdentity(t *testing.T) {
 			preexistingJob.Namespace = "test-namespace"
 			preexistingJob.UID = "preexisting-job-uid"
 			preexistingJob.Labels[tt.label] = tt.value
-			if _, err := k8sClient.BatchV1().Jobs("test-namespace").Create(t.Context(), preexistingJob, metav1.CreateOptions{}); err != nil {
-				t.Fatalf("Create pre-existing job: %v", err)
-			}
+			k8sClient.PrependReactor("create", "jobs", func(k8stesting.Action) (bool, runtime.Object, error) {
+				if err := k8sClient.Tracker().Create(batchv1.SchemeGroupVersion.WithResource("jobs"), preexistingJob, preexistingJob.Namespace); err != nil {
+					t.Fatalf("Track conflicting job: %v", err)
+				}
+				return true, nil, errors.New("job create response lost")
+			})
 			retryJob := buildJobWithJobAcquisitionToken(t, worker, "retry-jat")
 
 			if err := worker.createJob(t.Context(), retryJob, "retry-jat"); err == nil {

--- a/internal/controller/scheduler/job_acquisition_token_secret_test.go
+++ b/internal/controller/scheduler/job_acquisition_token_secret_test.go
@@ -1,0 +1,185 @@
+package scheduler
+
+import (
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/buildkite/agent-stack-k8s/v2/api"
+	"github.com/buildkite/agent-stack-k8s/v2/internal/controller/config"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+	"sigs.k8s.io/yaml"
+)
+
+func TestCreateJobWithJobAcquisitionTokenSecret(t *testing.T) {
+	k8sClient := fake.NewSimpleClientset()
+	setCreatedJobUID(k8sClient)
+	worker := newJobAcquisitionTokenWorker(k8sClient)
+	kjob := buildJobWithJobAcquisitionToken(t, worker, "jat-secret")
+
+	if err := worker.createJob(t.Context(), kjob, "jat-secret"); err != nil {
+		t.Fatalf("createJob() error = %v", err)
+	}
+
+	secretName := kjob.Annotations[config.JobAcquisitionTokenSecretAnnotation]
+	secret, err := k8sClient.CoreV1().Secrets("test-namespace").Get(t.Context(), secretName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Get secret: %v", err)
+	}
+	if secret.Immutable == nil || !*secret.Immutable {
+		t.Errorf("secret.Immutable = %v, want true", secret.Immutable)
+	}
+	if got := string(secret.Data[agentTokenKey]); got != "jat-secret" {
+		t.Errorf("secret token = %q, want %q", got, "jat-secret")
+	}
+	if got := secret.Labels[config.UUIDLabel]; got != "job-uuid" {
+		t.Errorf("secret job UUID label = %q, want %q", got, "job-uuid")
+	}
+	if got := secret.Labels[config.ControllerIDLabel]; got != "controller-id" {
+		t.Errorf("secret controller ID label = %q, want %q", got, "controller-id")
+	}
+	if len(secret.OwnerReferences) != 1 || secret.OwnerReferences[0].Name != kjob.Name || secret.OwnerReferences[0].UID != "created-job-uid" {
+		t.Errorf("secret owner references = %#v, want created Job", secret.OwnerReferences)
+	}
+
+	jobYAML, err := yaml.Marshal(kjob)
+	if err != nil {
+		t.Fatalf("yaml.Marshal(kjob) error = %v", err)
+	}
+	if strings.Contains(string(jobYAML), "jat-secret") {
+		t.Errorf("Job contains literal JAT:\n%s", jobYAML)
+	}
+}
+
+func TestCreateJobDoesNotCreateSecretWhenJobCreationFails(t *testing.T) {
+	k8sClient := fake.NewSimpleClientset()
+	k8sClient.PrependReactor("create", "jobs", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("job create failed")
+	})
+	worker := newJobAcquisitionTokenWorker(k8sClient)
+	kjob := buildJobWithJobAcquisitionToken(t, worker, "jat-secret")
+
+	if err := worker.createJob(t.Context(), kjob, "jat-secret"); err == nil {
+		t.Fatal("createJob() error = nil, want error")
+	}
+	secrets, err := k8sClient.CoreV1().Secrets("test-namespace").List(t.Context(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("List secrets: %v", err)
+	}
+	if len(secrets.Items) != 0 {
+		t.Errorf("len(secrets.Items) = %d, want 0", len(secrets.Items))
+	}
+}
+
+func TestCreateJobCleansUpJobWhenSecretCreationFails(t *testing.T) {
+	k8sClient := fake.NewSimpleClientset()
+	k8sClient.PrependReactor("create", "secrets", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("secret create failed")
+	})
+	worker := newJobAcquisitionTokenWorker(k8sClient)
+	kjob := buildJobWithJobAcquisitionToken(t, worker, "jat-secret")
+
+	if err := worker.createJob(t.Context(), kjob, "jat-secret"); err == nil {
+		t.Fatal("createJob() error = nil, want error")
+	}
+	jobs, err := k8sClient.BatchV1().Jobs("test-namespace").List(t.Context(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("List jobs: %v", err)
+	}
+	if len(jobs.Items) != 0 {
+		t.Errorf("len(jobs.Items) = %d, want 0", len(jobs.Items))
+	}
+	secrets, err := k8sClient.CoreV1().Secrets("test-namespace").List(t.Context(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("List secrets: %v", err)
+	}
+	if len(secrets.Items) != 0 {
+		t.Errorf("len(secrets.Items) = %d, want 0", len(secrets.Items))
+	}
+}
+
+func TestCreateJobRetryDoesNotReplaceExistingJobSecret(t *testing.T) {
+	k8sClient := fake.NewSimpleClientset()
+	setCreatedJobUID(k8sClient)
+	worker := newJobAcquisitionTokenWorker(k8sClient)
+	firstJob := buildJobWithJobAcquisitionToken(t, worker, "first-jat")
+	if err := worker.createJob(t.Context(), firstJob, "first-jat"); err != nil {
+		t.Fatalf("first createJob() error = %v", err)
+	}
+
+	retryJob := buildJobWithJobAcquisitionToken(t, worker, "retry-jat")
+	if err := worker.createJob(t.Context(), retryJob, "retry-jat"); err == nil {
+		t.Fatal("retry createJob() error = nil, want duplicate error")
+	}
+	secrets, err := k8sClient.CoreV1().Secrets("test-namespace").List(t.Context(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("List secrets: %v", err)
+	}
+	if len(secrets.Items) != 1 {
+		t.Fatalf("len(secrets.Items) = %d, want 1", len(secrets.Items))
+	}
+	if got := secrets.Items[0].Name; got != firstJob.Annotations[config.JobAcquisitionTokenSecretAnnotation] {
+		t.Errorf("remaining secret = %q, want %q", got, firstJob.Annotations[config.JobAcquisitionTokenSecretAnnotation])
+	}
+	if got := string(secrets.Items[0].Data[agentTokenKey]); got != "first-jat" {
+		t.Errorf("remaining token = %q, want %q", got, "first-jat")
+	}
+}
+
+func TestCreateJobWithoutJobAcquisitionTokensUsesNoPerJobSecret(t *testing.T) {
+	k8sClient := fake.NewSimpleClientset()
+	worker := New(slog.Default(), k8sClient, nil, Config{Image: "buildkite/agent:latest", Namespace: "test-namespace"})
+	kjob, err := worker.Build(&corev1.PodSpec{}, false, buildInputs{uuid: "job-uuid", envMap: map[string]string{}})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if err := worker.createJob(t.Context(), kjob, ""); err != nil {
+		t.Fatalf("createJob() error = %v", err)
+	}
+	secrets, err := k8sClient.CoreV1().Secrets("test-namespace").List(t.Context(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("List secrets: %v", err)
+	}
+	if len(secrets.Items) != 0 {
+		t.Errorf("len(secrets.Items) = %d, want 0", len(secrets.Items))
+	}
+}
+
+func newJobAcquisitionTokenWorker(k8sClient *fake.Clientset) *worker {
+	return New(slog.Default(), k8sClient, nil, Config{
+		Image:                      "buildkite/agent:latest",
+		Namespace:                  "test-namespace",
+		ID:                         "controller-id",
+		EnableJobAcquisitionTokens: true,
+	})
+}
+
+func buildJobWithJobAcquisitionToken(t *testing.T, worker *worker, token api.JobAcquisitionToken) *batchv1.Job {
+	t.Helper()
+	inputs, err := worker.ParseJob(
+		&api.AgentJob{ID: "job-uuid", Command: "true"},
+		&api.AgentScheduledJob{ID: "job-uuid", JobAcquisitionToken: token},
+	)
+	if err != nil {
+		t.Fatalf("ParseJob() error = %v", err)
+	}
+	kjob, err := worker.Build(&corev1.PodSpec{}, false, inputs)
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	return kjob
+}
+
+func setCreatedJobUID(k8sClient *fake.Clientset) {
+	k8sClient.PrependReactor("create", "jobs", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		action.(k8stesting.CreateAction).GetObject().(*batchv1.Job).UID = types.UID("created-job-uid")
+		return false, nil, nil
+	})
+}

--- a/internal/controller/scheduler/job_acquisition_token_secret_test.go
+++ b/internal/controller/scheduler/job_acquisition_token_secret_test.go
@@ -1,19 +1,23 @@
 package scheduler
 
 import (
+	"context"
 	"errors"
 	"log/slog"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/buildkite/agent-stack-k8s/v2/api"
 	"github.com/buildkite/agent-stack-k8s/v2/internal/controller/config"
+	"github.com/buildkite/agent-stack-k8s/v2/internal/controller/limiter"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
 	"sigs.k8s.io/yaml"
@@ -79,14 +83,32 @@ func TestCreateJobDoesNotCreateSecretWhenJobCreationFails(t *testing.T) {
 	}
 }
 
-func TestCreateJobRetryRecoversJobCreatedBeforeResponseWasLost(t *testing.T) {
+func TestCreateJobDoesNotRetryPermanentJobCreationError(t *testing.T) {
 	k8sClient := fake.NewSimpleClientset()
 	createCalls := 0
-	k8sClient.PrependReactor("create", "jobs", func(action k8stesting.Action) (bool, runtime.Object, error) {
+	k8sClient.PrependReactor("create", "jobs", func(k8stesting.Action) (bool, runtime.Object, error) {
 		createCalls++
-		if createCalls != 1 {
-			return false, nil, nil
+		return true, nil, kerrors.NewForbidden(batchv1.Resource("jobs"), "job-uuid", errors.New("forbidden"))
+	})
+	worker := newJobAcquisitionTokenWorker(k8sClient)
+	kjob := buildJobWithJobAcquisitionToken(t, worker, "jat-secret")
+
+	if err := worker.createJob(t.Context(), kjob, "jat-secret"); !kerrors.IsForbidden(err) {
+		t.Fatalf("createJob() error = %v, want Forbidden", err)
+	}
+	if createCalls != 1 {
+		t.Errorf("Job create calls = %d, want 1", createCalls)
+	}
+	for _, action := range k8sClient.Actions() {
+		if action.GetVerb() == "get" || action.GetVerb() == "delete" {
+			t.Errorf("unexpected %s action after permanent error: %v", action.GetVerb(), action)
 		}
+	}
+}
+
+func TestHandleReconcilesJobCreatedBeforeResponseWasLost(t *testing.T) {
+	k8sClient := fake.NewSimpleClientset()
+	k8sClient.PrependReactor("create", "jobs", func(action k8stesting.Action) (bool, runtime.Object, error) {
 		job := action.(k8stesting.CreateAction).GetObject().(*batchv1.Job).DeepCopy()
 		job.Namespace = action.GetNamespace()
 		job.UID = "accepted-job-uid"
@@ -103,44 +125,76 @@ func TestCreateJobRetryRecoversJobCreatedBeforeResponseWasLost(t *testing.T) {
 		}
 		return false, nil, nil
 	})
-	worker := newJobAcquisitionTokenWorker(k8sClient)
-	firstJob := buildJobWithJobAcquisitionToken(t, worker, "first-jat")
-	firstSecretName := firstJob.Annotations[config.JobAcquisitionTokenSecretAnnotation]
-
-	if err := worker.createJob(t.Context(), firstJob, "first-jat"); err == nil {
-		t.Fatal("first createJob() error = nil, want ambiguous creation error")
+	server := api.NewFakeAgentServer()
+	defer server.Close()
+	server.AgentJobs = map[string]*api.AgentJob{"job-uuid": {ID: "job-uuid", Command: "true"}}
+	agentClient, err := api.NewAgentClient(t.Context(), api.AgentClientOpts{
+		Token: "fake-token", Endpoint: server.URL(), StackID: "test-stack", Logger: slog.Default(),
+	})
+	if err != nil {
+		t.Fatalf("NewAgentClient() error = %v", err)
+	}
+	worker := New(slog.Default(), k8sClient, agentClient, Config{
+		Image: "buildkite/agent:latest", Namespace: "test-namespace", ID: "controller-id", EnableJobAcquisitionTokens: true,
+	})
+	ctx, cancel := context.WithCancel(t.Context())
+	lim := limiter.New(ctx, slog.Default(), worker, 1, 1, 10)
+	defer func() {
+		cancel()
+		lim.Wait()
+	}()
+	if err := lim.HandleMany(ctx, []*api.AgentScheduledJob{{ID: "job-uuid", JobAcquisitionToken: "jat-secret", QueriedAt: time.Now()}}); err != nil {
+		t.Fatalf("HandleMany() error = %v", err)
 	}
 
-	retryJob := buildJobWithJobAcquisitionToken(t, worker, "retry-jat")
-	if err := worker.createJob(t.Context(), retryJob, "retry-jat"); err != nil {
-		t.Fatalf("retry createJob() error = %v", err)
+	var secret *corev1.Secret
+	err = wait.PollUntilContextTimeout(t.Context(), 10*time.Millisecond, time.Second, true, func(ctx context.Context) (bool, error) {
+		secrets, err := k8sClient.CoreV1().Secrets("test-namespace").List(ctx, metav1.ListOptions{})
+		if err != nil || len(secrets.Items) == 0 {
+			return false, err
+		}
+		secret = &secrets.Items[0]
+		return true, nil
+	})
+	if err != nil {
+		t.Fatalf("waiting for reconciled secret: %v", err)
 	}
-	acceptedJob, err := k8sClient.BatchV1().Jobs("test-namespace").Get(t.Context(), firstJob.Name, metav1.GetOptions{})
+	acceptedJob, err := k8sClient.BatchV1().Jobs("test-namespace").Get(t.Context(), "job-uuid", metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Get accepted job: %v", err)
-	}
-	if got := acceptedJob.Annotations[config.JobAcquisitionTokenSecretAnnotation]; got != firstSecretName {
-		t.Errorf("accepted Job secret annotation = %q, want %q", got, firstSecretName)
-	}
-	secret, err := k8sClient.CoreV1().Secrets("test-namespace").Get(t.Context(), firstSecretName, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("Get reconciled secret: %v", err)
-	}
-	if got := string(secret.Data[agentTokenKey]); got != "retry-jat" {
-		t.Errorf("reconciled secret token = %q, want retry-jat", got)
 	}
 	if len(secret.OwnerReferences) != 1 || secret.OwnerReferences[0].UID != acceptedJob.UID {
 		t.Errorf("reconciled secret owner references = %#v, want accepted Job UID %q", secret.OwnerReferences, acceptedJob.UID)
 	}
-	if _, err := k8sClient.CoreV1().Secrets("test-namespace").Get(t.Context(), retryJob.Annotations[config.JobAcquisitionTokenSecretAnnotation], metav1.GetOptions{}); err == nil {
-		t.Fatal("retry's newly generated Secret unexpectedly exists")
+	if got := string(secret.Data[agentTokenKey]); got != "jat-secret" {
+		t.Errorf("reconciled secret token = %q, want jat-secret", got)
 	}
 }
 
-func TestCreateJobLeavesAcceptedJobForRetryWhenSecretCreationFails(t *testing.T) {
+func TestCreateJobExhaustedSecretReconciliationCleansVerifiedJobAndOwnedSecret(t *testing.T) {
 	k8sClient := fake.NewSimpleClientset()
-	k8sClient.PrependReactor("create", "secrets", func(k8stesting.Action) (bool, runtime.Object, error) {
-		return true, nil, errors.New("secret create failed")
+	setCreatedJobUID(k8sClient)
+	createCalls := 0
+	k8sClient.PrependReactor("create", "secrets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		createCalls++
+		if createCalls != 1 {
+			return false, nil, nil
+		}
+		secret := action.(k8stesting.CreateAction).GetObject().(*corev1.Secret).DeepCopy()
+		secret.Namespace = action.GetNamespace()
+		secret.UID = "accepted-secret-uid"
+		if err := k8sClient.Tracker().Create(corev1.SchemeGroupVersion.WithResource("secrets"), secret, secret.Namespace); err != nil {
+			t.Fatalf("Track accepted secret: %v", err)
+		}
+		return true, nil, errors.New("secret create response lost")
+	})
+	getCalls := 0
+	k8sClient.PrependReactor("get", "secrets", func(k8stesting.Action) (bool, runtime.Object, error) {
+		getCalls++
+		if getCalls <= resourceReconciliationBackoff.Steps {
+			return true, nil, kerrors.NewServerTimeout(corev1.Resource("secrets"), "get", 0)
+		}
+		return false, nil, nil
 	})
 	worker := newJobAcquisitionTokenWorker(k8sClient)
 	kjob := buildJobWithJobAcquisitionToken(t, worker, "jat-secret")
@@ -148,60 +202,56 @@ func TestCreateJobLeavesAcceptedJobForRetryWhenSecretCreationFails(t *testing.T)
 	if err := worker.createJob(t.Context(), kjob, "jat-secret"); err == nil {
 		t.Fatal("createJob() error = nil, want error")
 	}
-	jobs, err := k8sClient.BatchV1().Jobs("test-namespace").List(t.Context(), metav1.ListOptions{})
-	if err != nil {
-		t.Fatalf("List jobs: %v", err)
+	if _, err := k8sClient.BatchV1().Jobs("test-namespace").Get(t.Context(), kjob.Name, metav1.GetOptions{}); !kerrors.IsNotFound(err) {
+		t.Fatalf("Get cleaned Job error = %v, want NotFound", err)
 	}
-	if len(jobs.Items) != 1 {
-		t.Errorf("len(jobs.Items) = %d, want 1", len(jobs.Items))
+	secretName := kjob.Annotations[config.JobAcquisitionTokenSecretAnnotation]
+	if _, err := k8sClient.CoreV1().Secrets("test-namespace").Get(t.Context(), secretName, metav1.GetOptions{}); !kerrors.IsNotFound(err) {
+		t.Fatalf("Get cleaned Secret error = %v, want NotFound", err)
 	}
-	secrets, err := k8sClient.CoreV1().Secrets("test-namespace").List(t.Context(), metav1.ListOptions{})
-	if err != nil {
-		t.Fatalf("List secrets: %v", err)
+	deleteCounts := map[string]int{}
+	for _, action := range k8sClient.Actions() {
+		deleteAction, ok := action.(k8stesting.DeleteAction)
+		if !ok {
+			continue
+		}
+		deleteCounts[action.GetResource().Resource]++
+		preconditions := deleteAction.GetDeleteOptions().Preconditions
+		if action.GetResource().Resource == "jobs" && (preconditions == nil || preconditions.UID == nil || *preconditions.UID != "created-job-uid") {
+			t.Errorf("Job delete UID precondition = %v, want created-job-uid", preconditions)
+		}
+		if action.GetResource().Resource == "secrets" && (preconditions == nil || preconditions.UID == nil || *preconditions.UID != "accepted-secret-uid") {
+			t.Errorf("Secret delete UID precondition = %v, want accepted-secret-uid", preconditions)
+		}
 	}
-	if len(secrets.Items) != 0 {
-		t.Errorf("len(secrets.Items) = %d, want 0", len(secrets.Items))
-	}
-}
-
-func TestCreateJobRetryReusesExistingSecretOwnedByAcceptedJob(t *testing.T) {
-	k8sClient := fake.NewSimpleClientset()
-	setCreatedJobUID(k8sClient)
-	worker := newJobAcquisitionTokenWorker(k8sClient)
-	firstJob := buildJobWithJobAcquisitionToken(t, worker, "first-jat")
-	if err := worker.createJob(t.Context(), firstJob, "first-jat"); err != nil {
-		t.Fatalf("first createJob() error = %v", err)
-	}
-
-	retryJob := buildJobWithJobAcquisitionToken(t, worker, "retry-jat")
-	if err := worker.createJob(t.Context(), retryJob, "retry-jat"); err != nil {
-		t.Fatalf("retry createJob() error = %v", err)
-	}
-	secrets, err := k8sClient.CoreV1().Secrets("test-namespace").List(t.Context(), metav1.ListOptions{})
-	if err != nil {
-		t.Fatalf("List secrets: %v", err)
-	}
-	if len(secrets.Items) != 1 {
-		t.Fatalf("len(secrets.Items) = %d, want 1", len(secrets.Items))
-	}
-	if got := secrets.Items[0].Name; got != firstJob.Annotations[config.JobAcquisitionTokenSecretAnnotation] {
-		t.Errorf("remaining secret = %q, want %q", got, firstJob.Annotations[config.JobAcquisitionTokenSecretAnnotation])
-	}
-	if got := string(secrets.Items[0].Data[agentTokenKey]); got != "first-jat" {
-		t.Errorf("remaining token = %q, want %q", got, "first-jat")
+	if deleteCounts["jobs"] != 1 || deleteCounts["secrets"] != 1 {
+		t.Errorf("delete counts = %v, want one Job and one Secret", deleteCounts)
 	}
 }
 
-func TestCreateJobReconcilesSecretCreatedBeforeResponseWasLost(t *testing.T) {
+func TestCreateJobReconcilesTransientSecretCreateAndGetAmbiguity(t *testing.T) {
 	k8sClient := fake.NewSimpleClientset()
 	setCreatedJobUID(k8sClient)
+	createCalls := 0
 	k8sClient.PrependReactor("create", "secrets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		createCalls++
+		if createCalls != 1 {
+			return false, nil, nil
+		}
 		secret := action.(k8stesting.CreateAction).GetObject().(*corev1.Secret).DeepCopy()
 		secret.Namespace = action.GetNamespace()
 		if err := k8sClient.Tracker().Create(corev1.SchemeGroupVersion.WithResource("secrets"), secret, secret.Namespace); err != nil {
 			t.Fatalf("Track accepted secret: %v", err)
 		}
 		return true, nil, errors.New("secret create response lost")
+	})
+	getCalls := 0
+	k8sClient.PrependReactor("get", "secrets", func(k8stesting.Action) (bool, runtime.Object, error) {
+		getCalls++
+		if getCalls == 1 {
+			return true, nil, kerrors.NewServerTimeout(corev1.Resource("secrets"), "get", 0)
+		}
+		return false, nil, nil
 	})
 	worker := newJobAcquisitionTokenWorker(k8sClient)
 	kjob := buildJobWithJobAcquisitionToken(t, worker, "jat-secret")
@@ -235,6 +285,9 @@ func TestCreateJobDoesNotReconcileJobWithDifferentIdentity(t *testing.T) {
 
 			if err := worker.createJob(t.Context(), retryJob, "retry-jat"); err == nil {
 				t.Fatal("createJob() error = nil, want conflicting Job error")
+			}
+			if _, err := k8sClient.BatchV1().Jobs("test-namespace").Get(t.Context(), preexistingJob.Name, metav1.GetOptions{}); err != nil {
+				t.Fatalf("Get pre-existing Job after conflict: %v", err)
 			}
 			if _, err := k8sClient.CoreV1().Secrets("test-namespace").Get(t.Context(), preexistingJob.Annotations[config.JobAcquisitionTokenSecretAnnotation], metav1.GetOptions{}); !kerrors.IsNotFound(err) {
 				t.Fatalf("Get hostile Job secret error = %v, want NotFound", err)
@@ -273,6 +326,9 @@ func TestCreateJobDoesNotReuseSecretOwnedByDifferentJob(t *testing.T) {
 	}
 	if got := secret.OwnerReferences[0].UID; got != "different-job-uid" {
 		t.Errorf("foreign secret owner UID = %q, want different-job-uid", got)
+	}
+	if _, err := k8sClient.BatchV1().Jobs("test-namespace").Get(t.Context(), kjob.Name, metav1.GetOptions{}); !kerrors.IsNotFound(err) {
+		t.Fatalf("Get cleaned Job error = %v, want NotFound", err)
 	}
 }
 

--- a/internal/controller/scheduler/job_acquisition_token_secret_test.go
+++ b/internal/controller/scheduler/job_acquisition_token_secret_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/buildkite/agent-stack-k8s/v2/internal/controller/config"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -78,7 +79,65 @@ func TestCreateJobDoesNotCreateSecretWhenJobCreationFails(t *testing.T) {
 	}
 }
 
-func TestCreateJobCleansUpJobWhenSecretCreationFails(t *testing.T) {
+func TestCreateJobRetryRecoversJobCreatedBeforeResponseWasLost(t *testing.T) {
+	k8sClient := fake.NewSimpleClientset()
+	createCalls := 0
+	k8sClient.PrependReactor("create", "jobs", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		createCalls++
+		if createCalls != 1 {
+			return false, nil, nil
+		}
+		job := action.(k8stesting.CreateAction).GetObject().(*batchv1.Job).DeepCopy()
+		job.Namespace = action.GetNamespace()
+		job.UID = "accepted-job-uid"
+		if err := k8sClient.Tracker().Create(batchv1.SchemeGroupVersion.WithResource("jobs"), job, job.Namespace); err != nil {
+			t.Fatalf("Track accepted job: %v", err)
+		}
+		return true, nil, errors.New("job create response lost")
+	})
+	getCalls := 0
+	k8sClient.PrependReactor("get", "jobs", func(k8stesting.Action) (bool, runtime.Object, error) {
+		getCalls++
+		if getCalls == 1 {
+			return true, nil, errors.New("job lookup temporarily failed")
+		}
+		return false, nil, nil
+	})
+	worker := newJobAcquisitionTokenWorker(k8sClient)
+	firstJob := buildJobWithJobAcquisitionToken(t, worker, "first-jat")
+	firstSecretName := firstJob.Annotations[config.JobAcquisitionTokenSecretAnnotation]
+
+	if err := worker.createJob(t.Context(), firstJob, "first-jat"); err == nil {
+		t.Fatal("first createJob() error = nil, want ambiguous creation error")
+	}
+
+	retryJob := buildJobWithJobAcquisitionToken(t, worker, "retry-jat")
+	if err := worker.createJob(t.Context(), retryJob, "retry-jat"); err != nil {
+		t.Fatalf("retry createJob() error = %v", err)
+	}
+	acceptedJob, err := k8sClient.BatchV1().Jobs("test-namespace").Get(t.Context(), firstJob.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Get accepted job: %v", err)
+	}
+	if got := acceptedJob.Annotations[config.JobAcquisitionTokenSecretAnnotation]; got != firstSecretName {
+		t.Errorf("accepted Job secret annotation = %q, want %q", got, firstSecretName)
+	}
+	secret, err := k8sClient.CoreV1().Secrets("test-namespace").Get(t.Context(), firstSecretName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Get reconciled secret: %v", err)
+	}
+	if got := string(secret.Data[agentTokenKey]); got != "retry-jat" {
+		t.Errorf("reconciled secret token = %q, want retry-jat", got)
+	}
+	if len(secret.OwnerReferences) != 1 || secret.OwnerReferences[0].UID != acceptedJob.UID {
+		t.Errorf("reconciled secret owner references = %#v, want accepted Job UID %q", secret.OwnerReferences, acceptedJob.UID)
+	}
+	if _, err := k8sClient.CoreV1().Secrets("test-namespace").Get(t.Context(), retryJob.Annotations[config.JobAcquisitionTokenSecretAnnotation], metav1.GetOptions{}); err == nil {
+		t.Fatal("retry's newly generated Secret unexpectedly exists")
+	}
+}
+
+func TestCreateJobLeavesAcceptedJobForRetryWhenSecretCreationFails(t *testing.T) {
 	k8sClient := fake.NewSimpleClientset()
 	k8sClient.PrependReactor("create", "secrets", func(k8stesting.Action) (bool, runtime.Object, error) {
 		return true, nil, errors.New("secret create failed")
@@ -93,8 +152,8 @@ func TestCreateJobCleansUpJobWhenSecretCreationFails(t *testing.T) {
 	if err != nil {
 		t.Fatalf("List jobs: %v", err)
 	}
-	if len(jobs.Items) != 0 {
-		t.Errorf("len(jobs.Items) = %d, want 0", len(jobs.Items))
+	if len(jobs.Items) != 1 {
+		t.Errorf("len(jobs.Items) = %d, want 1", len(jobs.Items))
 	}
 	secrets, err := k8sClient.CoreV1().Secrets("test-namespace").List(t.Context(), metav1.ListOptions{})
 	if err != nil {
@@ -105,7 +164,7 @@ func TestCreateJobCleansUpJobWhenSecretCreationFails(t *testing.T) {
 	}
 }
 
-func TestCreateJobRetryDoesNotReplaceExistingJobSecret(t *testing.T) {
+func TestCreateJobRetryReusesExistingSecretOwnedByAcceptedJob(t *testing.T) {
 	k8sClient := fake.NewSimpleClientset()
 	setCreatedJobUID(k8sClient)
 	worker := newJobAcquisitionTokenWorker(k8sClient)
@@ -115,8 +174,8 @@ func TestCreateJobRetryDoesNotReplaceExistingJobSecret(t *testing.T) {
 	}
 
 	retryJob := buildJobWithJobAcquisitionToken(t, worker, "retry-jat")
-	if err := worker.createJob(t.Context(), retryJob, "retry-jat"); err == nil {
-		t.Fatal("retry createJob() error = nil, want duplicate error")
+	if err := worker.createJob(t.Context(), retryJob, "retry-jat"); err != nil {
+		t.Fatalf("retry createJob() error = %v", err)
 	}
 	secrets, err := k8sClient.CoreV1().Secrets("test-namespace").List(t.Context(), metav1.ListOptions{})
 	if err != nil {
@@ -130,6 +189,90 @@ func TestCreateJobRetryDoesNotReplaceExistingJobSecret(t *testing.T) {
 	}
 	if got := string(secrets.Items[0].Data[agentTokenKey]); got != "first-jat" {
 		t.Errorf("remaining token = %q, want %q", got, "first-jat")
+	}
+}
+
+func TestCreateJobReconcilesSecretCreatedBeforeResponseWasLost(t *testing.T) {
+	k8sClient := fake.NewSimpleClientset()
+	setCreatedJobUID(k8sClient)
+	k8sClient.PrependReactor("create", "secrets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		secret := action.(k8stesting.CreateAction).GetObject().(*corev1.Secret).DeepCopy()
+		secret.Namespace = action.GetNamespace()
+		if err := k8sClient.Tracker().Create(corev1.SchemeGroupVersion.WithResource("secrets"), secret, secret.Namespace); err != nil {
+			t.Fatalf("Track accepted secret: %v", err)
+		}
+		return true, nil, errors.New("secret create response lost")
+	})
+	worker := newJobAcquisitionTokenWorker(k8sClient)
+	kjob := buildJobWithJobAcquisitionToken(t, worker, "jat-secret")
+
+	if err := worker.createJob(t.Context(), kjob, "jat-secret"); err != nil {
+		t.Fatalf("createJob() error = %v", err)
+	}
+}
+
+func TestCreateJobDoesNotReconcileJobWithDifferentIdentity(t *testing.T) {
+	tests := []struct {
+		name  string
+		label string
+		value string
+	}{
+		{name: "Buildkite workload", label: config.UUIDLabel, value: "different-job-uuid"},
+		{name: "controller", label: config.ControllerIDLabel, value: "different-controller"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k8sClient := fake.NewSimpleClientset()
+			worker := newJobAcquisitionTokenWorker(k8sClient)
+			preexistingJob := buildJobWithJobAcquisitionToken(t, worker, "hostile-jat")
+			preexistingJob.Namespace = "test-namespace"
+			preexistingJob.UID = "preexisting-job-uid"
+			preexistingJob.Labels[tt.label] = tt.value
+			if _, err := k8sClient.BatchV1().Jobs("test-namespace").Create(t.Context(), preexistingJob, metav1.CreateOptions{}); err != nil {
+				t.Fatalf("Create pre-existing job: %v", err)
+			}
+			retryJob := buildJobWithJobAcquisitionToken(t, worker, "retry-jat")
+
+			if err := worker.createJob(t.Context(), retryJob, "retry-jat"); err == nil {
+				t.Fatal("createJob() error = nil, want conflicting Job error")
+			}
+			if _, err := k8sClient.CoreV1().Secrets("test-namespace").Get(t.Context(), preexistingJob.Annotations[config.JobAcquisitionTokenSecretAnnotation], metav1.GetOptions{}); !kerrors.IsNotFound(err) {
+				t.Fatalf("Get hostile Job secret error = %v, want NotFound", err)
+			}
+		})
+	}
+}
+
+func TestCreateJobDoesNotReuseSecretOwnedByDifferentJob(t *testing.T) {
+	k8sClient := fake.NewSimpleClientset()
+	setCreatedJobUID(k8sClient)
+	k8sClient.PrependReactor("create", "secrets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		desired := action.(k8stesting.CreateAction).GetObject().(*corev1.Secret)
+		foreign := desired.DeepCopy()
+		foreign.Namespace = action.GetNamespace()
+		foreign.Data[agentTokenKey] = []byte("foreign-jat")
+		foreign.OwnerReferences[0].UID = "different-job-uid"
+		if err := k8sClient.Tracker().Create(corev1.SchemeGroupVersion.WithResource("secrets"), foreign, foreign.Namespace); err != nil {
+			t.Fatalf("Track foreign secret: %v", err)
+		}
+		return true, nil, kerrors.NewAlreadyExists(corev1.Resource("secrets"), desired.Name)
+	})
+	worker := newJobAcquisitionTokenWorker(k8sClient)
+	kjob := buildJobWithJobAcquisitionToken(t, worker, "jat-secret")
+
+	if err := worker.createJob(t.Context(), kjob, "jat-secret"); err == nil {
+		t.Fatal("createJob() error = nil, want conflicting Secret error")
+	}
+	secretName := kjob.Annotations[config.JobAcquisitionTokenSecretAnnotation]
+	secret, err := k8sClient.CoreV1().Secrets("test-namespace").Get(t.Context(), secretName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Get foreign secret: %v", err)
+	}
+	if got := string(secret.Data[agentTokenKey]); got != "foreign-jat" {
+		t.Errorf("foreign secret token = %q, want foreign-jat", got)
+	}
+	if got := secret.OwnerReferences[0].UID; got != "different-job-uid" {
+		t.Errorf("foreign secret owner UID = %q, want different-job-uid", got)
 	}
 }
 

--- a/internal/controller/scheduler/job_watcher.go
+++ b/internal/controller/scheduler/job_watcher.go
@@ -130,6 +130,7 @@ func (w *jobWatcher) OnDelete(prev any) {
 	if kjob == nil {
 		return
 	}
+	w.cleanupJobAcquisitionTokenSecret(w.resourceEventHandlerCtx, loggerForObject(w.logger, kjob), kjob)
 
 	jobUUID, err := jobUUIDForObject(kjob)
 	if err != nil {
@@ -161,6 +162,7 @@ func (w *jobWatcher) runChecks(ctx context.Context, kjob *batchv1.Job) {
 	if model.JobFinished(kjob) {
 		w.removeFromStalling(jobUUID)
 		w.stopCheckingBuildkiteJob(jobUUID)
+		w.cleanupJobAcquisitionTokenSecret(ctx, log, kjob)
 		w.checkFinished(ctx, log, jobUUID, kjob)
 		return
 	}
@@ -174,6 +176,16 @@ func (w *jobWatcher) runChecks(ctx context.Context, kjob *batchv1.Job) {
 	}
 
 	w.checkStalledWithoutPod(log, jobUUID, kjob)
+}
+
+func (w *jobWatcher) cleanupJobAcquisitionTokenSecret(ctx context.Context, log *slog.Logger, kjob *batchv1.Job) {
+	name := kjob.Annotations[config.JobAcquisitionTokenSecretAnnotation]
+	if name == "" {
+		return
+	}
+	if err := w.k8s.CoreV1().Secrets(kjob.Namespace).Delete(ctx, name, metav1.DeleteOptions{}); err != nil && !kerrors.IsNotFound(err) {
+		log.Warn("Failed to delete job acquisition token secret", "error", err)
+	}
 }
 
 func (w *jobWatcher) addToBuildkiteJobChecker(jobUUID uuid.UUID, kjob *batchv1.Job) {

--- a/internal/controller/scheduler/job_watcher.go
+++ b/internal/controller/scheduler/job_watcher.go
@@ -192,8 +192,7 @@ func (w *jobWatcher) cleanupJobAcquisitionTokenSecret(ctx context.Context, log *
 		log.Warn("Failed to get job acquisition token secret", "error", err)
 		return
 	}
-	controller := metav1.GetControllerOf(secret)
-	if !metav1.IsControlledBy(secret, kjob) || controller.Name != kjob.Name || controller.APIVersion != batchv1.SchemeGroupVersion.String() || controller.Kind != "Job" {
+	if !secretControlledByJob(secret, kjob) {
 		log.Warn("Refusing to delete job acquisition token secret not controlled by Job", "secret", name)
 		return
 	}

--- a/internal/controller/scheduler/job_watcher.go
+++ b/internal/controller/scheduler/job_watcher.go
@@ -183,7 +183,21 @@ func (w *jobWatcher) cleanupJobAcquisitionTokenSecret(ctx context.Context, log *
 	if name == "" {
 		return
 	}
-	if err := w.k8s.CoreV1().Secrets(kjob.Namespace).Delete(ctx, name, metav1.DeleteOptions{}); err != nil && !kerrors.IsNotFound(err) {
+	secrets := w.k8s.CoreV1().Secrets(kjob.Namespace)
+	secret, err := secrets.Get(ctx, name, metav1.GetOptions{})
+	if kerrors.IsNotFound(err) {
+		return
+	}
+	if err != nil {
+		log.Warn("Failed to get job acquisition token secret", "error", err)
+		return
+	}
+	controller := metav1.GetControllerOf(secret)
+	if !metav1.IsControlledBy(secret, kjob) || controller.Name != kjob.Name || controller.APIVersion != batchv1.SchemeGroupVersion.String() || controller.Kind != "Job" {
+		log.Warn("Refusing to delete job acquisition token secret not controlled by Job", "secret", name)
+		return
+	}
+	if err := secrets.Delete(ctx, name, metav1.DeleteOptions{Preconditions: &metav1.Preconditions{UID: &secret.UID}}); err != nil && !kerrors.IsNotFound(err) {
 		log.Warn("Failed to delete job acquisition token secret", "error", err)
 	}
 }

--- a/internal/controller/scheduler/job_watcher_test.go
+++ b/internal/controller/scheduler/job_watcher_test.go
@@ -73,6 +73,147 @@ func newTestK8sJob(jobUUID string) *batchv1.Job {
 	}
 }
 
+func newTestJobAcquisitionTokenSecret(kjob *batchv1.Job, name string) *corev1.Secret {
+	return &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+		Name:            name,
+		Namespace:       kjob.Namespace,
+		UID:             "secret-uid",
+		OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(kjob, batchv1.SchemeGroupVersion.WithKind("Job"))},
+	}}
+}
+
+func TestCleanupJobAcquisitionTokenSecret(t *testing.T) {
+	t.Run("deletes a Secret controlled by the Job with a UID precondition", func(t *testing.T) {
+		server := api.NewFakeAgentServer()
+		defer server.Close()
+		w, k8sClient := newTestJobWatcher(t, server)
+		kjob := newTestK8sJob(testJobUUID)
+		secret := newTestJobAcquisitionTokenSecret(kjob, "job-acquisition-token")
+		kjob.Annotations = map[string]string{config.JobAcquisitionTokenSecretAnnotation: secret.Name}
+		if _, err := k8sClient.CoreV1().Secrets(kjob.Namespace).Create(t.Context(), secret, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("Create secret: %v", err)
+		}
+
+		w.cleanupJobAcquisitionTokenSecret(t.Context(), slog.Default(), kjob)
+
+		if _, err := k8sClient.CoreV1().Secrets(kjob.Namespace).Get(t.Context(), secret.Name, metav1.GetOptions{}); !kerrors.IsNotFound(err) {
+			t.Fatalf("Get secret after cleanup error = %v, want NotFound", err)
+		}
+		actions := k8sClient.Actions()
+		deleteAction, ok := actions[len(actions)-2].(k8stesting.DeleteAction)
+		if !ok {
+			t.Fatalf("cleanup action = %T, want DeleteAction", actions[len(actions)-2])
+		}
+		preconditions := deleteAction.GetDeleteOptions().Preconditions
+		if preconditions == nil || preconditions.UID == nil || *preconditions.UID != secret.UID {
+			t.Errorf("delete UID precondition = %v, want %q", preconditions, secret.UID)
+		}
+	})
+
+	t.Run("preserves a replacement Secret when the UID precondition conflicts", func(t *testing.T) {
+		server := api.NewFakeAgentServer()
+		defer server.Close()
+		w, k8sClient := newTestJobWatcher(t, server)
+		kjob := newTestK8sJob(testJobUUID)
+		secret := newTestJobAcquisitionTokenSecret(kjob, "job-acquisition-token")
+		kjob.Annotations = map[string]string{config.JobAcquisitionTokenSecretAnnotation: secret.Name}
+		if _, err := k8sClient.CoreV1().Secrets(kjob.Namespace).Create(t.Context(), secret, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("Create secret: %v", err)
+		}
+		k8sClient.PrependReactor("delete", "secrets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+			deleteAction := action.(k8stesting.DeleteAction)
+			preconditions := deleteAction.GetDeleteOptions().Preconditions
+			if preconditions == nil || preconditions.UID == nil || *preconditions.UID != secret.UID {
+				t.Fatalf("delete UID precondition = %v, want %q", preconditions, secret.UID)
+			}
+			replacement := secret.DeepCopy()
+			replacement.UID = "replacement-secret-uid"
+			if err := k8sClient.Tracker().Update(corev1.SchemeGroupVersion.WithResource("secrets"), replacement, kjob.Namespace); err != nil {
+				t.Fatalf("Update replacement secret: %v", err)
+			}
+			return true, nil, kerrors.NewConflict(corev1.Resource("secrets"), secret.Name, errors.New("UID precondition failed"))
+		})
+
+		w.cleanupJobAcquisitionTokenSecret(t.Context(), slog.Default(), kjob)
+
+		got, err := k8sClient.CoreV1().Secrets(kjob.Namespace).Get(t.Context(), secret.Name, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("Get replacement secret: %v", err)
+		}
+		if got.UID != "replacement-secret-uid" {
+			t.Errorf("replacement secret UID = %q, want replacement-secret-uid", got.UID)
+		}
+	})
+
+	tests := []struct {
+		name   string
+		secret func(*batchv1.Job) *corev1.Secret
+	}{
+		{
+			name: "preserves an unowned shared Secret named by a malicious annotation",
+			secret: func(kjob *batchv1.Job) *corev1.Secret {
+				return &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "buildkite-agent-token", Namespace: kjob.Namespace, UID: "shared-secret-uid"}}
+			},
+		},
+		{
+			name: "preserves a Secret controlled by a different Job UID",
+			secret: func(kjob *batchv1.Job) *corev1.Secret {
+				secret := newTestJobAcquisitionTokenSecret(kjob, "job-acquisition-token")
+				secret.OwnerReferences[0].UID = "different-job-uid"
+				return secret
+			},
+		},
+		{
+			name: "preserves a Secret with a mismatched Job owner identity",
+			secret: func(kjob *batchv1.Job) *corev1.Secret {
+				secret := newTestJobAcquisitionTokenSecret(kjob, "job-acquisition-token")
+				secret.OwnerReferences[0].Name = "different-job"
+				return secret
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := api.NewFakeAgentServer()
+			defer server.Close()
+			w, k8sClient := newTestJobWatcher(t, server)
+			kjob := newTestK8sJob(testJobUUID)
+			secret := tt.secret(kjob)
+			kjob.Annotations = map[string]string{config.JobAcquisitionTokenSecretAnnotation: secret.Name}
+			if _, err := k8sClient.CoreV1().Secrets(kjob.Namespace).Create(t.Context(), secret, metav1.CreateOptions{}); err != nil {
+				t.Fatalf("Create secret: %v", err)
+			}
+
+			w.cleanupJobAcquisitionTokenSecret(t.Context(), slog.Default(), kjob)
+
+			if _, err := k8sClient.CoreV1().Secrets(kjob.Namespace).Get(t.Context(), secret.Name, metav1.GetOptions{}); err != nil {
+				t.Fatalf("Get secret after cleanup: %v", err)
+			}
+			for _, action := range k8sClient.Actions() {
+				if action.GetVerb() == "delete" {
+					t.Errorf("unexpected delete action: %v", action)
+				}
+			}
+		})
+	}
+
+	t.Run("treats a missing Secret as successful cleanup", func(t *testing.T) {
+		server := api.NewFakeAgentServer()
+		defer server.Close()
+		w, k8sClient := newTestJobWatcher(t, server)
+		kjob := newTestK8sJob(testJobUUID)
+		kjob.Annotations = map[string]string{config.JobAcquisitionTokenSecretAnnotation: "missing"}
+
+		w.cleanupJobAcquisitionTokenSecret(t.Context(), slog.Default(), kjob)
+
+		for _, action := range k8sClient.Actions() {
+			if action.GetVerb() == "delete" {
+				t.Errorf("unexpected delete action: %v", action)
+			}
+		}
+	})
+}
+
 func TestCleanupStalledJobs(t *testing.T) {
 	tests := []struct {
 		name string
@@ -434,7 +575,7 @@ func TestJobAcquisitionTokenSecretIsDeletedWhenJobFinishes(t *testing.T) {
 	kjob.Annotations = map[string]string{config.JobAcquisitionTokenSecretAnnotation: "job-token"}
 	kjob.Status.Succeeded = 1
 	kjob.Status.Conditions = []batchv1.JobCondition{{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}}
-	if _, err := k8sClient.CoreV1().Secrets("default").Create(t.Context(), &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "job-token"}}, metav1.CreateOptions{}); err != nil {
+	if _, err := k8sClient.CoreV1().Secrets("default").Create(t.Context(), newTestJobAcquisitionTokenSecret(kjob, "job-token"), metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Create secret: %v", err)
 	}
 
@@ -454,7 +595,7 @@ func TestJobAcquisitionTokenSecretIsDeletedWhenJobIsDeleted(t *testing.T) {
 	w.resourceEventHandlerCtx = t.Context()
 	kjob := newTestK8sJob(testJobUUID)
 	kjob.Annotations = map[string]string{config.JobAcquisitionTokenSecretAnnotation: "job-token"}
-	if _, err := k8sClient.CoreV1().Secrets("default").Create(t.Context(), &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "job-token"}}, metav1.CreateOptions{}); err != nil {
+	if _, err := k8sClient.CoreV1().Secrets("default").Create(t.Context(), newTestJobAcquisitionTokenSecret(kjob, "job-token"), metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Create secret: %v", err)
 	}
 

--- a/internal/controller/scheduler/job_watcher_test.go
+++ b/internal/controller/scheduler/job_watcher_test.go
@@ -13,6 +13,7 @@ import (
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
@@ -420,5 +421,46 @@ func TestFinishedJobIsDeregistered(t *testing.T) {
 
 	if got := checker.GetActiveCheckCount(); got != 0 {
 		t.Errorf("checker.GetActiveCheckCount() = %d, want 0", got)
+	}
+}
+
+func TestJobAcquisitionTokenSecretIsDeletedWhenJobFinishes(t *testing.T) {
+	t.Parallel()
+
+	fakeServer := api.NewFakeAgentServer()
+	defer fakeServer.Close()
+	w, k8sClient := newTestJobWatcher(t, fakeServer)
+	kjob := newTestK8sJob(testJobUUID)
+	kjob.Annotations = map[string]string{config.JobAcquisitionTokenSecretAnnotation: "job-token"}
+	kjob.Status.Succeeded = 1
+	kjob.Status.Conditions = []batchv1.JobCondition{{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}}
+	if _, err := k8sClient.CoreV1().Secrets("default").Create(t.Context(), &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "job-token"}}, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Create secret: %v", err)
+	}
+
+	w.runChecks(t.Context(), kjob)
+
+	if _, err := k8sClient.CoreV1().Secrets("default").Get(t.Context(), "job-token", metav1.GetOptions{}); !kerrors.IsNotFound(err) {
+		t.Errorf("Get secret error = %v, want NotFound", err)
+	}
+}
+
+func TestJobAcquisitionTokenSecretIsDeletedWhenJobIsDeleted(t *testing.T) {
+	t.Parallel()
+
+	fakeServer := api.NewFakeAgentServer()
+	defer fakeServer.Close()
+	w, k8sClient := newTestJobWatcher(t, fakeServer)
+	w.resourceEventHandlerCtx = t.Context()
+	kjob := newTestK8sJob(testJobUUID)
+	kjob.Annotations = map[string]string{config.JobAcquisitionTokenSecretAnnotation: "job-token"}
+	if _, err := k8sClient.CoreV1().Secrets("default").Create(t.Context(), &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "job-token"}}, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Create secret: %v", err)
+	}
+
+	w.OnDelete(kjob)
+
+	if _, err := k8sClient.CoreV1().Secrets("default").Get(t.Context(), "job-token", metav1.GetOptions{}); !kerrors.IsNotFound(err) {
+		t.Errorf("Get secret error = %v, want NotFound", err)
 	}
 }

--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -53,6 +53,7 @@ var (
 	errJobIdentityConflict        = errors.New("existing Job does not match the intended workload identity")
 	errSecretIdentityConflict     = errors.New("existing Secret does not match the intended Job identity")
 	resourceReconciliationBackoff = wait.Backoff{Duration: 100 * time.Millisecond, Factor: 2, Jitter: 0.1, Steps: 5}
+	resourceRecoveryTimeout       = 5 * time.Second
 )
 
 var (
@@ -228,13 +229,28 @@ func (w *worker) createJob(ctx context.Context, kjob *batchv1.Job, token api.Job
 		if !w.cfg.EnableJobAcquisitionTokens {
 			return fmt.Errorf("failed to create job: %w", createErr)
 		}
-		if isPermanentKubernetesError(createErr) {
+		if !isAmbiguousKubernetesCreateError(createErr) {
 			return fmt.Errorf("failed to create job: %w", createErr)
 		}
-		createdJob, err = w.reconcileCreatedJob(ctx, kjob)
+		reconcileCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), resourceRecoveryTimeout)
+		createdJob, err = w.reconcileCreatedJob(reconcileCtx, kjob)
 		if err != nil {
-			return errors.Join(fmt.Errorf("failed to create job: %w", createErr), fmt.Errorf("failed to reconcile job: %w", err))
+			cancel()
+			reconcileErr := fmt.Errorf("failed to reconcile job: %w", err)
+			if errors.Is(err, errJobIdentityConflict) || isPermanentKubernetesError(err) {
+				return errors.Join(fmt.Errorf("failed to create job: %w", createErr), reconcileErr)
+			}
+
+			recoveryCtx, recoveryCancel := context.WithTimeout(context.WithoutCancel(ctx), resourceRecoveryTimeout)
+			verifiedJob, recoveryErr := w.reconcileCreatedJob(recoveryCtx, kjob)
+			recoveryCancel()
+			if recoveryErr != nil {
+				return errors.Join(fmt.Errorf("failed to create job: %w", createErr), reconcileErr, fmt.Errorf("failed to recover job for cleanup: %w", recoveryErr))
+			}
+			return errors.Join(fmt.Errorf("failed to create job: %w", createErr), reconcileErr, w.cleanupIncompleteJob(context.WithoutCancel(ctx), verifiedJob))
 		}
+		defer cancel()
+		ctx = reconcileCtx
 	}
 	if !w.cfg.EnableJobAcquisitionTokens {
 		return nil
@@ -374,6 +390,17 @@ func isPermanentKubernetesError(err error) bool {
 	return kerrors.IsInvalid(err) || kerrors.IsForbidden(err) || kerrors.IsUnauthorized(err) || kerrors.IsBadRequest(err) ||
 		kerrors.IsMethodNotSupported(err) || kerrors.IsNotAcceptable(err) || kerrors.IsRequestEntityTooLargeError(err) ||
 		kerrors.IsUnsupportedMediaType(err)
+}
+
+func isAmbiguousKubernetesCreateError(err error) bool {
+	if kerrors.IsAlreadyExists(err) || kerrors.IsConflict(err) || isPermanentKubernetesError(err) {
+		return false
+	}
+	if kerrors.IsTimeout(err) || kerrors.IsServerTimeout(err) {
+		return true
+	}
+	var status kerrors.APIStatus
+	return !errors.As(err, &status)
 }
 
 func hasSameJobIdentity(expected, actual map[string]string) bool {

--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -60,6 +60,7 @@ type Config struct {
 	JobPrefix                            string
 	AgentToken                           string
 	AgentTokenSecretName                 string
+	EnableJobAcquisitionTokens           bool
 	JobTTL                               time.Duration
 	JobActiveDeadlineSeconds             int
 	AdditionalRedactedVars               []string
@@ -194,7 +195,7 @@ func (w *worker) Handle(ctx context.Context, job *api.AgentScheduledJob) error {
 
 		case kerrors.IsInvalid(err):
 			out := ""
-			yamlOut, marshalErr := yaml.Marshal(kjob)
+			yamlOut, marshalErr := yaml.Marshal(redactedJob(kjob))
 			if marshalErr != nil {
 				out = fmt.Sprintf("Couldn't marshal the Job into YAML: %v", marshalErr)
 			} else {
@@ -230,18 +231,23 @@ type buildInputs struct {
 	priority        int
 
 	// Involves some parsing of the job env / plugins map
-	envMap       map[string]string
-	k8sPlugin    *KubernetesPlugin
-	otherPlugins []map[string]json.RawMessage
+	envMap              map[string]string
+	k8sPlugin           *KubernetesPlugin
+	otherPlugins        []map[string]json.RawMessage
+	jobAcquisitionToken api.JobAcquisitionToken
 }
 
 func (w *worker) ParseJob(job *api.AgentJob, sjob *api.AgentScheduledJob) (buildInputs, error) {
 	parsed := buildInputs{
-		uuid:            job.ID,
-		command:         job.Command,
-		agentQueryRules: sjob.AgentQueryRules,
-		priority:        sjob.Priority,
-		envMap:          job.Env,
+		uuid:                job.ID,
+		command:             job.Command,
+		agentQueryRules:     sjob.AgentQueryRules,
+		priority:            sjob.Priority,
+		envMap:              job.Env,
+		jobAcquisitionToken: sjob.JobAcquisitionToken,
+	}
+	if w.cfg.EnableJobAcquisitionTokens && parsed.jobAcquisitionToken == "" {
+		return parsed, errors.New("job acquisition token is missing")
 	}
 
 	var plugins []map[string]json.RawMessage
@@ -551,6 +557,19 @@ func (w *worker) Build(podSpec *corev1.PodSpec, skipCheckout bool, inputs buildI
 	// Calculating this imperatively is risky given we lack control over the context, this is subject to refactor.
 	managedContainerCount := len(podSpec.Containers) + systemContainerCount
 
+	agentTokenEnv := corev1.EnvVar{
+		Name: agentTokenKey,
+		ValueFrom: &corev1.EnvVarSource{
+			SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: w.cfg.AgentTokenSecretName},
+				Key:                  agentTokenKey,
+			},
+		},
+	}
+	if w.cfg.EnableJobAcquisitionTokens {
+		agentTokenEnv = corev1.EnvVar{Name: agentTokenKey, Value: string(inputs.jobAcquisitionToken)}
+	}
+
 	agentContainer := corev1.Container{
 		Name:            AgentContainerName,
 		Args:            []string{"start"},
@@ -622,15 +641,7 @@ func (w *worker) Build(podSpec *corev1.PodSpec, skipCheckout bool, inputs buildI
 				Name:  "BUILDKITE_SHELL",
 				Value: "/bin/sh -ec",
 			},
-			{
-				Name: agentTokenKey, // BUILDKITE_AGENT_TOKEN
-				ValueFrom: &corev1.EnvVarSource{
-					SecretKeyRef: &corev1.SecretKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{Name: w.cfg.AgentTokenSecretName},
-						Key:                  agentTokenKey,
-					},
-				},
-			},
+			agentTokenEnv,
 			{
 				Name:  "BUILDKITE_AGENT_ACQUIRE_JOB",
 				Value: inputs.uuid,
@@ -756,7 +767,7 @@ func (w *worker) Build(podSpec *corev1.PodSpec, skipCheckout bool, inputs buildI
 			return nil, fmt.Errorf("failed to apply podSpec patch from controller: %w", err)
 		}
 		podSpec = patched
-		w.logger.Debug("Applied podSpec patch from controller", "patched", patched)
+		w.logger.Debug("Applied podSpec patch from controller", "patched", redactedPodSpec(patched))
 	}
 
 	// Support `image: ` syntax, this HAS TO happen between controller podSpec patch and plugin podSpec patch.
@@ -769,7 +780,7 @@ func (w *worker) Build(podSpec *corev1.PodSpec, skipCheckout bool, inputs buildI
 			return nil, fmt.Errorf("failed to apply podSpec patch from k8s plugin: %w", err)
 		}
 		podSpec = patched
-		w.logger.Debug("Applied podSpec patch from k8s plugin", "patched", patched)
+		w.logger.Debug("Applied podSpec patch from k8s plugin", "patched", redactedPodSpec(patched))
 	}
 
 	// Removes all containers named "checkout" when checkout disabled via controller config or plugin
@@ -798,6 +809,27 @@ func (w *worker) Build(podSpec *corev1.PodSpec, skipCheckout bool, inputs buildI
 	kjob.Spec.Template.Spec = *podSpec
 
 	return kjob, nil
+}
+
+func redactedPodSpec(podSpec *corev1.PodSpec) *corev1.PodSpec {
+	redacted := podSpec.DeepCopy()
+	for _, containers := range [][]corev1.Container{redacted.Containers, redacted.InitContainers} {
+		for i := range containers {
+			for j := range containers[i].Env {
+				env := &containers[i].Env[j]
+				if env.Name == agentTokenKey && env.Value != "" {
+					env.Value = "<redacted>"
+				}
+			}
+		}
+	}
+	return redacted
+}
+
+func redactedJob(job *batchv1.Job) *batchv1.Job {
+	redacted := job.DeepCopy()
+	redacted.Spec.Template.Spec = *redactedPodSpec(&redacted.Spec.Template.Spec)
+	return redacted
 }
 
 var ErrNoCommandModification = errors.New("modifying container commands or args via podSpecPatch is not supported")

--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -34,6 +34,7 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/yaml"
 )
@@ -47,7 +48,12 @@ const (
 	DefaultCommandContainerName   = "container-0"
 )
 
-var errK8sPluginProhibited = errors.New("the kubernetes plugin is prohibited by this controller, but was configured on this job")
+var (
+	errK8sPluginProhibited        = errors.New("the kubernetes plugin is prohibited by this controller, but was configured on this job")
+	errJobIdentityConflict        = errors.New("existing Job does not match the intended workload identity")
+	errSecretIdentityConflict     = errors.New("existing Secret does not match the intended Job identity")
+	resourceReconciliationBackoff = wait.Backoff{Duration: 100 * time.Millisecond, Factor: 2, Jitter: 0.1, Steps: 5}
+)
 
 var (
 	commandContainerCommand = []string{"/workspace/tini-static"}
@@ -218,23 +224,60 @@ func (w *worker) Handle(ctx context.Context, job *api.AgentScheduledJob) error {
 func (w *worker) createJob(ctx context.Context, kjob *batchv1.Job, token api.JobAcquisitionToken) error {
 	createdJob, err := w.client.BatchV1().Jobs(w.cfg.Namespace).Create(ctx, kjob, metav1.CreateOptions{})
 	if err != nil {
+		createErr := err
 		if !w.cfg.EnableJobAcquisitionTokens {
-			return fmt.Errorf("failed to create job: %w", err)
+			return fmt.Errorf("failed to create job: %w", createErr)
 		}
-		liveJob, getErr := w.client.BatchV1().Jobs(w.cfg.Namespace).Get(ctx, kjob.Name, metav1.GetOptions{})
-		if getErr != nil {
-			return errors.Join(fmt.Errorf("failed to create job: %w", err), fmt.Errorf("failed to reconcile job: %w", getErr))
+		if isPermanentKubernetesError(createErr) {
+			return fmt.Errorf("failed to create job: %w", createErr)
 		}
-		secretName := liveJob.Annotations[config.JobAcquisitionTokenSecretAnnotation]
-		if !hasSameJobIdentity(kjob.Labels, liveJob.Labels) || liveJob.UID == "" || secretName == "" || !jobReferencesSecret(liveJob, secretName) {
-			return fmt.Errorf("failed to create job: %w", err)
+		createdJob, err = w.reconcileCreatedJob(ctx, kjob)
+		if err != nil {
+			return errors.Join(fmt.Errorf("failed to create job: %w", createErr), fmt.Errorf("failed to reconcile job: %w", err))
 		}
-		createdJob = liveJob
 	}
 	if !w.cfg.EnableJobAcquisitionTokens {
 		return nil
 	}
 
+	if err := w.reconcileJobAcquisitionTokenSecret(ctx, createdJob, token); err != nil {
+		return errors.Join(err, w.cleanupIncompleteJob(context.WithoutCancel(ctx), createdJob))
+	}
+	return nil
+}
+
+func (w *worker) reconcileCreatedJob(ctx context.Context, expected *batchv1.Job) (*batchv1.Job, error) {
+	var liveJob *batchv1.Job
+	var lastErr error
+	err := wait.ExponentialBackoffWithContext(ctx, resourceReconciliationBackoff, func(ctx context.Context) (bool, error) {
+		job, err := w.client.BatchV1().Jobs(w.cfg.Namespace).Get(ctx, expected.Name, metav1.GetOptions{})
+		if err != nil {
+			if isPermanentKubernetesError(err) {
+				return false, err
+			}
+			lastErr = err
+			return false, nil
+		}
+		secretName := job.Annotations[config.JobAcquisitionTokenSecretAnnotation]
+		if !hasSameJobIdentity(expected.Labels, job.Labels) || job.UID == "" || secretName == "" || !jobReferencesSecret(job, secretName) {
+			return false, errJobIdentityConflict
+		}
+		liveJob = job
+		return true, nil
+	})
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		if wait.Interrupted(err) && lastErr != nil {
+			return nil, lastErr
+		}
+		return nil, err
+	}
+	return liveJob, nil
+}
+
+func (w *worker) reconcileJobAcquisitionTokenSecret(ctx context.Context, createdJob *batchv1.Job, token api.JobAcquisitionToken) error {
 	secretName := createdJob.Annotations[config.JobAcquisitionTokenSecretAnnotation]
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -246,17 +289,91 @@ func (w *worker) createJob(ctx context.Context, kjob *batchv1.Job, token api.Job
 		Immutable: new(true),
 		Data:      map[string][]byte{agentTokenKey: []byte(token)},
 	}
-	if _, err := w.client.CoreV1().Secrets(w.cfg.Namespace).Create(ctx, secret, metav1.CreateOptions{}); err != nil {
-		liveSecret, getErr := w.client.CoreV1().Secrets(w.cfg.Namespace).Get(ctx, secret.Name, metav1.GetOptions{})
-		if getErr != nil {
-			return errors.Join(fmt.Errorf("failed to create job acquisition token secret: %w", err), fmt.Errorf("failed to reconcile job acquisition token secret: %w", getErr))
+	var lastErr error
+	err := wait.ExponentialBackoffWithContext(ctx, resourceReconciliationBackoff, func(ctx context.Context) (bool, error) {
+		if _, err := w.client.CoreV1().Secrets(w.cfg.Namespace).Create(ctx, secret, metav1.CreateOptions{}); err == nil {
+			return true, nil
+		} else if isPermanentKubernetesError(err) {
+			return false, err
+		} else {
+			lastErr = err
+		}
+		liveSecret, err := w.client.CoreV1().Secrets(w.cfg.Namespace).Get(ctx, secret.Name, metav1.GetOptions{})
+		if err != nil {
+			if isPermanentKubernetesError(err) {
+				return false, err
+			}
+			lastErr = errors.Join(lastErr, err)
+			return false, nil
 		}
 		if !secretControlledByJob(liveSecret, createdJob) || !hasSameJobIdentity(createdJob.Labels, liveSecret.Labels) ||
-			liveSecret.Immutable == nil || !*liveSecret.Immutable || len(liveSecret.Data[agentTokenKey]) == 0 {
-			return fmt.Errorf("job acquisition token secret %q does not match Job %q", secret.Name, createdJob.Name)
+			liveSecret.Immutable == nil || !*liveSecret.Immutable || !slices.Equal(liveSecret.Data[agentTokenKey], secret.Data[agentTokenKey]) {
+			return false, errSecretIdentityConflict
 		}
+		return true, nil
+	})
+	if err == nil {
+		return nil
 	}
-	return nil
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	if wait.Interrupted(err) && lastErr != nil {
+		err = lastErr
+	}
+	return fmt.Errorf("failed to reconcile job acquisition token secret: %w", err)
+}
+
+func (w *worker) cleanupIncompleteJob(ctx context.Context, kjob *batchv1.Job) error {
+	cleanupCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	var errs []error
+	secrets := w.client.CoreV1().Secrets(w.cfg.Namespace)
+	secretName := kjob.Annotations[config.JobAcquisitionTokenSecretAnnotation]
+	secret, err := secrets.Get(cleanupCtx, secretName, metav1.GetOptions{})
+	if err == nil && secretControlledByJob(secret, kjob) && hasSameJobIdentity(kjob.Labels, secret.Labels) {
+		if err := retryKubernetesDelete(cleanupCtx, func(ctx context.Context) error {
+			return secrets.Delete(ctx, secretName, metav1.DeleteOptions{Preconditions: &metav1.Preconditions{UID: &secret.UID}})
+		}); err != nil {
+			errs = append(errs, fmt.Errorf("failed to delete incomplete job acquisition token secret: %w", err))
+		}
+	} else if err != nil && !kerrors.IsNotFound(err) {
+		errs = append(errs, fmt.Errorf("failed to get incomplete job acquisition token secret: %w", err))
+	}
+	if err := retryKubernetesDelete(cleanupCtx, func(ctx context.Context) error {
+		return w.client.BatchV1().Jobs(w.cfg.Namespace).Delete(ctx, kjob.Name, metav1.DeleteOptions{Preconditions: &metav1.Preconditions{UID: &kjob.UID}})
+	}); err != nil {
+		errs = append(errs, fmt.Errorf("failed to delete incomplete job: %w", err))
+	}
+	return errors.Join(errs...)
+}
+
+func retryKubernetesDelete(ctx context.Context, deleteResource func(context.Context) error) error {
+	var lastErr error
+	err := wait.ExponentialBackoffWithContext(ctx, resourceReconciliationBackoff, func(ctx context.Context) (bool, error) {
+		err := deleteResource(ctx)
+		if err == nil || kerrors.IsNotFound(err) {
+			return true, nil
+		}
+		if isPermanentKubernetesError(err) || kerrors.IsConflict(err) {
+			return false, err
+		}
+		lastErr = err
+		return false, nil
+	})
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	if wait.Interrupted(err) && lastErr != nil {
+		return lastErr
+	}
+	return err
+}
+
+func isPermanentKubernetesError(err error) bool {
+	return kerrors.IsInvalid(err) || kerrors.IsForbidden(err) || kerrors.IsUnauthorized(err) || kerrors.IsBadRequest(err) ||
+		kerrors.IsMethodNotSupported(err) || kerrors.IsNotAcceptable(err) || kerrors.IsRequestEntityTooLargeError(err) ||
+		kerrors.IsUnsupportedMediaType(err)
 }
 
 func hasSameJobIdentity(expected, actual map[string]string) bool {

--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -27,6 +27,7 @@ import (
 	"github.com/buildkite/agent/v3/clicommand"
 
 	"github.com/distribution/reference"
+	"github.com/google/uuid"
 	"github.com/jedib0t/go-pretty/v6/table"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -185,7 +186,7 @@ func (w *worker) Handle(ctx context.Context, job *api.AgentScheduledJob) error {
 	}
 
 	jobCreateCallsCounter.Inc()
-	if err := w.createJob(ctx, kjob); err != nil {
+	if err := w.createJob(ctx, kjob, inputs.jobAcquisitionToken); err != nil {
 		jobCreateErrorCounter.WithLabelValues(string(kerrors.ReasonForError(err))).Inc()
 
 		switch {
@@ -214,10 +215,56 @@ func (w *worker) Handle(ctx context.Context, job *api.AgentScheduledJob) error {
 	return nil
 }
 
-func (w *worker) createJob(ctx context.Context, kjob *batchv1.Job) error {
-	_, err := w.client.BatchV1().Jobs(w.cfg.Namespace).Create(ctx, kjob, metav1.CreateOptions{})
+func (w *worker) createJob(ctx context.Context, kjob *batchv1.Job, token api.JobAcquisitionToken) error {
+	createdJob, err := w.client.BatchV1().Jobs(w.cfg.Namespace).Create(ctx, kjob, metav1.CreateOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to create job: %w", err)
+	}
+	if !w.cfg.EnableJobAcquisitionTokens {
+		return nil
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            kjob.Annotations[config.JobAcquisitionTokenSecretAnnotation],
+			Namespace:       w.cfg.Namespace,
+			Labels:          maps.Clone(kjob.Labels),
+			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(createdJob, batchv1.SchemeGroupVersion.WithKind("Job"))},
+		},
+		Immutable: new(true),
+		Data:      map[string][]byte{agentTokenKey: []byte(token)},
+	}
+	if _, err := w.client.CoreV1().Secrets(w.cfg.Namespace).Create(ctx, secret, metav1.CreateOptions{}); err != nil {
+		var cleanupSecretErr error
+		if !kerrors.IsAlreadyExists(err) {
+			cleanupSecretErr = w.deleteSecret(ctx, secret.Name)
+		}
+		return errors.Join(
+			fmt.Errorf("failed to create job acquisition token secret: %w", err),
+			w.deleteJob(ctx, createdJob.Name),
+			cleanupSecretErr,
+		)
+	}
+	return nil
+}
+
+func (w *worker) deleteSecret(ctx context.Context, name string) error {
+	if name == "" {
+		return nil
+	}
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer cancel()
+	if err := w.client.CoreV1().Secrets(w.cfg.Namespace).Delete(cleanupCtx, name, metav1.DeleteOptions{}); err != nil && !kerrors.IsNotFound(err) {
+		return fmt.Errorf("failed to delete job acquisition token secret: %w", err)
+	}
+	return nil
+}
+
+func (w *worker) deleteJob(ctx context.Context, name string) error {
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer cancel()
+	if err := w.client.BatchV1().Jobs(w.cfg.Namespace).Delete(cleanupCtx, name, metav1.DeleteOptions{}); err != nil && !kerrors.IsNotFound(err) {
+		return fmt.Errorf("failed to delete job after job acquisition token secret failure: %w", err)
 	}
 	return nil
 }
@@ -567,7 +614,9 @@ func (w *worker) Build(podSpec *corev1.PodSpec, skipCheckout bool, inputs buildI
 		},
 	}
 	if w.cfg.EnableJobAcquisitionTokens {
-		agentTokenEnv = corev1.EnvVar{Name: agentTokenKey, Value: string(inputs.jobAcquisitionToken)}
+		secretName := "buildkite-job-token-" + uuid.NewString()
+		kjob.Annotations[config.JobAcquisitionTokenSecretAnnotation] = secretName
+		agentTokenEnv.ValueFrom.SecretKeyRef.Name = secretName
 	}
 
 	agentContainer := corev1.Container{

--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -218,55 +218,71 @@ func (w *worker) Handle(ctx context.Context, job *api.AgentScheduledJob) error {
 func (w *worker) createJob(ctx context.Context, kjob *batchv1.Job, token api.JobAcquisitionToken) error {
 	createdJob, err := w.client.BatchV1().Jobs(w.cfg.Namespace).Create(ctx, kjob, metav1.CreateOptions{})
 	if err != nil {
-		return fmt.Errorf("failed to create job: %w", err)
+		if !w.cfg.EnableJobAcquisitionTokens {
+			return fmt.Errorf("failed to create job: %w", err)
+		}
+		liveJob, getErr := w.client.BatchV1().Jobs(w.cfg.Namespace).Get(ctx, kjob.Name, metav1.GetOptions{})
+		if getErr != nil {
+			return errors.Join(fmt.Errorf("failed to create job: %w", err), fmt.Errorf("failed to reconcile job: %w", getErr))
+		}
+		secretName := liveJob.Annotations[config.JobAcquisitionTokenSecretAnnotation]
+		if !hasSameJobIdentity(kjob.Labels, liveJob.Labels) || liveJob.UID == "" || secretName == "" || !jobReferencesSecret(liveJob, secretName) {
+			return fmt.Errorf("failed to create job: %w", err)
+		}
+		createdJob = liveJob
 	}
 	if !w.cfg.EnableJobAcquisitionTokens {
 		return nil
 	}
 
+	secretName := createdJob.Annotations[config.JobAcquisitionTokenSecretAnnotation]
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            kjob.Annotations[config.JobAcquisitionTokenSecretAnnotation],
+			Name:            secretName,
 			Namespace:       w.cfg.Namespace,
-			Labels:          maps.Clone(kjob.Labels),
+			Labels:          maps.Clone(createdJob.Labels),
 			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(createdJob, batchv1.SchemeGroupVersion.WithKind("Job"))},
 		},
 		Immutable: new(true),
 		Data:      map[string][]byte{agentTokenKey: []byte(token)},
 	}
 	if _, err := w.client.CoreV1().Secrets(w.cfg.Namespace).Create(ctx, secret, metav1.CreateOptions{}); err != nil {
-		var cleanupSecretErr error
-		if !kerrors.IsAlreadyExists(err) {
-			cleanupSecretErr = w.deleteSecret(ctx, secret.Name)
+		liveSecret, getErr := w.client.CoreV1().Secrets(w.cfg.Namespace).Get(ctx, secret.Name, metav1.GetOptions{})
+		if getErr != nil {
+			return errors.Join(fmt.Errorf("failed to create job acquisition token secret: %w", err), fmt.Errorf("failed to reconcile job acquisition token secret: %w", getErr))
 		}
-		return errors.Join(
-			fmt.Errorf("failed to create job acquisition token secret: %w", err),
-			w.deleteJob(ctx, createdJob.Name),
-			cleanupSecretErr,
-		)
+		if !secretControlledByJob(liveSecret, createdJob) || !hasSameJobIdentity(createdJob.Labels, liveSecret.Labels) ||
+			liveSecret.Immutable == nil || !*liveSecret.Immutable || len(liveSecret.Data[agentTokenKey]) == 0 {
+			return fmt.Errorf("job acquisition token secret %q does not match Job %q", secret.Name, createdJob.Name)
+		}
 	}
 	return nil
 }
 
-func (w *worker) deleteSecret(ctx context.Context, name string) error {
-	if name == "" {
-		return nil
-	}
-	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
-	defer cancel()
-	if err := w.client.CoreV1().Secrets(w.cfg.Namespace).Delete(cleanupCtx, name, metav1.DeleteOptions{}); err != nil && !kerrors.IsNotFound(err) {
-		return fmt.Errorf("failed to delete job acquisition token secret: %w", err)
-	}
-	return nil
+func hasSameJobIdentity(expected, actual map[string]string) bool {
+	expectedControllerID, expectedHasControllerID := expected[config.ControllerIDLabel]
+	actualControllerID, actualHasControllerID := actual[config.ControllerIDLabel]
+	return expected[config.UUIDLabel] != "" && actual[config.UUIDLabel] == expected[config.UUIDLabel] &&
+		expectedHasControllerID == actualHasControllerID && actualControllerID == expectedControllerID
 }
 
-func (w *worker) deleteJob(ctx context.Context, name string) error {
-	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
-	defer cancel()
-	if err := w.client.BatchV1().Jobs(w.cfg.Namespace).Delete(cleanupCtx, name, metav1.DeleteOptions{}); err != nil && !kerrors.IsNotFound(err) {
-		return fmt.Errorf("failed to delete job after job acquisition token secret failure: %w", err)
+func jobReferencesSecret(kjob *batchv1.Job, secretName string) bool {
+	for _, container := range kjob.Spec.Template.Spec.Containers {
+		if container.Name != AgentContainerName {
+			continue
+		}
+		for _, env := range container.Env {
+			if env.Name == agentTokenKey && env.Value == "" && env.ValueFrom != nil && env.ValueFrom.SecretKeyRef != nil && env.ValueFrom.SecretKeyRef.Name == secretName {
+				return true
+			}
+		}
 	}
-	return nil
+	return false
+}
+
+func secretControlledByJob(secret *corev1.Secret, kjob *batchv1.Job) bool {
+	controller := metav1.GetControllerOf(secret)
+	return metav1.IsControlledBy(secret, kjob) && controller.Name == kjob.Name && controller.APIVersion == batchv1.SchemeGroupVersion.String() && controller.Kind == "Job"
 }
 
 // buildInputs contains the relevant components of a CommandJob needed for Build.

--- a/internal/controller/scheduler/scheduler_test.go
+++ b/internal/controller/scheduler/scheduler_test.go
@@ -23,11 +23,10 @@ func TestJobAcquisitionTokenCredentials(t *testing.T) {
 		name          string
 		enabled       bool
 		token         api.JobAcquisitionToken
-		wantLiteral   string
 		wantSecretRef string
 	}{
 		{name: "disabled uses shared secret", wantSecretRef: "token-secret"},
-		{name: "enabled uses JAT", enabled: true, token: "jat-secret", wantLiteral: "jat-secret"},
+		{name: "enabled uses per-job secret", enabled: true, token: "jat-secret"},
 	}
 
 	for _, test := range tests {
@@ -49,15 +48,18 @@ func TestJobAcquisitionTokenCredentials(t *testing.T) {
 
 			agent := findContainer(t, kjob.Spec.Template.Spec.Containers, AgentContainerName)
 			token := findEnv(t, agent.Env, agentTokenKey)
-			if got := token.Value; got != test.wantLiteral {
-				t.Errorf("agent token literal = %q, want %q", got, test.wantLiteral)
+			if token.Value != "" {
+				t.Errorf("agent token literal = %q, want empty", token.Value)
 			}
-			if test.wantSecretRef == "" {
-				if token.ValueFrom != nil {
-					t.Errorf("agent token ValueFrom = %#v, want nil", token.ValueFrom)
-				}
-			} else if got := token.ValueFrom.SecretKeyRef.Name; got != test.wantSecretRef {
+			if token.ValueFrom == nil || token.ValueFrom.SecretKeyRef == nil {
+				t.Fatalf("agent token ValueFrom.SecretKeyRef = nil, want secret reference")
+			}
+			if test.wantSecretRef != "" && token.ValueFrom.SecretKeyRef.Name != test.wantSecretRef {
+				got := token.ValueFrom.SecretKeyRef.Name
 				t.Errorf("agent token secret = %q, want %q", got, test.wantSecretRef)
+			}
+			if test.enabled && token.ValueFrom.SecretKeyRef.Name == "token-secret" {
+				t.Error("agent token references shared token secret")
 			}
 			if got := findEnv(t, agent.Env, "BUILDKITE_AGENT_ACQUIRE_JOB").Value; got != "job-uuid" {
 				t.Errorf("BUILDKITE_AGENT_ACQUIRE_JOB = %q, want %q", got, "job-uuid")
@@ -117,9 +119,6 @@ func TestJobAcquisitionTokenIsRedactedFromSchedulerOutput(t *testing.T) {
 	}
 	if strings.Contains(string(serialized), "jat-secret") {
 		t.Errorf("redacted invalid Job output contains JAT: %s", serialized)
-	}
-	if !strings.Contains(string(serialized), "<redacted>") {
-		t.Errorf("redacted invalid Job output does not contain redaction marker: %s", serialized)
 	}
 }
 

--- a/internal/controller/scheduler/scheduler_test.go
+++ b/internal/controller/scheduler/scheduler_test.go
@@ -1,6 +1,7 @@
 package scheduler
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"log/slog"
@@ -14,6 +15,113 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/yaml"
 )
+
+func TestJobAcquisitionTokenCredentials(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		enabled       bool
+		token         api.JobAcquisitionToken
+		wantLiteral   string
+		wantSecretRef string
+	}{
+		{name: "disabled uses shared secret", wantSecretRef: "token-secret"},
+		{name: "enabled uses JAT", enabled: true, token: "jat-secret", wantLiteral: "jat-secret"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			worker := New(slog.Default(), nil, nil, Config{
+				Image:                      "buildkite/agent:latest",
+				AgentTokenSecretName:       "token-secret",
+				EnableJobAcquisitionTokens: test.enabled,
+			})
+			sjob := &api.AgentScheduledJob{ID: "job-uuid", JobAcquisitionToken: test.token}
+			inputs, err := worker.ParseJob(&api.AgentJob{ID: "job-uuid", Command: "true"}, sjob)
+			if err != nil {
+				t.Fatalf("ParseJob() error = %v", err)
+			}
+			kjob, err := worker.Build(&corev1.PodSpec{}, false, inputs)
+			if err != nil {
+				t.Fatalf("Build() error = %v", err)
+			}
+
+			agent := findContainer(t, kjob.Spec.Template.Spec.Containers, AgentContainerName)
+			token := findEnv(t, agent.Env, agentTokenKey)
+			if got := token.Value; got != test.wantLiteral {
+				t.Errorf("agent token literal = %q, want %q", got, test.wantLiteral)
+			}
+			if test.wantSecretRef == "" {
+				if token.ValueFrom != nil {
+					t.Errorf("agent token ValueFrom = %#v, want nil", token.ValueFrom)
+				}
+			} else if got := token.ValueFrom.SecretKeyRef.Name; got != test.wantSecretRef {
+				t.Errorf("agent token secret = %q, want %q", got, test.wantSecretRef)
+			}
+			if got := findEnv(t, agent.Env, "BUILDKITE_AGENT_ACQUIRE_JOB").Value; got != "job-uuid" {
+				t.Errorf("BUILDKITE_AGENT_ACQUIRE_JOB = %q, want %q", got, "job-uuid")
+			}
+
+			for _, container := range append(kjob.Spec.Template.Spec.InitContainers, kjob.Spec.Template.Spec.Containers...) {
+				if container.Name == AgentContainerName {
+					continue
+				}
+				for _, env := range container.Env {
+					if env.Name == agentTokenKey && env.Value == "jat-secret" {
+						t.Errorf("container %q received JAT", container.Name)
+					}
+				}
+			}
+			if test.enabled {
+				for _, container := range append(kjob.Spec.Template.Spec.InitContainers, kjob.Spec.Template.Spec.Containers...) {
+					for _, env := range container.Env {
+						if env.ValueFrom != nil && env.ValueFrom.SecretKeyRef != nil && env.ValueFrom.SecretKeyRef.Name == "token-secret" {
+							t.Errorf("container %q references shared token secret", container.Name)
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestJobAcquisitionTokenIsRedactedFromSchedulerOutput(t *testing.T) {
+	t.Parallel()
+
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	worker := New(logger, nil, nil, Config{
+		Image:                      "buildkite/agent:latest",
+		EnableJobAcquisitionTokens: true,
+		PodSpecPatch:               &corev1.PodSpec{NodeName: "patched-node"},
+	})
+	inputs, err := worker.ParseJob(
+		&api.AgentJob{ID: "job-uuid", Command: "true"},
+		&api.AgentScheduledJob{ID: "job-uuid", JobAcquisitionToken: "jat-secret"},
+	)
+	if err != nil {
+		t.Fatalf("ParseJob() error = %v", err)
+	}
+	kjob, err := worker.Build(&corev1.PodSpec{}, false, inputs)
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if strings.Contains(logs.String(), "jat-secret") {
+		t.Errorf("debug logs contain JAT: %s", logs.String())
+	}
+
+	serialized, err := yaml.Marshal(redactedJob(kjob))
+	if err != nil {
+		t.Fatalf("yaml.Marshal(redactedJob(kjob)) error = %v", err)
+	}
+	if strings.Contains(string(serialized), "jat-secret") {
+		t.Errorf("redacted invalid Job output contains JAT: %s", serialized)
+	}
+	if !strings.Contains(string(serialized), "<redacted>") {
+		t.Errorf("redacted invalid Job output does not contain redaction marker: %s", serialized)
+	}
+}
 
 func TestPatchPodSpec(t *testing.T) {
 	t.Parallel()

--- a/test.yaml
+++ b/test.yaml
@@ -23,3 +23,5 @@ rules:
     - secrets
     verbs:
     - get
+    - create
+    - delete

--- a/utils/check-rbac.sh
+++ b/utils/check-rbac.sh
@@ -73,6 +73,8 @@ echo "------------------------------"
 
 # Secrets permissions
 check_permission "secrets" "get" "" "Secrets"
+check_permission "secrets" "create" "" "Secrets"
+check_permission "secrets" "delete" "" "Secrets"
 
 # Pods permissions
 check_permission "pods" "get" "" "Pods"


### PR DESCRIPTION
## Change

Runs Kubernetes jobs with job-scoped acquisition tokens instead of exposing the controller’s shared cluster credential to every job Pod.

The controller:

- reserves jobs through the existing Stacks reservation flow
- requests a short-lived JAT after limiter capacity is available
- carries the token in memory through scheduling
- creates a unique immutable Kubernetes Secret for each JAT
- supplies the Secret only to the coordinating agent container
- preserves `BUILDKITE_AGENT_ACQUIRE_JOB` for exact-job acquisition
- removes the shared token Secret reference from JAT-backed job Pods
- makes the Kubernetes Job own its JAT Secret and explicitly removes the Secret after completion or failed Job creation
- redacts literal JAT values from scheduler debug output and invalid Job diagnostics

JATs are enabled by default. Set `enable-job-acquisition-tokens: false` to return workload Pods to the shared cluster-token Secret path.

The Helm RBAC grants only the additional Secret `create` and `delete` permissions required for per-job credentials. The values schema validates the option as a boolean.

## Context

This uses the dedicated stack issuance API from https://github.com/buildkite/buildkite/pull/32347.

The controller retains the cluster or cluster-queue registration credential for stack-level operations. Each workload receives only a short-lived credential capable of registering for and acquiring its intended Buildkite job.

## Verification

- `go test ./api ./cmd/controller ./internal/controller/...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go tool assertzapper ./...`
- `helm lint charts/agent-stack-k8s --set agentToken=test --set image=test:latest`
- Helm schema rejects non-boolean `config.enable-job-acquisition-tokens` values
- End-to-end smoke against the production APIs verified JAT issuance, job-bound agent registration, exact-job acquisition, and successful completion
- Unit coverage verifies immutable per-job Secret delivery, creation-failure cleanup, completion cleanup, retry behaviour, and the shared-token opt-out path

## Disclosures / Credits

Implementation developed with AI assistance.

@buildsworth-bk permission to approve if risk L2