### PR TITLE
ci: skip cache save on controller step

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -103,7 +103,7 @@ steps:
       - buildkite-agent cache restore --name go_mod --name go_build
       - 'echo "--- :docker: Build and push controller image"'
       - .buildkite/steps/build-and-push-controller.sh
-      - buildkite-agent cache save --name go_mod --name go_build
+      # - buildkite-agent cache save --name go_mod --name go_build
 
   # On feature branches, don't wait for tests. We may want to deploy
   # to a test cluster to debug the feature branch.


### PR DESCRIPTION
## Change

Comments out cache save command in the `controller` step.

<!-- What does this PR change? -->

## Context

There is a bug in the cache save command. Bypass until fixed to unblock pipeline.

<!-- Why is this change needed? Link to relevant issues or discussions. -->

## Affiliation (optional, external contributors)

<!--
If you're contributing from outside Buildkite and are comfortable sharing, let us know your company or organisation — it helps us prioritise review and may accelerate a response.
-->

## Disclosures / Credits

<!-- Disclose any AI assistance, prior art, or contributors who deserve credit. -->
