### PR TITLE
Use read-only git credential helper for checkout secrets

### DIFF
--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -1166,14 +1166,6 @@ func (w *worker) createCheckoutContainer(
 				Name:         "git-credentials-ro",
 				VolumeSource: corev1.VolumeSource{Secret: gitCredsSecret},
 			},
-			corev1.Volume{
-				Name: "git-credentials",
-				VolumeSource: corev1.VolumeSource{
-					EmptyDir: &corev1.EmptyDirVolumeSource{
-						Medium: "Memory",
-					},
-				},
-			},
 		)
 
 		checkoutContainer.VolumeMounts = append(checkoutContainer.VolumeMounts,
@@ -1181,23 +1173,12 @@ func (w *worker) createCheckoutContainer(
 				Name:      "git-credentials-ro",
 				MountPath: "/buildkite/git-credentials-ro",
 			},
-			corev1.VolumeMount{
-				Name:      "git-credentials",
-				MountPath: "/buildkite/git-credentials",
-			},
 		)
 
-		// Why copy the file between volumes instead of mounting it directly
-		// into place?
-		// K8s secret mounts are *always* read only, but the 'store' credential
-		// helper always tries to write back to the file.
-		// If we didn't do this, we'd get some alarming-looking log lines like:
-		// "fatal: unable to write credential store: Resource busy"
-		// (despite Git being a drama llama, the failure doesn't impact the
-		// checkout process in any meaningful way).
-		// TODO: replace this nonsense with a better git credential helper
-		gitConfigCmd = "cp /buildkite/git-credentials-ro/.git-credentials /buildkite/git-credentials && " +
-			"git config --global credential.helper 'store --file /buildkite/git-credentials/.git-credentials'"
+		// K8s secret mounts are always read-only, but the 'store' credential
+		// helper tries to write credentials back to the file. Use a custom
+		// helper that only reads from the mounted secret via credential-store.
+		gitConfigCmd = "git config --global credential.helper '!f() { [ \"$1\" = get ] && git credential-store --file=/buildkite/git-credentials-ro/.git-credentials get; }; f'"
 	}
 
 	// Ensure that the checkout occurs as the user/group specified in the pod's security context.
@@ -1219,7 +1200,9 @@ func (w *worker) createCheckoutContainer(
 		}
 
 		createUserScript := generateCreateUserScript(podUser, gid, "buildkite-agent", groupname)
-		bootstrapCmd := fmt.Sprintf(`su buildkite-agent -c "%s && buildkite-agent-entrypoint kubernetes-bootstrap"`, gitConfigCmd)
+		// Escape $1 so the outer shell does not expand it inside su's double-quoted -c string.
+		gitConfigCmdForSu := strings.ReplaceAll(gitConfigCmd, "$1", `\$1`)
+		bootstrapCmd := fmt.Sprintf(`su buildkite-agent -c "%s && buildkite-agent-entrypoint kubernetes-bootstrap"`, gitConfigCmdForSu)
 		checkoutScript := strings.Join([]string{"set -exuf", createUserScript, bootstrapCmd}, "\n")
 
 		checkoutContainer.Command = []string{"/bin/sh", "-c"}

--- a/internal/controller/scheduler/scheduler_test.go
+++ b/internal/controller/scheduler/scheduler_test.go
@@ -1091,21 +1091,15 @@ func TestBuildDefaultCheckoutParams(t *testing.T) {
 	}
 
 	// Validate that git credential secret is mounted and available in checkout container's path
-	var hasGitCredentialsRO, hasGitCredentials bool
+	var hasGitCredentialsRO bool
 	for _, mount := range checkoutContainer.VolumeMounts {
 		if mount.Name == "git-credentials-ro" && mount.MountPath == "/buildkite/git-credentials-ro" {
 			hasGitCredentialsRO = true
-		}
-		if mount.Name == "git-credentials" && mount.MountPath == "/buildkite/git-credentials" {
-			hasGitCredentials = true
 		}
 	}
 
 	if !hasGitCredentialsRO {
 		t.Error("checkout container missing git-credentials-ro volume mount at /buildkite/git-credentials-ro")
-	}
-	if !hasGitCredentials {
-		t.Error("checkout container missing git-credentials volume mount at /buildkite/git-credentials")
 	}
 
 	// Validate that the EnvFrom is passed down to checkout container pod spec
@@ -1192,21 +1186,15 @@ func TestBuildCheckoutParams(t *testing.T) {
 	}
 
 	// Validate that git credential secret is mounted and available in checkout container's path
-	var hasGitCredentialsRO, hasGitCredentials bool
+	var hasGitCredentialsRO bool
 	for _, mount := range checkoutContainer.VolumeMounts {
 		if mount.Name == "git-credentials-ro" && mount.MountPath == "/buildkite/git-credentials-ro" {
 			hasGitCredentialsRO = true
-		}
-		if mount.Name == "git-credentials" && mount.MountPath == "/buildkite/git-credentials" {
-			hasGitCredentials = true
 		}
 	}
 
 	if !hasGitCredentialsRO {
 		t.Error("checkout container missing git-credentials-ro volume mount at /buildkite/git-credentials-ro")
-	}
-	if !hasGitCredentials {
-		t.Error("checkout container missing git-credentials volume mount at /buildkite/git-credentials")
 	}
 
 	// Validate that the EnvFrom is passed down to checkout container pod spec

--- a/internal/controller/scheduler/scheduler_test.go
+++ b/internal/controller/scheduler/scheduler_test.go
@@ -1127,6 +1127,59 @@ func TestBuildDefaultCheckoutParams(t *testing.T) {
 	}
 }
 
+func TestCheckoutGitCredentialsHelperEscaping(t *testing.T) {
+	t.Parallel()
+
+	podUser := int64(1000)
+	job := &api.AgentJob{
+		ID:      "abc",
+		Command: "echo hello world",
+	}
+	sjob := &api.AgentScheduledJob{}
+	worker := New(slog.Default(), nil, nil, Config{
+		Image: "buildkite/agent:latest",
+		DefaultCheckoutParams: &config.CheckoutParams{
+			GitCredentialsSecret: &corev1.SecretVolumeSource{
+				SecretName: "bluh",
+			},
+		},
+	})
+	inputs, err := worker.ParseJob(job, sjob)
+	if err != nil {
+		t.Fatalf("worker.ParseJob(job, sjob) error = %v, want nil", err)
+	}
+	podSpec := &corev1.PodSpec{
+		SecurityContext: &corev1.PodSecurityContext{
+			RunAsUser: &podUser,
+		},
+	}
+	kjob, err := worker.Build(podSpec, false, inputs)
+	if err != nil {
+		t.Fatalf("worker.Build(podSpec, %t, inputs) error = %v, want nil", false, err)
+	}
+
+	var checkoutContainer *corev1.Container
+	for _, container := range kjob.Spec.Template.Spec.Containers {
+		if container.Name == "checkout" {
+			checkoutContainer = &container
+		}
+	}
+	if checkoutContainer == nil {
+		t.Fatal("checkout container not found")
+	}
+	if len(checkoutContainer.Args) != 1 {
+		t.Fatalf("checkout container Args = %v, want single shell script arg", checkoutContainer.Args)
+	}
+
+	checkoutScript := checkoutContainer.Args[0]
+	if !strings.Contains(checkoutScript, `\$1`) {
+		t.Error("checkout script missing escaped \\$1 in git credential helper for su -c path")
+	}
+	if strings.Contains(checkoutScript, `"$1"`) {
+		t.Error("checkout script contains unescaped $1 in git credential helper; outer shell would expand it inside su -c")
+	}
+}
+
 // CheckoutParams come from our bk yaml
 func TestBuildCheckoutParams(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary
- Replace the git credential `store` helper (which tries to write back to the credentials file) with a custom read-only helper that only handles `get` requests against the mounted secret
- Remove the workaround that copied credentials from the read-only secret mount into a writable `emptyDir` volume
- Escape `$1` in the helper when embedding the git config command inside `su`'s double-quoted `-c` string

This avoids alarming log lines like `fatal: unable to write credential store: Resource busy` during checkout.

Because the credentials file stays on the Kubernetes secret volume mount (instead of a one-time copy into `emptyDir`), long-running jobs continue to see updated credentials when Kubernetes rotates or updates the mapped secret.

## Example: before vs after

**Before** — `store` helper. When credentials live on a read-only mount (K8s secret volumes are always read-only), Git can still clone but logs a fatal-looking error when it tries to write credentials back:

```sh
docker run -it --rm \
    -v $HOME/.git-credentials:/root/.git-credentials \
    -e GIT_CONFIG_COUNT=1 \
    -e GIT_CONFIG_KEY_0=credential.helper \
    -e GIT_CONFIG_VALUE_0='store' \
    alpine/git clone https://github.com/some-org/some-repo.git
```

```
fatal: unable to write credential store: Read-only file system
```

**After** — custom helper that only reads credentials on `get`, with an explicit read-only mount:

```sh
docker run -it --rm \
      -v "$HOME/.git-credentials:/root/.git-credentials:ro" \
      -e GIT_CONFIG_COUNT=1 \
      -e GIT_CONFIG_KEY_0=credential.helper \
      -e 'GIT_CONFIG_VALUE_0=!f() { [ "$1" = get ] && git credential-store --file=/root/.git-credentials get; }; f' \
      alpine/git clone https://github.com/some-org/some-repo.git
```

No `fatal: unable to write credential store` message.

## Test plan
- [ ] `go test ./internal/controller/scheduler/... -run 'TestBuildDefaultCheckoutParams|TestBuildCheckoutParams'`
- [ ] Verify checkout succeeds in a cluster using `gitCredentialsSecret` without credential store write errors in logs