### PR TITLE
Use a read-only git credential helper for checkout secrets

### DIFF
--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -1166,14 +1166,6 @@ func (w *worker) createCheckoutContainer(
 				Name:         "git-credentials-ro",
 				VolumeSource: corev1.VolumeSource{Secret: gitCredsSecret},
 			},
-			corev1.Volume{
-				Name: "git-credentials",
-				VolumeSource: corev1.VolumeSource{
-					EmptyDir: &corev1.EmptyDirVolumeSource{
-						Medium: "Memory",
-					},
-				},
-			},
 		)
 
 		checkoutContainer.VolumeMounts = append(checkoutContainer.VolumeMounts,
@@ -1181,23 +1173,12 @@ func (w *worker) createCheckoutContainer(
 				Name:      "git-credentials-ro",
 				MountPath: "/buildkite/git-credentials-ro",
 			},
-			corev1.VolumeMount{
-				Name:      "git-credentials",
-				MountPath: "/buildkite/git-credentials",
-			},
 		)
 
-		// Why copy the file between volumes instead of mounting it directly
-		// into place?
-		// K8s secret mounts are *always* read only, but the 'store' credential
-		// helper always tries to write back to the file.
-		// If we didn't do this, we'd get some alarming-looking log lines like:
-		// "fatal: unable to write credential store: Resource busy"
-		// (despite Git being a drama llama, the failure doesn't impact the
-		// checkout process in any meaningful way).
-		// TODO: replace this nonsense with a better git credential helper
-		gitConfigCmd = "cp /buildkite/git-credentials-ro/.git-credentials /buildkite/git-credentials && " +
-			"git config --global credential.helper 'store --file /buildkite/git-credentials/.git-credentials'"
+		// K8s secret mounts are always read-only, but the 'store' credential
+		// helper tries to write credentials back to the file. Use a custom
+		// helper that only reads from the mounted secret via credential-store.
+		gitConfigCmd = "git config --global credential.helper '!f() { [ \"$1\" = get ] && git credential-store --file=/buildkite/git-credentials-ro/.git-credentials get; }; f'"
 	}
 
 	// Ensure that the checkout occurs as the user/group specified in the pod's security context.
@@ -1219,7 +1200,9 @@ func (w *worker) createCheckoutContainer(
 		}
 
 		createUserScript := generateCreateUserScript(podUser, gid, "buildkite-agent", groupname)
-		bootstrapCmd := fmt.Sprintf(`su buildkite-agent -c "%s && buildkite-agent-entrypoint kubernetes-bootstrap"`, gitConfigCmd)
+		// Escape $1 so the outer shell does not expand it inside su's double-quoted -c string.
+		gitConfigCmdForSu := strings.ReplaceAll(gitConfigCmd, "$1", `\$1`)
+		bootstrapCmd := fmt.Sprintf(`su buildkite-agent -c "%s && buildkite-agent-entrypoint kubernetes-bootstrap"`, gitConfigCmdForSu)
 		checkoutScript := strings.Join([]string{"set -exuf", createUserScript, bootstrapCmd}, "\n")
 
 		checkoutContainer.Command = []string{"/bin/sh", "-c"}

--- a/internal/controller/scheduler/scheduler_test.go
+++ b/internal/controller/scheduler/scheduler_test.go
@@ -1091,21 +1091,15 @@ func TestBuildDefaultCheckoutParams(t *testing.T) {
 	}
 
 	// Validate that git credential secret is mounted and available in checkout container's path
-	var hasGitCredentialsRO, hasGitCredentials bool
+	var hasGitCredentialsRO bool
 	for _, mount := range checkoutContainer.VolumeMounts {
 		if mount.Name == "git-credentials-ro" && mount.MountPath == "/buildkite/git-credentials-ro" {
 			hasGitCredentialsRO = true
-		}
-		if mount.Name == "git-credentials" && mount.MountPath == "/buildkite/git-credentials" {
-			hasGitCredentials = true
 		}
 	}
 
 	if !hasGitCredentialsRO {
 		t.Error("checkout container missing git-credentials-ro volume mount at /buildkite/git-credentials-ro")
-	}
-	if !hasGitCredentials {
-		t.Error("checkout container missing git-credentials volume mount at /buildkite/git-credentials")
 	}
 
 	// Validate that the EnvFrom is passed down to checkout container pod spec
@@ -1130,6 +1124,64 @@ func TestBuildDefaultCheckoutParams(t *testing.T) {
 	}
 	if !hasExtraVolumeMount {
 		t.Error("checkout container missing ExtraVolumeMount 'extra-volume-something'")
+	}
+}
+
+// TestCheckoutGitCredentialsHelperEscaping checks that when the checkout
+// container needs a user switch (su buildkite-agent -c "..."), the git
+// credential helper's $1 stays escaped through that extra layer of
+// double-quoting, so the outer shell doesn't expand it before su/git ever
+// see it.
+func TestCheckoutGitCredentialsHelperEscaping(t *testing.T) {
+	t.Parallel()
+
+	podUser := int64(1000)
+	job := &api.AgentJob{
+		ID:      "abc",
+		Command: "echo hello world",
+	}
+	sjob := &api.AgentScheduledJob{}
+	worker := New(slog.Default(), nil, nil, Config{
+		Image: "buildkite/agent:latest",
+		DefaultCheckoutParams: &config.CheckoutParams{
+			GitCredentialsSecret: &corev1.SecretVolumeSource{
+				SecretName: "bluh",
+			},
+		},
+	})
+	inputs, err := worker.ParseJob(job, sjob)
+	if err != nil {
+		t.Fatalf("worker.ParseJob(job, sjob) error = %v, want nil", err)
+	}
+	podSpec := &corev1.PodSpec{
+		SecurityContext: &corev1.PodSecurityContext{
+			RunAsUser: &podUser,
+		},
+	}
+	kjob, err := worker.Build(podSpec, false, inputs)
+	if err != nil {
+		t.Fatalf("worker.Build(podSpec, %t, inputs) error = %v, want nil", false, err)
+	}
+
+	var checkoutContainer *corev1.Container
+	for _, container := range kjob.Spec.Template.Spec.Containers {
+		if container.Name == "checkout" {
+			checkoutContainer = &container
+		}
+	}
+	if checkoutContainer == nil {
+		t.Fatal("checkout container not found")
+	}
+	if len(checkoutContainer.Args) != 1 {
+		t.Fatalf("checkout container Args = %v, want single shell script arg", checkoutContainer.Args)
+	}
+
+	checkoutScript := checkoutContainer.Args[0]
+	if !strings.Contains(checkoutScript, `\$1`) {
+		t.Error("checkout script missing escaped \\$1 in git credential helper for su -c path")
+	}
+	if strings.Contains(checkoutScript, `"$1"`) {
+		t.Error("checkout script contains unescaped $1 in git credential helper; outer shell would expand it inside su -c")
 	}
 }
 
@@ -1192,21 +1244,15 @@ func TestBuildCheckoutParams(t *testing.T) {
 	}
 
 	// Validate that git credential secret is mounted and available in checkout container's path
-	var hasGitCredentialsRO, hasGitCredentials bool
+	var hasGitCredentialsRO bool
 	for _, mount := range checkoutContainer.VolumeMounts {
 		if mount.Name == "git-credentials-ro" && mount.MountPath == "/buildkite/git-credentials-ro" {
 			hasGitCredentialsRO = true
-		}
-		if mount.Name == "git-credentials" && mount.MountPath == "/buildkite/git-credentials" {
-			hasGitCredentials = true
 		}
 	}
 
 	if !hasGitCredentialsRO {
 		t.Error("checkout container missing git-credentials-ro volume mount at /buildkite/git-credentials-ro")
-	}
-	if !hasGitCredentials {
-		t.Error("checkout container missing git-credentials volume mount at /buildkite/git-credentials")
 	}
 
 	// Validate that the EnvFrom is passed down to checkout container pod spec


### PR DESCRIPTION
## Description

The `store` credential helper always tries to write back to its file on every lookup, and k8s Secret mounts are always read-only. The current code works around this by copying the secret into a writable `emptyDir` just to give that doomed write attempt somewhere to fail against — but it still surfaces an alarming (if harmless) `fatal: unable to write credential store: Resource busy` on every checkout.

This replaces it with a custom helper that only implements `get`, reading directly from the read-only secret mount — no write-back ever attempted, so nothing fails. The `emptyDir`/copy workaround is removed entirely.

Also escapes `$1` where the helper string is embedded inside `su`'s double-quoted `-c` string (the non-root-user checkout path), so the outer shell doesn't expand it before git ever gets to interpret it.

## Context

[A-1733](https://linear.app/buildkite/issue/A-1733/use-read-only-git-credential-helper-for-checkout-secrets)

## Testing

- `go test ./internal/controller/scheduler/...` passes, including a new `TestCheckoutGitCredentialsHelperEscaping` covering the `$1` escaping.
- `go build ./...` and `go vet ./internal/controller/scheduler/...` clean.