### PR TITLE
fix: prevent cross-queue stack registration collisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ helm install agent-stack-k8s oci://ghcr.io/buildkite/helm/agent-stack-k8s \
 
 Full instructions can be found [in the documentation](https://buildkite.com/docs/agent/v3/agent-stack-k8s/installation).
 
+The controller derives its API stack key from the Buildkite cluster UUID, queue,
+and configured controller ID. This prevents installations with the same Helm
+release name from overwriting another queue's organization-wide stack registration.
+The derived key is stable across restarts and agent-token rotation. Kubernetes
+controller-ID labels stay unchanged, so the controller continues watching its
+existing Jobs. Upgrading from a version that used the controller ID directly as
+the stack key creates a new API stack registration.
+
 ## Documentation
 
 Comprehensive documentation for the Buildkite Agent Stack for Kubernetes controller can be found in the [Agent Stack for Kubernetes section of the Buildkite Docs](https://buildkite.com/docs/agent/v3/agent-stack-k8s).

--- a/api/agent_client.go
+++ b/api/agent_client.go
@@ -43,10 +43,11 @@ type AgentClient struct {
 const DefaultHTTPTimeout = 60 * time.Second
 
 type AgentClientOpts struct {
-	Token           string
-	Endpoint        string
-	ClusterID       string
-	Queue           string
+	Token     string
+	Endpoint  string
+	ClusterID string
+	Queue     string
+	// StackID is the local controller ID. API keys also include cluster/queue scope.
 	StackID         string
 	AgentQueryRules []string
 	Logger          *slog.Logger
@@ -104,10 +105,7 @@ func NewAgentClient(ctx context.Context, opts AgentClientOpts) (*AgentClient, er
 		return nil, fmt.Errorf("couldn't create Buildkite Stacks API client: %w", err)
 	}
 
-	stackKey := opts.StackID
-	if stackKey == "" {
-		stackKey = "agent-stack-k8s"
-	}
+	stackKey := scopedStackKey(opts.ClusterID, opts.Queue, opts.StackID)
 
 	client.notificationBatcher = newNotificationBatcher(stackKey, client.stacksAPIClient, opts.Logger)
 	stack, _, err := client.stacksAPIClient.RegisterStack(ctx, stacksapi.RegisterStackRequest{

--- a/api/fake_agent_server.go
+++ b/api/fake_agent_server.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"sync"
 
 	"github.com/buildkite/stacksapi"
@@ -80,11 +79,12 @@ func NewFakeAgentServer() *FakeAgentServer {
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/stacks/register", fake.handleRegisterStack)
-	mux.HandleFunc("/stacks/test-stack/scheduled-jobs/batch-reserve", fake.handleReserveJobs)
-	mux.HandleFunc("/stacks/test-stack/job-acquisition-tokens", fake.handleIssueJobAcquisitionTokens)
-	mux.HandleFunc("/stacks/test-stack/notifications", fake.handleNotifications)
-	mux.HandleFunc("/stacks/test-stack/jobs/get-states", fake.handleGetJobStates)
-	mux.HandleFunc("/stacks/test-stack/jobs/", fake.handleFinishJob)
+	mux.HandleFunc("/stacks/{stack}/scheduled-jobs/batch-reserve", fake.handleReserveJobs)
+	mux.HandleFunc("/stacks/{stack}/job-acquisition-tokens", fake.handleIssueJobAcquisitionTokens)
+	mux.HandleFunc("/stacks/{stack}/notifications", fake.handleNotifications)
+	mux.HandleFunc("/stacks/{stack}/jobs/get-states", fake.handleGetJobStates)
+	mux.HandleFunc("/stacks/{stack}/jobs/{uuid}", fake.handleFinishJob)
+	mux.HandleFunc("/stacks/{stack}/jobs/{uuid}/finish", fake.handleFinishJob)
 
 	fake.server = httptest.NewServer(mux)
 	return fake
@@ -241,10 +241,8 @@ func (f *FakeAgentServer) handleGetJobStates(w http.ResponseWriter, r *http.Requ
 }
 
 func (f *FakeAgentServer) handleFinishJob(w http.ResponseWriter, r *http.Request) {
-	path := r.URL.Path
-	const prefix = "/stacks/test-stack/jobs/"
+	jobUUID := r.PathValue("uuid")
 	if r.Method == http.MethodGet {
-		jobUUID := strings.TrimPrefix(path, prefix)
 		job, ok := f.AgentJobs[jobUUID]
 		if !ok {
 			writeJSONResponse(w, http.StatusNotFound, map[string]string{"message": "job not found"})
@@ -257,14 +255,6 @@ func (f *FakeAgentServer) handleFinishJob(w http.ResponseWriter, r *http.Request
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-
-	// Path: /stacks/test-stack/jobs/{uuid}/finish
-	const suffix = "/finish"
-	if !strings.HasPrefix(path, prefix) || !strings.HasSuffix(path, suffix) {
-		http.Error(w, "not found", http.StatusNotFound)
-		return
-	}
-	jobUUID := path[len(prefix) : len(path)-len(suffix)]
 
 	f.mu.Lock()
 	f.FinishJobCalls = append(f.FinishJobCalls, jobUUID)

--- a/api/stack_key.go
+++ b/api/stack_key.go
@@ -1,0 +1,25 @@
+package api
+
+import (
+	"crypto/sha256"
+	"fmt"
+
+	"github.com/buildkite/stacksapi"
+)
+
+// scopedStackKey separates organization-wide API registration from the local
+// Kubernetes controller ID. Both cluster and queue are necessary because queue
+// keys can repeat across Buildkite clusters in the same organization.
+func scopedStackKey(clusterID, queue, controllerID string) string {
+	if controllerID == "" {
+		controllerID = "agent-stack-k8s"
+	}
+	if queue == "" || isDefaultQueue(queue) {
+		queue = stacksapi.DefaultQueue
+	}
+	// Quote each component so separators in input cannot create ambiguous scopes.
+	// Hash the complete ID, including any part omitted from the readable prefix.
+	digest := sha256.Sum256(fmt.Appendf(nil, "%q/%q/%q", clusterID, queue, controllerID))
+	// Keep the key within the existing Helm controller-ID limit of 63 characters.
+	return fmt.Sprintf("%s-%x", controllerID[:min(len(controllerID), 30)], digest[:16])
+}

--- a/api/stack_key_test.go
+++ b/api/stack_key_test.go
@@ -1,0 +1,129 @@
+package api
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/buildkite/stacksapi"
+)
+
+// Registration keys are organization-wide. This server deliberately models the
+// API's upsert behavior: registering the same key replaces its queue association.
+func TestControllersSharingIDCanAcquireTokensFromTheirOwnQueues(t *testing.T) {
+	var mu sync.Mutex
+	stacks := make(map[string]string)
+	clusters := map[string]string{
+		"Token cluster-1-token":         "cluster-1",
+		"Token cluster-1-token-rotated": "cluster-1",
+		"Token cluster-2-token":         "cluster-2",
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /stacks/register", func(w http.ResponseWriter, r *http.Request) {
+		var req stacksapi.RegisterStackRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Error(err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		// The token determines the Buildkite cluster; queue keys can repeat across clusters.
+		scope := clusters[r.Header.Get("Authorization")] + "/" + req.QueueKey
+		mu.Lock()
+		stacks[req.Key] = scope
+		mu.Unlock()
+		writeJSONResponse(w, http.StatusCreated, stacksapi.RegisterStackResponse{Key: req.Key, ClusterQueueKey: req.QueueKey})
+	})
+	mux.HandleFunc("POST /stacks/{key}/job-acquisition-tokens", func(w http.ResponseWriter, r *http.Request) {
+		var req IssueJobAcquisitionTokensRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Error(err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		mu.Lock()
+		scope := stacks[r.PathValue("key")]
+		mu.Unlock()
+		if len(req.JobUUIDs) != 1 || req.JobUUIDs[0] != scope {
+			writeJSONResponse(w, http.StatusForbidden, map[string]string{"message": "job does not belong to the registered stack queue"})
+			return
+		}
+		writeJSONResponse(w, http.StatusCreated, IssueJobAcquisitionTokensResponse{JobAcquisitionTokens: []IssuedJobAcquisitionToken{{JobUUID: req.JobUUIDs[0], JobAcquisitionToken: "issued-token"}}})
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	var clients []*AgentClient
+	for _, opts := range []AgentClientOpts{
+		{ClusterID: "cluster-1", Queue: "production", Token: "cluster-1-token"},
+		{ClusterID: "cluster-1", Queue: "staging", Token: "cluster-1-token"},
+		{ClusterID: "cluster-2", Queue: "production", Token: "cluster-2-token"},
+		{ClusterID: "cluster-1", Queue: "production", Token: "cluster-1-token-rotated"},
+	} {
+		opts.StackID = "identical-helm-release-name"
+		opts.Endpoint = server.URL
+		opts.Logger = slog.Default()
+		client, err := NewAgentClient(t.Context(), opts)
+		if err != nil {
+			t.Fatal(err)
+		}
+		clients = append(clients, client)
+	}
+	if clients[0].stack.Key != clients[3].stack.Key {
+		t.Error("restarting with a rotated token changed the stack key")
+	}
+	// All registrations must finish before issuing tokens, so the second/third
+	// controller cannot silently steal the first controller's stack registration.
+	for _, client := range clients {
+		jobID := client.clusterID + "/" + client.queue
+		response, _, err := client.IssueJobAcquisitionTokens(t.Context(), []string{jobID}, 0)
+		if err != nil {
+			t.Errorf("cluster %s queue %s: %v", client.clusterID, client.queue, err)
+			continue
+		}
+		if len(response.JobAcquisitionTokens) != 1 {
+			t.Errorf("cluster %s queue %s: token not issued", client.clusterID, client.queue)
+		}
+	}
+}
+
+func TestStackKeyScopeIsStableAndUnambiguous(t *testing.T) {
+	base := scopedStackKey("cluster", "queue", "controller")
+	tests := []struct {
+		name, cluster, queue, id string
+		same                     bool
+	}{
+		{"restart", "cluster", "queue", "controller", true},
+		{"different cluster", "other", "queue", "controller", false},
+		{"different queue", "cluster", "other", "controller", false},
+		{"different controller", "cluster", "queue", "other", false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := scopedStackKey(test.cluster, test.queue, test.id)
+			if (got == base) != test.same {
+				t.Errorf("key equality = %t, want %t", got == base, test.same)
+			}
+		})
+	}
+	for _, queue := range []string{"", "~", "-", stacksapi.DefaultQueue} {
+		if scopedStackKey("cluster", queue, "controller") != scopedStackKey("cluster", stacksapi.DefaultQueue, "controller") {
+			t.Errorf("default queue alias %q changes identity", queue)
+		}
+	}
+	if scopedStackKey("a/b", "c", "d") == scopedStackKey("a", "b/c", "d") {
+		t.Error("scope components are ambiguous")
+	}
+	prefix := strings.Repeat("a", 63)
+	a, b := scopedStackKey("cluster", "queue", prefix+"a"), scopedStackKey("cluster", "queue", prefix+"b")
+	if a == b {
+		t.Error("IDs differing beyond the display prefix collide")
+	}
+	for _, key := range []string{base, a, b} {
+		if len(key) > 63 {
+			t.Errorf("key has %d characters, want at most 63", len(key))
+		}
+	}
+}

--- a/cmd/controller/flags.go
+++ b/cmd/controller/flags.go
@@ -40,7 +40,7 @@ type CLI struct {
 
 	// Controller settings
 	// name= and env= needed: Go field "ID" → Kong default "--i-d" and "$I_D", but we want "--id" and "$BUILDKITE_K8S_STACK_CONTROLLER_ID"
-	ID                         string         `kong:"name='id',env='BUILDKITE_K8S_STACK_CONTROLLER_ID',help='Unique identifier for this controller instance. Used as a k8s label to filter resources and as the Stack key when registering with the Buildkite API. Must be distinct per controller when running multiple instances in the same namespace, otherwise duplicate pods may be spawned'"`
+	ID                         string         `kong:"name='id',env='BUILDKITE_K8S_STACK_CONTROLLER_ID',help='Unique identifier for this controller instance. Used as a k8s label to filter resources and combined with the Buildkite cluster and queue to derive the API stack key. Must be distinct per controller when running multiple instances in the same namespace, otherwise duplicate pods may be spawned'"`
 	JobCreationConcurrency     *int           `kong:"help='Number of concurrent goroutines to run for converting Buildkite jobs into Kubernetes jobs (default: 25)'"`
 	AgentTokenSecret           string         `kong:"help='Name of the Buildkite agent token secret (default: buildkite-agent-token)'"`
 	Image                      string         `kong:"help='The image to use for the Buildkite agent'"`

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -78,8 +78,9 @@ type Config struct {
 	ReservationExpirySeconds int `json:"reservation-expiry-seconds" validate:"omitempty,min=0,max=3600"`
 
 	// ID is an optional unique identifier for the controller instance.
-	// It is used as both a Kubernetes label (buildkite.com/controller-id) to filter
-	// resources, and as the Stack key when registering with the Buildkite API.
+	// It is used as a Kubernetes label (buildkite.com/controller-id) to filter
+	// resources. The API stack key is derived from this ID, the Buildkite cluster
+	// UUID, and the queue, so another queue cannot overwrite its registration.
 	// When running multiple controllers in the same namespace, each must have a
 	// distinct ID so that they target the correct pods and register separate stacks.
 	// If two controllers share the same ID, both may successfully reserve the same


### PR DESCRIPTION
Two controllers with the same ID can register different queues under the same organization-wide stack key. A disposable live registration test confirmed that the second registration replaces the first queue association. Whether that overwrite caused the observed job-acquisition-token failures remains unproven: the original HTTP errors were not retained, and no live token-issuance comparison has yet been performed before and after an overwrite. Helm's default ID is the release full name, making this possible when release names repeat across Kubernetes clusters.

Derive the API stack key from the Buildkite cluster UUID, queue, and complete controller ID. Keep a readable ID prefix and a deterministic hash within 63 characters. This isolates queues and Buildkite clusters even when local controller IDs match, and preserves the same API key across restarts and token rotation. Kubernetes controller-ID labels and informer selectors are unchanged. All stack API operations, including notifications and token issuance, use the derived registration key.

The HTTP regression test models the observed registration upsert behavior and an assumed queue check during token issuance. The queue-overwrite behavior is confirmed live; the token-refusal rule in this test is an assumption, not independently verified backend behavior. Controllers using the same ID register different queues and clusters, then each requests its own job token after every registration has completed. This test fails with the previous implementation and passes with the fix, including a restart using a rotated token. Additional cases cover default-queue aliases, ambiguous separators, and long controller IDs.

Validation: all Go unit tests passed (all packages except the live `internal/integration` suite); lint passed for the modified Go packages; `git diff --check` passed. The new controller has not been deployed against live Buildkite/Kubernetes infrastructure.

Upgrade behavior: existing installations create a new API stack registration on upgrade because their keys become scoped. The local controller ID stays unchanged so existing Kubernetes Jobs remain visible to the controller. This PR makes the functional registration change; it does not add diagnostic logging.

Draft verification gate: reproduce token-issuance failure against the live API using isolated queues and disposable stack keys; demonstrate the same experiment succeeds with scoped keys; then validate the controller upgrade and existing-job lifecycle. Recovery heartbeats on controller 0.48.0 do not validate this 0.50.0-era token flow.
