### PR TITLE
fix: stop cancellation cleanup retry storms

### DIFF
--- a/internal/controller/scheduler/batch_buildkite_job_checker.go
+++ b/internal/controller/scheduler/batch_buildkite_job_checker.go
@@ -137,16 +137,22 @@ func (c *BatchBuildkiteJobChecker) checkJobStates(ctx context.Context) {
 		close(jobStatesCh)
 	}()
 
-	// Process results from all batches
+	// Process results from all batches. Wait for handlers before the next poll:
+	// otherwise slow, rate-limited DELETEs accumulate another goroutine for the
+	// same target on every tick and starve unrelated Kubernetes requests.
+	var handlers sync.WaitGroup
 	for jobStates := range jobStatesCh {
 		for jobUUIDStr, jobState := range jobStates {
 			target := jobToTarget[jobUUIDStr]
 			// Concurrently handle cancelled jobs.
 			// This is at the mercy of k8s API rate limit and buildkite stack API rate limit.
 			// If either rate limit were breached, it will result in delay in resource release.
-			go c.handleJobState(ctx, jobUUIDStr, jobState, target)
+			handlers.Go(func() {
+				c.handleJobState(ctx, jobUUIDStr, jobState, target)
+			})
 		}
 	}
+	handlers.Wait()
 }
 
 // AddPod registers a Buildkite job whose pod exists and is pending. A pod is

--- a/internal/controller/scheduler/batch_buildkite_job_checker_test.go
+++ b/internal/controller/scheduler/batch_buildkite_job_checker_test.go
@@ -1,0 +1,121 @@
+package scheduler
+
+import (
+	"bytes"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/buildkite/agent-stack-k8s/v2/api"
+	"github.com/google/uuid"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func TestCancelCheckerMissingResource(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		kind cancelTargetKind
+	}{
+		{name: "pod", kind: cancelTargetPod},
+		{name: "job", kind: cancelTargetJob},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var logs bytes.Buffer
+			client := fake.NewSimpleClientset()
+			checker := NewBatchBuildkiteJobChecker(slog.New(slog.NewTextHandler(&logs, nil)), nil, client, time.Second)
+			id := uuid.New()
+			target := cancelTarget{kind: tc.kind, meta: metav1.ObjectMeta{Name: "already-deleted", Namespace: "default"}}
+			checker.checkingJobs[id] = target
+
+			// A delete event can be delayed or lost; NotFound must also end
+			// cancellation checks rather than requeueing the same DELETE forever.
+			checker.handleJobState(t.Context(), id.String(), api.JobStateCanceled, target)
+
+			if got := checker.GetActiveCheckCount(); got != 0 {
+				t.Fatalf("active checks = %d, want 0 after NotFound", got)
+			}
+			if strings.Contains(logs.String(), "level=ERROR") {
+				t.Errorf("already-deleted resource logged as an error: %s", &logs)
+			}
+		})
+	}
+}
+
+func TestCancelCheckerRetainsFailedDeletion(t *testing.T) {
+	for _, resource := range []string{"pods", "jobs"} {
+		for _, deleteErr := range []error{
+			kerrors.NewForbidden(schema.GroupResource{Resource: resource}, "pending", errors.New("denied")),
+			kerrors.NewInternalError(errors.New("temporary failure")),
+		} {
+			t.Run(resource+"/"+string(kerrors.ReasonForError(deleteErr)), func(t *testing.T) {
+				client := fake.NewSimpleClientset()
+				client.PrependReactor("delete", resource, func(k8stesting.Action) (bool, runtime.Object, error) {
+					return true, nil, deleteErr
+				})
+				checker := NewBatchBuildkiteJobChecker(slog.Default(), nil, client, time.Second)
+				id := uuid.New()
+				target := cancelTarget{kind: cancelTargetPod, meta: metav1.ObjectMeta{Name: "pending", Namespace: "default"}}
+				if resource == "jobs" {
+					target.kind = cancelTargetJob
+				}
+				checker.checkingJobs[id] = target
+
+				checker.handleJobState(t.Context(), id.String(), api.JobStateCanceling, target)
+
+				if got := checker.GetActiveCheckCount(); got != 1 {
+					t.Errorf("active checks = %d, want 1 so failed cleanup is retried", got)
+				}
+			})
+		}
+	}
+}
+
+func TestCancelCheckerWaitsForSlowDeletion(t *testing.T) {
+	server := api.NewFakeAgentServer()
+	defer server.Close()
+	id := uuid.MustParse(testJobUUID)
+	server.JobStates = map[string]string{id.String(): string(api.JobStateCanceled)}
+	_, client, checker := newTestJobWatcherWithChecker(t, server)
+	checker.AddK8sJob(id, metav1.ObjectMeta{Name: "pending", Namespace: "default"})
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	client.PrependReactor("delete", "jobs", func(k8stesting.Action) (bool, runtime.Object, error) {
+		close(started)
+		<-release
+		return true, nil, nil
+	})
+	finished := make(chan struct{})
+	go func() {
+		checker.checkJobStates(t.Context())
+		close(finished)
+	}()
+	defer func() {
+		close(release)
+		select {
+		case <-finished:
+		case <-time.After(5 * time.Second):
+			t.Error("poll did not finish after cancellation DELETE completed")
+		}
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("cancellation DELETE did not start")
+	}
+	// A slow API call must apply backpressure to the polling loop. Returning
+	// early lets each tick enqueue another DELETE behind the same rate limiter.
+	select {
+	case <-finished:
+		t.Fatal("poll completed while cancellation DELETE was still in flight")
+	case <-time.After(100 * time.Millisecond):
+	}
+}

--- a/internal/controller/scheduler/pod_watcher.go
+++ b/internal/controller/scheduler/pod_watcher.go
@@ -496,6 +496,11 @@ func forcefullyDeletePod(
 	}
 
 	if err := k8s.CoreV1().Pods(podMetadata.Namespace).Delete(ctx, podMetadata.Name, deleteOptions); err != nil {
+		// Another cleanup path may have already removed the pod. Its absence
+		// satisfies the deletion request and must not keep cancellation alive.
+		if kerrors.IsNotFound(err) {
+			return nil
+		}
 		log.Error("Couldn't forcefully delete pod", "error", err)
 		forcefulPodDeletionErrorsCounter.WithLabelValues(reason, string(kerrors.ReasonForError(err))).Inc()
 		return err
@@ -524,6 +529,11 @@ func forcefullyDeleteJob(
 	}
 
 	if err := k8s.BatchV1().Jobs(jobMetadata.Namespace).Delete(ctx, jobMetadata.Name, deleteOptions); err != nil {
+		// A delayed delete event must not turn an already-deleted Job into an
+		// endless cancellation retry loop.
+		if kerrors.IsNotFound(err) {
+			return nil
+		}
 		log.Error("Couldn't forcefully delete job", "error", err)
 		forcefulJobDeletionErrorsCounter.WithLabelValues(reason, string(kerrors.ReasonForError(err))).Inc()
 		return err


### PR DESCRIPTION
## Change

Treat Kubernetes `NotFound` responses when deleting canceled Pods or Jobs as successful cleanup, so the cancellation checker removes the target. Other deletion errors still leave the target registered for retry.

Wait for the current batch of state handlers before returning from a cancellation poll. Handlers still run concurrently within the batch, but a slow Kubernetes DELETE cannot accumulate another deletion goroutine for the same target on every subsequent tick.

Regression coverage checks missing Pods and Jobs, retry retention for forbidden/internal errors, and a blocked DELETE that must keep the poll in flight. The missing-resource and overlapping-poll tests failed against the original implementation and pass with this change.

Validation passed:

- `go test ./internal/controller/... ./api/... -count=1`
- `go test -race ./internal/controller/scheduler -run 'TestCancelChecker' -count=1`
- `git diff --check`

## Context

We observed this failure in production on v0.50.0: canceled podless Jobs that no longer existed remained registered in the cancellation checker, and repeated polls kept launching DELETE requests. Requests piled up behind the shared Kubernetes client rate limiter, with observed delays approaching 24 minutes. Job acquisition token Secret creation was delayed, agents could not acquire jobs, and the build queue stalled.

Restarting the controller restored progress; rolling back to v0.48.0 mitigated the incident. This change addresses both retention of already-absent resources and accumulation of overlapping cleanup requests.

## Disclosures / Credits

Prepared with assistance from OpenAI Codex.
