### PR TITLE
fix: surface token issuance failures and clarify organization-wide stack IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,22 @@ helm install agent-stack-k8s oci://ghcr.io/buildkite/helm/agent-stack-k8s \
 
 Full instructions can be found [in the documentation](https://buildkite.com/docs/agent/v3/agent-stack-k8s/installation).
 
+Each controller needs an ID that is unique within the Buildkite organization,
+including across Kubernetes clusters and namespaces. The ID is also the API stack
+key: reusing it for a different queue overwrites the existing stack registration
+and can prevent job acquisition tokens from being issued for the original queue.
+Helm defaults the ID to the release full name. When reusing a release name across
+clusters, set a distinct ID through `controllerEnv` in each installation:
+
+```yaml
+controllerEnv:
+  - name: BUILDKITE_K8S_STACK_CONTROLLER_ID
+    value: production-usw2-agent-stack-k8s
+```
+
+The ID is also a Kubernetes label value, so it must meet Kubernetes label-value
+requirements, including a maximum length of 63 characters.
+
 ## Documentation
 
 Comprehensive documentation for the Buildkite Agent Stack for Kubernetes controller can be found in the [Agent Stack for Kubernetes section of the Buildkite Docs](https://buildkite.com/docs/agent/v3/agent-stack-k8s).

--- a/cmd/controller/controller_test.go
+++ b/cmd/controller/controller_test.go
@@ -581,6 +581,20 @@ unknown-field: some-value
 		}
 	})
 
+	t.Run("controller ID environment variable overrides Helm config", func(t *testing.T) {
+		cleanTestEnv(t)
+		configFile := createTempConfigFile(t, "id: agent-stack-k8s\n")
+		t.Setenv("BUILDKITE_K8S_STACK_CONTROLLER_ID", "production-usw2-agent-stack-k8s")
+
+		cfg, err := buildConfig(t, []string{}, configFile)
+		if err != nil {
+			t.Fatalf("buildConfig() error = %v", err)
+		}
+		if got, want := cfg.ID, "production-usw2-agent-stack-k8s"; got != want {
+			t.Errorf("cfg.ID = %q, want %q", got, want)
+		}
+	})
+
 	t.Run("CLI can override config file tags with empty", func(t *testing.T) {
 		cleanTestEnv(t)
 		configFile := createTempConfigFile(t, `

--- a/cmd/controller/flags.go
+++ b/cmd/controller/flags.go
@@ -40,7 +40,7 @@ type CLI struct {
 
 	// Controller settings
 	// name= and env= needed: Go field "ID" → Kong default "--i-d" and "$I_D", but we want "--id" and "$BUILDKITE_K8S_STACK_CONTROLLER_ID"
-	ID                         string         `kong:"name='id',env='BUILDKITE_K8S_STACK_CONTROLLER_ID',help='Unique identifier for this controller instance. Used as a k8s label to filter resources and as the Stack key when registering with the Buildkite API. Must be distinct per controller when running multiple instances in the same namespace, otherwise duplicate pods may be spawned'"`
+	ID                         string         `kong:"name='id',env='BUILDKITE_K8S_STACK_CONTROLLER_ID',help='Unique identifier for this controller instance. Used as a k8s label to filter resources and as the Stack key when registering with the Buildkite API. Must be distinct within the Buildkite organization, including across Kubernetes clusters and namespaces, to avoid overwriting another stack registration'"`
 	JobCreationConcurrency     *int           `kong:"help='Number of concurrent goroutines to run for converting Buildkite jobs into Kubernetes jobs (default: 25)'"`
 	AgentTokenSecret           string         `kong:"help='Name of the Buildkite agent token secret (default: buildkite-agent-token)'"`
 	Image                      string         `kong:"help='The image to use for the Buildkite agent'"`

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -80,8 +80,10 @@ type Config struct {
 	// ID is an optional unique identifier for the controller instance.
 	// It is used as both a Kubernetes label (buildkite.com/controller-id) to filter
 	// resources, and as the Stack key when registering with the Buildkite API.
-	// When running multiple controllers in the same namespace, each must have a
-	// distinct ID so that they target the correct pods and register separate stacks.
+	// Each controller must have a distinct ID within the Buildkite organization,
+	// including controllers in different Kubernetes clusters or namespaces.
+	// Reusing an ID for a different queue overwrites the stack's queue registration,
+	// which can prevent job acquisition tokens from being issued for the first queue.
 	// If two controllers share the same ID, both may successfully reserve the same
 	// job, causing duplicate pods to be spawned.
 	// By default, if Helm is used to install, this is set to the Helm release full name.

--- a/internal/controller/jatissuer/jatissuer.go
+++ b/internal/controller/jatissuer/jatissuer.go
@@ -42,13 +42,16 @@ func (i *Issuer) Handle(ctx context.Context, job *api.AgentScheduledJob) error {
 		return response, err
 	})
 	if err != nil {
+		i.logger.Warn("job acquisition token issuance failed", "job-uuid", job.ID, "error", err)
 		return fmt.Errorf("issuing job acquisition token for job %s: %w", job.ID, err)
 	}
 	if response == nil || len(response.NotIssued) != 0 || len(response.JobAcquisitionTokens) != 1 {
+		i.logger.Warn("job acquisition token was not issued", "job-uuid", job.ID)
 		return fmt.Errorf("job acquisition token was not issued for job %s", job.ID)
 	}
 	issued := response.JobAcquisitionTokens[0]
 	if issued.JobUUID != job.ID || issued.JobAcquisitionToken == "" {
+		i.logger.Warn("invalid job acquisition token response", "job-uuid", job.ID)
 		return fmt.Errorf("invalid job acquisition token response for job %s", job.ID)
 	}
 	job.JobAcquisitionToken = issued.JobAcquisitionToken

--- a/internal/controller/jatissuer/jatissuer_test.go
+++ b/internal/controller/jatissuer/jatissuer_test.go
@@ -1,9 +1,12 @@
 package jatissuer
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"log/slog"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -66,21 +69,27 @@ func TestHandleCorrelatesIssuedTokenByJobUUID(t *testing.T) {
 	t.Parallel()
 
 	jobID := uuid.NewString()
+	const secret = "jat-secret-must-not-appear-in-logs"
 	tests := []struct {
 		name string
 		resp *api.IssueJobAcquisitionTokensResponse
+		err  error
 	}{
+		{name: "API error", err: api.AgentError{Message: "stack queue mismatch", StatusCode: 403}},
+		{name: "nil response"},
 		{name: "not issued", resp: &api.IssueJobAcquisitionTokensResponse{NotIssued: []string{jobID}}},
 		{name: "missing", resp: &api.IssueJobAcquisitionTokensResponse{}},
-		{name: "mismatched", resp: &api.IssueJobAcquisitionTokensResponse{JobAcquisitionTokens: []api.IssuedJobAcquisitionToken{{JobUUID: uuid.NewString(), JobAcquisitionToken: "wrong"}}}},
-		{name: "duplicate", resp: &api.IssueJobAcquisitionTokensResponse{JobAcquisitionTokens: []api.IssuedJobAcquisitionToken{{JobUUID: jobID, JobAcquisitionToken: "one"}, {JobUUID: jobID, JobAcquisitionToken: "two"}}}},
+		{name: "mismatched", resp: &api.IssueJobAcquisitionTokensResponse{JobAcquisitionTokens: []api.IssuedJobAcquisitionToken{{JobUUID: uuid.NewString(), JobAcquisitionToken: secret}}}},
+		{name: "duplicate", resp: &api.IssueJobAcquisitionTokensResponse{JobAcquisitionTokens: []api.IssuedJobAcquisitionToken{{JobUUID: jobID, JobAcquisitionToken: secret}, {JobUUID: jobID, JobAcquisitionToken: secret}}}},
 		{name: "empty token", resp: &api.IssueJobAcquisitionTokensResponse{JobAcquisitionTokens: []api.IssuedJobAcquisitionToken{{JobUUID: jobID}}}},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			next := &captureHandler{jobs: make(chan *api.AgentScheduledJob, 1)}
-			h := New(slog.Default(), &fakeClient{responses: []*api.IssueJobAcquisitionTokensResponse{test.resp}}, next, 0)
+			var logs bytes.Buffer
+			logger := slog.New(slog.NewJSONHandler(&logs, nil)) // Default Info level, as in production.
+			h := New(logger, &fakeClient{responses: []*api.IssueJobAcquisitionTokensResponse{test.resp}, errors: []error{test.err}}, next, 0)
 			if err := h.Handle(t.Context(), &api.AgentScheduledJob{ID: jobID}); err == nil {
 				t.Fatal("Handle() error = nil, want non-nil")
 			}
@@ -88,6 +97,21 @@ func TestHandleCorrelatesIssuedTokenByJobUUID(t *testing.T) {
 			case <-next.jobs:
 				t.Fatal("next handler called for malformed issuance response")
 			default:
+			}
+			var record map[string]any
+			// Unmarshal also rejects multiple records: terminal issuance failures
+			// should emit exactly one warning after retries finish.
+			if err := json.Unmarshal(logs.Bytes(), &record); err != nil {
+				t.Fatalf("expected one visible log record: %v", err)
+			}
+			if record["level"] != "WARN" || record["job-uuid"] != jobID {
+				t.Errorf("log record = %v, want warning for job %s", record, jobID)
+			}
+			if test.err != nil && record["error"] != test.err.Error() {
+				t.Errorf("logged error = %v, want %v", record["error"], test.err)
+			}
+			if strings.Contains(logs.String(), secret) {
+				t.Error("log contains a job acquisition token")
 			}
 		})
 	}
@@ -104,7 +128,9 @@ func TestHandleRetriesWithConfiguredLifetimeAndForwardsTokenThroughDeduper(t *te
 		errors: []error{errors.New("temporary failure"), nil},
 	}
 	next := &captureHandler{jobs: make(chan *api.AgentScheduledJob, 1)}
-	h := New(slog.Default(), client, deduper.New(slog.Default(), next), 1800)
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&logs, nil))
+	h := New(logger, client, deduper.New(logger, next), 1800)
 
 	if err := h.Handle(t.Context(), &api.AgentScheduledJob{ID: jobID}); err != nil {
 		t.Fatalf("Handle() error = %v", err)
@@ -115,6 +141,9 @@ func TestHandleRetriesWithConfiguredLifetimeAndForwardsTokenThroughDeduper(t *te
 	}
 	if got := len(client.calls); got != 2 {
 		t.Errorf("issuance calls = %d, want 2", got)
+	}
+	if logs.Len() != 0 {
+		t.Errorf("successful retry emitted a log at default level: %s", logs.String())
 	}
 	for i, call := range client.calls {
 		if len(call.ids) != 1 || call.ids[0] != jobID {


### PR DESCRIPTION
Job-acquisition-token failures return through the limiter, whose `next handler failed` message is debug-only. At the default Info level, a controller can repeatedly reserve jobs without creating Kubernetes Jobs and emit no visible explanation.

Log a warning when issuance fails after its existing retries, when the API does not issue the token, or when the returned token cannot be correlated with the requested job. Include the job UUID and API error where available; do not log token response payloads. Successful retries stay quiet at the default log level.

Also clarify that controller IDs (API stack keys) must be unique within the Buildkite organization, including across Kubernetes clusters and namespaces. Re-registering a disposable stack with the same key and a different queue returned the same stack ID with the queue association changed. Identical Helm release names across clusters can therefore collide. Document the existing controller environment override and test that it takes precedence over the chart's config-file ID.

Validation:
- All Go unit tests passed (all packages except `internal/integration`, which requires live Buildkite/Kubernetes test infrastructure).
- `golangci-lint run` passed for the modified Go packages.
- Tests cover visible warnings at the default Info level, API errors, missing/not-issued/malformed responses, token non-disclosure, successful retry silence, and controller-ID environment precedence.
- `git diff --check` passed.
